### PR TITLE
0.8.0: auto-memory spec + /dream curator substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.8.0] — Auto-memory + dream curator substrate
+### Added
+- `docs/auto-memory.md` — spec for Claude Code's auto-memory: four typed entries (`user`, `feedback`, `project`, `reference`), what to save / NOT save, body structure with **Why:** + **How to apply:** lines, two-step write (detail file + index pointer), 100-line MEMORY.md cap
+- `docs/memory-template.md` — seed `MEMORY.md` template with one-line example pointers per type + first-time setup
+- `docs/dream-architecture.md` — three-layer design (inputs → curator pass → proposal artifact → human-gated apply), curator catalog (rot v0.1 ships, pattern/contradiction/untapped/audit planned), proposal schema, local-only memory git rationale, risks + mitigations
+- `commands/dream.md` — `/dream {curator}` slash command. Default curator: `rot`. Derives memory dir from pwd, gathers inputs (read-only), writes `proposals.json` + `REPORT.md` + `inputs.json` to `memory/.dreams/{ISO}/`, commits to memory git
+- `commands/dream-apply.md` — `/dream-apply {ISO}` slash command. Walks proposals with `AskUserQuestion`, supports Accept / Reject / Edit-then-accept / Skip-rest, applies `modify`/`archive`/`add`/`flag` actions, writes `applied.json`, commits to memory git
+- `scripts/dream/README.md` — usage, first-time setup (init memory git, no remote), how to add new curators
+- `scripts/dream/prompts/rot.md` — rot-detector curator prompt: role, inputs, classification rules, required-evidence rule, output schema (`proposals.json` + `REPORT.md`)
+### Changed
+- `README.md` — opening paragraph now leads with auto-memory + `/dream` as the second-most-distinctive thing the starter ships; new "Auto-memory" section with the four types and curator overview; command table adds `/dream`, `/dream-apply`, `/recover`; file tree shows `scripts/dream/` and the external memory dir layout
+- `CLAUDE.md` template — command table adds `/dream` + `/dream-apply`; new "Memory" section points at `docs/auto-memory.md` + `docs/dream-architecture.md`
+
+---
+
 ## [0.7.1] — Safety contract and /recover
 ### Added
 - `docs/safety-contract.md` — centralized policy for actions requiring confirmation (approval patterns, advisory warnings, design principles)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@
 | `/reconcile` | Drift detection after parallel sessions |
 | `/recover` | Scan orphaned worktrees and stale branches, offer cleanup |
 | `/content-shipped` | Log a published piece of content |
+| `/dream` | Run an autonomous curator pass over the memory dir (default: rot detection) |
+| `/dream-apply` | Walk a curator proposal artifact, accept/reject/edit per item |
 
 Add more commands as you build out skills. See `docs/agent-template.md` for how.
 
@@ -41,6 +43,11 @@ This mode applies to career moves, strategy decisions, project bets, and any "he
 
 ## Safety Contract
 Actions that change external state or are hard to reverse require confirmation. See `docs/safety-contract.md` for the full policy, approval patterns, and design principles.
+
+## Memory
+Claude Code auto-loads `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md` on every conversation in this project. Use it as a persistent, file-based memory: typed entries (`user`, `feedback`, `project`, `reference`), one-line pointers in `MEMORY.md`, detail in `<topic>.md` files. See `docs/auto-memory.md` for the full spec — when to save, when NOT to save, body structure, the two-step write. `MEMORY.md` is capped at ~100 lines.
+
+Run `/dream` periodically to curate (rot, contradictions, untapped patterns). Run `/dream-apply` to review proposed changes. See `docs/dream-architecture.md`.
 
 ## Single Source of Truth
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Most people paste their context into Claude's project instructions and forget ab
 
 This repo flips that. Your context lives in files. Claude Code reads them directly; claude.ai projects read the same files as uploaded knowledge. Update a file once, and every interface you use stays current. Build a skill once — like the `avoid-ai-writing` skill included here — and it works as a slash command in Claude Code and as uploaded context in any claude.ai project.
 
+It also gives Claude a persistent, file-based **auto-memory** that grows over time (typed entries for user/feedback/project/reference) plus a `/dream` curator that runs autonomous passes over the memory dir — rot detection, contradiction surfacing, pattern capture — and produces reviewable proposals before anything writes back. See [`docs/auto-memory.md`](docs/auto-memory.md) and [`docs/dream-architecture.md`](docs/dream-architecture.md).
+
 ---
 
 ## Quick start
@@ -54,7 +56,10 @@ claude
 | `/capture` | When inbox has items | Triages raw notes from `inbox/` into the right files |
 | `/context` | Any time | Finds relevant context files by topic keyword |
 | `/reconcile` | After parallel work | Detects drift between sessions, SSOT violations |
+| `/recover` | After a crash | Scans orphaned worktrees and stale branches, offers safe cleanup |
 | `/content-shipped` | After publishing | Logs a published piece to `content/log.md` |
+| `/dream` | Weekly-ish | Runs an autonomous curator pass over the memory dir (default: rot detection) |
+| `/dream-apply` | After `/dream` | Walks the proposal artifact, accept/reject/edit per item |
 
 ---
 
@@ -72,12 +77,19 @@ state/                            # Session state, priorities, decisions, blocke
 sessions/                         # Per-day session logs (created by /end)
 inbox/                            # Drop zone for raw notes (triaged by /capture)
 content/log.md                    # Published content log
-commands/                         # Slash command definitions (including /setup onboarding)
+commands/                         # Slash command definitions (including /setup, /dream, /dream-apply)
 scripts/                          # Setup, validation, repo map generation
-docs/                             # Architecture guides, migration, safety contract
+scripts/dream/                    # Curator prompts + how-to for the /dream substrate
+docs/                             # Architecture guides — auto-memory, dream, migration, safety
 references/                       # Integration setup (Google Workspace, Notion)
 .claude/hooks/                    # Session start + SSOT guard hooks
 .github/                          # CI validation + PR template
+
+# Auto-memory lives outside the repo (per-machine, often confidential):
+~/.claude/projects/<encoded-cwd>/memory/
+  MEMORY.md                       # Index loaded into every conversation
+  <topic>.md                      # Detail files loaded on demand
+  .dreams/<ISO>/                  # Curator proposal artifacts
 ```
 
 ---
@@ -96,6 +108,27 @@ To build your own:
 4. Run `scripts/validate-skills.sh` to verify
 
 See `projects/README.md` for conventions and the example musician project for the full pattern.
+
+---
+
+## Auto-memory
+
+Claude Code auto-loads `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md` at the start of every conversation in this project. The starter ships a spec ([`docs/auto-memory.md`](docs/auto-memory.md)) for what to save (and what NOT to save) across four typed memory categories:
+
+- **user** — role, expertise, preferences
+- **feedback** — guidance about *how* to work, both corrections and validated approaches
+- **project** — in-flight work, decisions, the *why* behind them
+- **reference** — pointers to external systems (trackers, dashboards, channels)
+
+`MEMORY.md` is an index. Detail files load on demand. Cap the index at ~100 lines.
+
+`docs/memory-template.md` is the seed file. Copy it to the memory dir on first setup.
+
+### /dream — autonomous curator
+
+Memory accumulates faster than humans review it. `/dream` runs an autonomous curator pass over the memory dir (default curator: **rot detection** — flags project memories that no longer match your state files or recent commits) and writes a reviewable proposal artifact. `/dream-apply` walks the artifact and applies accepted items, all under git on the memory dir so any pass is one `git revert` away.
+
+See [`docs/dream-architecture.md`](docs/dream-architecture.md) for the full design (curator catalog, proposal schema, scope guards).
 
 ---
 

--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -1,0 +1,116 @@
+---
+name: dream-apply
+description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
+allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
+---
+
+# /dream-apply — review + apply a curator pass
+
+Substrate background: `docs/dream-architecture.md`.
+
+## Usage
+
+```
+/dream-apply {ISO-timestamp}
+/dream-apply latest        # auto-resolves to most recent .dreams/ subdir
+```
+
+## Steps
+
+### 1. Resolve the dream dir
+
+```
+PROJECT_KEY=$(pwd | sed 's|[:\\/]|-|g')
+DREAMS_ROOT="$HOME/.claude/projects/$PROJECT_KEY/memory/.dreams"
+```
+
+If `$ARGUMENTS` is `latest` or empty: pick the most recent subdir by name (ISO timestamps sort lexically). Otherwise treat `$ARGUMENTS` as the ISO timestamp.
+
+If the dir doesn't exist, list available dreams and stop.
+
+### 2. Load the proposal artifact
+
+Read `$DREAMS_ROOT/$TS/proposals.json` and `$DREAMS_ROOT/$TS/REPORT.md`. If either is missing, stop with an error.
+
+### 3. Show the report header
+
+Print the top of REPORT.md (header + counts). Don't dump the whole thing — the user already has it if they want the full text.
+
+### 4. Walk each proposal
+
+For each `proposals[i]`:
+
+a. Print:
+   ```
+   ─── Proposal {id} ({i+1}/{N}) ───
+   Action: {action}    Target: {target}    Confidence: {confidence}
+   Reasoning: {reasoning}
+   Evidence:
+     - {evidence[0]}
+     - {evidence[1]}
+
+   Current:
+     {current_excerpt}
+
+   Proposed:
+     {proposed_excerpt}
+   ```
+
+b. Ask via `AskUserQuestion`:
+   - Question: "Apply this proposal?"
+   - Options: `Accept` / `Reject` / `Edit then accept` / `Skip rest`
+   - For `high` confidence: order options Accept-first.
+   - For `medium`: order Reject-first (forces reading).
+   - For `flag` (rot ambiguous): order Reject-first; treat Accept as opt-in only.
+
+c. On `Accept`: apply the change.
+   - For `modify` action: use Edit tool on `memory/{target}`, replacing `current_excerpt` with `proposed_excerpt`.
+   - For `archive` action: append a row to `memory/ARCHIVE.md` (`| {today} | {target} | {one-line reason from proposal.reasoning} |`), then remove the corresponding line from `memory/MEMORY.md` index, then leave the file in place (don't delete the .md).
+   - For `add` action (pattern curator, v0.2): create new memory file with proposed content, add an index line to `memory/MEMORY.md`.
+   - For `flag` action: write nothing — flags are just surfacing.
+
+d. On `Edit then accept`: open `proposed_excerpt` for inline edit (use `AskUserQuestion` with an "Other" textarea option), then apply the edited version.
+
+e. On `Reject`: skip, log to `applied.json` as `rejected`.
+
+f. On `Skip rest`: break the loop, log remaining as `deferred`.
+
+### 5. Write `applied.json` to the dream dir
+
+```json
+{
+  "applied_at": "{ISO}",
+  "decisions": [
+    {"id": "rot-001", "decision": "accepted"},
+    {"id": "rot-002", "decision": "rejected"},
+    {"id": "rot-003", "decision": "edited", "edited_excerpt": "..."}
+  ]
+}
+```
+
+### 6. Commit to memory git
+
+```
+cd "$HOME/.claude/projects/$PROJECT_KEY/memory"
+git add -A
+git commit -m "dream-apply($TS): N accepted / M rejected / K deferred"
+```
+
+If no proposals were accepted, still commit `applied.json` so the audit trail is complete.
+
+### 7. Final summary
+
+```
+Dream apply complete: {TS}
+Accepted: N    Rejected: M    Edited: K    Deferred: L
+Memory git HEAD: {short-sha}    Files changed: {count}
+
+Reverting this pass: cd <memory dir> && git revert HEAD
+```
+
+## Safety rules
+
+- Never push memory git anywhere. Local-only. If a remote has been added, refuse to apply and ask the user to remove it.
+- Never accept a proposal with empty `evidence`. Reject + warn that the curator violated the schema.
+- If applying a `modify` and the `current_excerpt` doesn't match the file (because memory was edited between dream + apply), Edit tool will error. Surface the conflict, ask the user to resolve manually.
+- Don't auto-apply anything. Every proposal goes through review.

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -1,0 +1,106 @@
+---
+name: dream
+description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
+allowed-tools: Read, Bash, Write, Glob, Grep
+---
+
+# /dream — autonomous memory curator pass
+
+Substrate background: `docs/dream-architecture.md`. Curator prompts: `scripts/dream/prompts/`.
+
+## Usage
+
+```
+/dream             # default curator: rot
+/dream rot         # explicit
+/dream pattern     # NOT YET BUILT (v0.2)
+/dream contradiction  # NOT YET BUILT (v0.3)
+/dream untapped    # NOT YET BUILT (v0.4)
+/dream audit       # NOT YET BUILT (v0.5)
+```
+
+## Steps
+
+### 1. Resolve curator name
+
+If `$ARGUMENTS` is empty or `rot`, proceed with rot. If anything else, check whether `scripts/dream/prompts/{name}.md` exists. If not, list available curators and stop.
+
+### 2. Resolve the memory dir + generate ISO timestamp
+
+```
+PROJECT_KEY=$(pwd | sed 's|[:\\/]|-|g')
+MEMORY_DIR="$HOME/.claude/projects/$PROJECT_KEY/memory"
+TS=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+DREAM_DIR="$MEMORY_DIR/.dreams/$TS"
+mkdir -p "$DREAM_DIR"
+```
+
+If `$MEMORY_DIR/.git` doesn't exist, stop and tell the user to run the first-time setup from `scripts/dream/README.md`.
+
+### 3. Load the curator prompt
+
+Read `scripts/dream/prompts/{curator}.md` in full. This is your role + output schema for the rest of this command.
+
+### 4. Gather inputs (read-only)
+
+Per the curator's required inputs (rot needs all of these):
+
+- `ls $MEMORY_DIR/*.md` and read each `project_*.md` / `reference_*.md` (skip `env_`, `feedback_`, `user_` unless the curator asks)
+- Read `state/decisions.md`, `state/blockers.md`, `state/current.md`
+- `find sessions/ -name "*.md" -mtime -14` and read each
+- `git log --since="14 days ago" --oneline` for the current repo
+
+### 5. Write `inputs.json` to the dream dir
+
+Record what was fed in (file paths + line counts), so the run is reproducible.
+
+```json
+{
+  "curator": "rot",
+  "ran_at": "{ISO}",
+  "memory_files_read": [...],
+  "state_files_read": [...],
+  "session_files_read": [...],
+  "git_log_window_days": 14,
+  "git_log_commit_count": N
+}
+```
+
+### 6. Run the curator
+
+Following the role + question + classification logic in the loaded prompt, walk every input target and produce findings. **Be conservative — empty-evidence proposals get rejected at apply time.**
+
+### 7. Write `proposals.json` to the dream dir
+
+Schema is defined in the curator prompt. Each proposal must have: `id`, `action`, `target`, `reasoning`, `evidence` (array, never empty), `current_excerpt`, `proposed_excerpt`, `confidence`.
+
+### 8. Write `REPORT.md` to the dream dir
+
+Human-readable summary per the curator prompt's format. Top: dream-pass header + counts. Then findings grouped by confidence. Then skipped items. Footer: `Run /dream-apply {ISO} to review and apply.`
+
+### 9. Commit the artifact to memory git
+
+```
+cd "$MEMORY_DIR"
+git add ".dreams/$TS/"
+git commit -m "dream($TS): {curator} — N proposals (H high / M med / L flag)"
+```
+
+### 10. Surface the result
+
+Print:
+
+```
+Dream pass complete: {curator}
+Artifact: memory/.dreams/{ISO}/REPORT.md
+Proposals: N (H high, M medium, L flag)
+Top finding: {one-line summary of the highest-confidence proposal}
+
+Review and apply: /dream-apply {ISO}
+```
+
+## Scope guards
+
+- Curator MUST NOT modify any input file. Read-only on `memory/`, `state/`, `sessions/`.
+- Curator MUST NOT push the memory git repo to any remote. Local-only by design.
+- If `$ARGUMENTS` names a curator that hasn't been built yet, refuse politely and list what is available.

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -1,0 +1,111 @@
+# Auto-memory
+
+Claude Code reads `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md` automatically at the start of every conversation in that project. The starter uses this to give Claude a persistent, file-based memory that survives across sessions.
+
+This doc is the spec. Add it to your global `~/.claude/CLAUDE.md` (so every Claude session in this project follows it) or copy the relevant rules into this project's `CLAUDE.md`.
+
+## Storage layout
+
+```
+~/.claude/projects/<encoded-cwd>/memory/
+├── MEMORY.md           ← index, loaded into every conversation (cap 100 lines)
+├── ARCHIVE.md          ← pruned / superseded entries
+└── <topic>.md          ← one detail file per memory, loaded on demand
+```
+
+`<encoded-cwd>` is your current working directory with `:`, `/`, and `\` replaced by `-`. For example `C:\Users\you\my-context` becomes `C--Users-you-my-context`. Claude Code creates the directory automatically the first time a memory is written.
+
+`MEMORY.md` is an index, not a memory. Each entry is one line — a pointer to the detail file plus a short hook. Detail files load only when relevant.
+
+## What to save (four types)
+
+### user
+Information about who the user is — role, goals, knowledge, preferences. Helps tailor responses.
+
+**Save when:** you learn role, expertise, responsibilities, or non-obvious preferences.
+
+**Example:** "Senior backend engineer, deep Go expertise, new to this repo's frontend — frame frontend explanations in terms of backend analogues."
+
+### feedback
+Guidance the user gave you about *how to work* — corrections AND validated approaches.
+
+**Save when:** the user corrects your approach ("don't do X") OR confirms a non-obvious choice worked ("yes, that was the right call"). Corrections are easy to spot; confirmations are quieter — watch for them.
+
+**Body structure:**
+- The rule, in one sentence
+- **Why:** the reason the user gave (often a past incident)
+- **How to apply:** when this guidance kicks in
+
+The *why* lets you judge edge cases instead of following rules blindly.
+
+**Example:** "Integration tests must hit a real database, not mocks. **Why:** prior incident where mock/prod divergence masked a broken migration. **How to apply:** any test touching the persistence layer."
+
+### project
+Context about ongoing work that isn't derivable from the code or git history — who's doing what, why, by when.
+
+**Save when:** you learn motivation, deadlines, stakeholder context, or decisions.
+
+**Important:** convert relative dates to absolute when saving. "Thursday" → "2026-03-05". Memories outlive the conversation that created them.
+
+**Body structure:** Fact / decision, then **Why:** and **How to apply:** lines.
+
+**Example:** "Merge freeze begins 2026-03-05 for mobile release cut. **Why:** mobile team is cutting a release branch. **How to apply:** flag any non-critical PR work scheduled after that date."
+
+### reference
+Pointers to where information lives in external systems.
+
+**Save when:** the user names a tracker, dashboard, channel, or doc by purpose.
+
+**Example:** "Pipeline bugs tracked in Linear project 'INGEST'." / "grafana.internal/d/api-latency is the oncall latency dashboard."
+
+## What NOT to save
+
+These belong in code, git history, or the conversation — not memory:
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the project.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` is authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in `CLAUDE.md`.
+- Ephemeral state: in-progress work, current conversation context, today's plan.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save
+
+Two steps.
+
+**Step 1 — write the detail file** (e.g., `feedback_testing.md`) with frontmatter:
+
+```markdown
+---
+name: {memory name}
+description: {one-line description — used to decide relevance in future conversations, so be specific}
+type: {user | feedback | project | reference}
+---
+
+{memory content — for feedback/project, structure as: rule/fact, then **Why:** and **How to apply:** lines}
+```
+
+**Step 2 — add a pointer to `MEMORY.md`:**
+
+```markdown
+- [Title](file.md) — one-line hook
+```
+
+`MEMORY.md` has no frontmatter. It's a flat index, organized semantically by topic (not chronologically). Keep entries to one line under ~150 characters — the index loads on every conversation and excess truncates.
+
+## When to access memories
+
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory, don't apply remembered facts.
+
+Memories can become stale. Before acting on a memory that names a specific file, function, or flag, verify it still exists. The memory is a claim about what was true when it was written — current state is the source of truth.
+
+## Memory budget
+
+`MEMORY.md` loads on every conversation. Cap it at ~100 lines. When approaching the cap, consolidate or move detail files to `ARCHIVE.md`. Detail files are exempt from the cap — they load on demand.
+
+## Curation: /dream
+
+Memory accumulates faster than humans review it. The `/dream` substrate runs autonomous curator passes against the memory dir (rot detection, pattern surfacing, contradiction flagging) and produces a proposal artifact you review with `/dream-apply`. See `docs/dream-architecture.md`.

--- a/docs/dream-architecture.md
+++ b/docs/dream-architecture.md
@@ -1,0 +1,182 @@
+# Dream — autonomous memory curator
+
+**Status:** v0.1 substrate. First curator prompt: rot detection.
+
+## Why this exists
+
+Memory accumulates faster than humans review it. The only forcing functions are `/end` (hand-curated at session close, biased toward what's fresh in context) and `/today` (morning heartbeat, biased toward today's priorities). Neither catches:
+
+1. **Rot** — project memories stale within days ("X submitted, awaiting approval" → false a week later)
+2. **Cross-session patterns** — same friction hit 3+ times across sessions but only captured as a memory once
+3. **Contradictions** — two memory rules giving conflicting guidance, both still indexed
+4. **Untapped patterns** — recurring session-log themes that never got promoted to memory
+5. **Adherence drift** — sessions ignoring rules they should have followed
+
+These are LLM-shaped tasks: pattern detection across 7-30 days of episodic memory, compression into semantic rules, contradiction detection.
+
+The bet: compounding pattern-capture over months beats waiting for the perfect memory product. Curator file shapes (markdown + JSON proposals) stay portable even if the runner gets thrown away.
+
+## Architecture
+
+### Three layers
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ LAYER 1: Inputs (read-only)                                     │
+│   sessions/*.md  state/*.md  memory/*.md  git log (14d)         │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ LAYER 2: Curator pass (prompted)                                │
+│   /dream {curator-name}                                         │
+│   Curator prompts live in scripts/dream/prompts/                │
+│   {rot, pattern, contradiction, untapped, audit}.md             │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ LAYER 3: Proposal artifact (write to memory git)                │
+│   memory/.dreams/{ISO}/                                         │
+│     REPORT.md       — human-readable summary                    │
+│     proposals.json  — machine-readable per-item diff            │
+│     inputs.json     — what was fed in (reproducibility)         │
+│   Committed to memory git on creation.                          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ APPLY: separate command, gated on human review                  │
+│   /dream-apply {ISO-timestamp}                                  │
+│   Walks proposals.json, asks accept/reject/edit per item,       │
+│   applies accepted to memory files, commits in memory git.      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Why slash commands, not standalone Python
+
+1. **No separate API key.** The curator runs inside the existing Claude Code session — same model, same auth.
+2. **Easier prompt iteration.** Curator prompts are markdown files; tweak one, run again, no redeploy.
+3. **Structured-tool access.** `AskUserQuestion` for the apply step gives a real review UI rather than terminal Y/N.
+
+Tradeoff: can't run truly unattended. To schedule, use `/loop` or wire a remote agent via `/schedule` that fires `claude --headless /dream rot`.
+
+### Why git on the memory dir
+
+Three load-bearing benefits once a curator runs autonomously:
+
+1. **Diff before/after.** "What changed in this dream pass" is the most-asked question after every run.
+2. **Revert path.** A bad accept-all on `/dream-apply` is one `git revert` away.
+3. **Migration insurance.** `cp -r memory/ <new machine>` + `git log` keeps the full history.
+
+**Local-only repo. No remote.** Memory often contains personal or confidential context. If you need backup, snapshot to a private location separately.
+
+### Storage layout
+
+```
+~/.claude/projects/<encoded-cwd>/memory/
+├── .git/                   ← local-only repo
+├── MEMORY.md               ← index (cap 100 lines)
+├── ARCHIVE.md              ← pruned/superseded entries
+├── {topic}.md              ← detail files
+└── .dreams/                ← curator artifacts
+    └── {ISO-timestamp}/
+        ├── REPORT.md       ← human review surface
+        ├── proposals.json  ← machine apply surface
+        └── inputs.json     ← reproducibility
+```
+
+### Proposal schema (v0.1)
+
+Each proposal is one of four actions: `modify`, `archive`, `add`, `flag`.
+
+```json
+{
+  "id": "rot-001",
+  "action": "modify",
+  "target": "project_acme_migration.md",
+  "reasoning": "Memory says 'Acme migration awaiting approval.' state/blockers.md (2026-03-04 update) shows it shipped. Update memory to reflect shipped status.",
+  "evidence": [
+    "state/blockers.md L24: 'Acme migration shipped 2026-03-04'",
+    "sessions/2026-03-05.md: '...Acme migration deployed clean'"
+  ],
+  "current": "<excerpt of memory file>",
+  "proposed": "<rewritten excerpt>",
+  "confidence": "high"
+}
+```
+
+Apply step honors `confidence`: `high` defaults to accept, `medium` shows full diff, `low` requires explicit edit.
+
+## Curator catalog (build order)
+
+### v0.1: rot (ships with starter)
+
+**Question:** "For each project-type memory entry, does it still match the current state of the world?"
+
+**Inputs:** `memory/project_*.md` + `state/{decisions,blockers,current}.md` + `git log --since=14.days.ago`.
+
+**Output actions:** `modify`, `archive`, `flag`.
+
+**Why first:** Easiest objective spec. Lowest false-positive cost ("no, this is still true" is cheap to dismiss). Runs against existing data, proves substrate value on day 1.
+
+### v0.2: pattern (next)
+
+**Question:** "What recurring frictions in the last 14 days of sessions don't have a memory entry yet?"
+
+**Inputs:** `sessions/*.md` (last 14d) + `memory/*.md` (to dedupe).
+
+**Output actions:** `add` (new memory candidate). Required-evidence floor: must appear in 3+ sessions to propose.
+
+### v0.3: contradiction (later)
+
+**Question:** "Does memory contain rules that give conflicting guidance for the same situation?"
+
+**Output actions:** `flag` (always — never auto-resolve a contradiction; surface to the user).
+
+### v0.4: untapped (later)
+
+**Question:** "What recurring themes in session logs have never been raised into memory or a skill?"
+
+**Output actions:** `flag`.
+
+### v0.5: audit (later, possibly never)
+
+**Question:** "Did sessions in the last 7 days follow the rules in MEMORY.md?"
+
+**Risk:** Memory rules aren't structured enough to mechanically check adherence. May produce noise. Hold until v0.4 ships.
+
+## What this deliberately doesn't do (v0.1)
+
+- **No skill generation.** Skills stay manual via `/skill-creator` (or your own equivalent).
+- **No autonomous apply.** Review gate stays. Maybe never removed for high-stakes scopes.
+- **No vector store / SQLite / FTS.** Plain markdown + JSON. Smallest substrate that works.
+- **No scheduled trigger.** Manual `/dream rot` for v0.1. Schedule via `/loop` once the prompt stabilizes for your workflow.
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Curator hallucinates rot that's actually current | Required `evidence` array — every claim cites a state-file line or commit. Apply rejects empty-evidence proposals. |
+| Apply step accept-all destroys good memories | Git on memory dir → revert is one command. Apply shows full diff before each accept. |
+| Memory + state files drift apart over time | Curator reads both each pass; rot detector specifically cross-references them. |
+| Confidential memory leaks via accidental `git push` | No remote configured. Pre-commit hook on memory git: refuse if any remote is added. (TODO.) |
+
+## Open questions
+
+- Should `state/decisions.md` ever be a curator write target? Currently read-only.
+- Should the curator propose `CLAUDE.md` changes when a feedback rule validates 3+ times? Promotion changes Claude's default behavior — high-leverage and high-risk.
+- Multi-repo curators? Same substrate could run against any project's `state/` + `memory/`.
+
+## Files
+
+| Path | Role |
+|---|---|
+| `docs/dream-architecture.md` | This file. |
+| `docs/auto-memory.md` | Memory spec the curator operates on. |
+| `scripts/dream/README.md` | How to use, how to add curators. |
+| `scripts/dream/prompts/rot.md` | Rot-detector prompt body. |
+| `commands/dream.md` | `/dream {curator}` slash command. Default: `rot`. |
+| `commands/dream-apply.md` | `/dream-apply {timestamp}` slash command. |
+| `~/.claude/projects/<encoded-cwd>/memory/.git/` | Local-only repo for memory dir. Run `git init` there on first use. |
+| `~/.claude/projects/<encoded-cwd>/memory/.dreams/` | Per-pass artifacts. Tracked. |

--- a/docs/memory-template.md
+++ b/docs/memory-template.md
@@ -1,0 +1,64 @@
+# Memory template
+
+Drop this into `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md` to seed your auto-memory index. Claude Code will load it on every conversation in this project.
+
+See `docs/auto-memory.md` for the full spec (what to save, what NOT to save, body structure, the two-step write).
+
+---
+
+```markdown
+# Auto Memory
+
+## User
+
+<!-- One-line pointers to user_*.md detail files. Examples:
+- [Role + expertise](user_role.md) — senior backend, deep Go, new to React side of this repo
+-->
+
+## Environment
+
+<!-- One-line pointers to env_*.md detail files (toolchain quirks, platform gotchas). Examples:
+- [Windows Git Bash regex](env_git_bash_regex.md) — `grep -P` not supported. Use `sed` in hooks.
+-->
+
+## Projects
+
+<!-- One-line pointers to project_*.md detail files (in-flight work, decisions, why). Examples:
+- [Auth middleware rewrite](project_auth_rewrite.md) — compliance-driven, not tech debt. Sub-scope decisions favor compliance over ergonomics.
+-->
+
+## Feedback
+
+<!-- One-line pointers to feedback_*.md detail files (how the user wants you to work). Examples:
+- [No mocked DBs in integration tests](feedback_no_mocked_db.md) — prior mock/prod divergence masked a broken migration.
+- [Terse responses, no trailing summaries](feedback_terse_responses.md) — user reads the diff.
+-->
+
+## References
+
+<!-- One-line pointers to reference_*.md detail files (external systems by purpose). Examples:
+- [Pipeline bug tracker](reference_linear_ingest.md) — Linear project "INGEST"
+- [Oncall latency dashboard](reference_grafana_latency.md) — grafana.internal/d/api-latency
+-->
+```
+
+---
+
+## Conventions
+
+- **One detail file per memory.** Frontmatter: `name`, `description`, `type`.
+- **MEMORY.md is index-only.** One line per entry, under ~150 chars. No frontmatter on this file.
+- **Organize by type, then topic.** Not chronologically.
+- **Cap at ~100 lines.** When approaching, consolidate or move to `ARCHIVE.md`.
+
+## First-time setup
+
+```bash
+PROJECT_KEY=$(pwd | sed 's|[:\\/]|-|g')
+MEMORY_DIR="$HOME/.claude/projects/$PROJECT_KEY/memory"
+mkdir -p "$MEMORY_DIR"
+cp docs/memory-template.md "$MEMORY_DIR/MEMORY.md"
+# then edit out the docs preamble — keep only the markdown block under the rule
+```
+
+For `/dream` curator support, also initialize the memory dir as a local-only git repo. See `scripts/dream/README.md`.

--- a/scripts/dream/README.md
+++ b/scripts/dream/README.md
@@ -1,0 +1,53 @@
+# /dream — autonomous memory curator
+
+Substrate for curator passes against `~/.claude/projects/<encoded-cwd>/memory/`.
+
+**Full architectural rationale: `docs/dream-architecture.md`.**
+
+## Usage
+
+```
+/dream [curator]              # default: rot. produces a proposal artifact, no apply.
+/dream-apply {ISO-timestamp}  # walks the proposal, accept/reject/edit per item.
+```
+
+Curator catalog (build order):
+- `rot` (v0.1, ships with starter) — flag project memories that no longer match state files / recent commits
+- `pattern` (v0.2, planned) — propose new memories from recurring session-log frictions
+- `contradiction` (v0.3, planned) — flag memory rules giving conflicting guidance
+- `untapped` (v0.4, planned) — surface session-log themes never raised to memory
+- `audit` (v0.5, maybe) — flag sessions that ignored MEMORY.md rules
+
+## First-time setup
+
+The memory dir is created automatically by Claude Code, but the git repo on it is not. Initialize it once:
+
+```bash
+PROJECT_KEY=$(pwd | sed 's|[:\\/]|-|g')
+MEMORY_DIR="$HOME/.claude/projects/$PROJECT_KEY/memory"
+mkdir -p "$MEMORY_DIR"
+cd "$MEMORY_DIR"
+git init
+git add -A
+git commit -m "initial memory snapshot"
+```
+
+No remote. The memory dir often contains personal or confidential context.
+
+## Where things live
+
+- **Curator prompts:** `prompts/{name}.md` here
+- **Slash commands:** `commands/dream.md` + `commands/dream-apply.md` in the repo root
+- **Proposal artifacts:** `~/.claude/projects/<encoded-cwd>/memory/.dreams/{ISO}/`
+- **Memory git repo:** `~/.claude/projects/<encoded-cwd>/memory/.git/` (local-only, no remote)
+
+## Adding a new curator
+
+1. Write `prompts/{name}.md` with the curator's role + question + output schema (use `prompts/rot.md` as the template).
+2. Add the curator name to the `/dream` slash command's accepted list.
+3. Run `/dream {name}`, review the artifact, iterate the prompt.
+4. Update `docs/dream-architecture.md` to mark the curator shipped.
+
+## Why slash commands, not Python
+
+Curator runs inside the existing Claude Code session — no separate API key, easier prompt iteration, structured-tool access for the apply step. Tradeoff: can't run truly unattended without `claude --headless`. Schedule via `/loop` once a prompt stabilizes for your workflow.

--- a/scripts/dream/prompts/rot.md
+++ b/scripts/dream/prompts/rot.md
@@ -1,0 +1,117 @@
+# Curator prompt: rot detection
+
+**Role:** You are a memory curator. Your single job in this pass is to find rot — memory entries that were once true but are no longer accurate given the current state of the world.
+
+**Scope of rot:** Project-type memories rot fastest (`memory/project_*.md`). They make assertions about in-progress work ("X submitted, awaiting approval") that flip from true to false as work moves. Reference-type memories rot more slowly (addresses, API endpoints, URLs) but still rot. Feedback-type memories almost never rot — skip them unless an entry references a specific dated incident that has been superseded.
+
+## Inputs you'll be given
+
+You'll have access to:
+
+- All files in `memory/` (the memories under audit)
+- `state/decisions.md` (append-only history of decisions — strong evidence for "this happened")
+- `state/blockers.md` (current blockers + recently-unblocked — strong evidence for "this resolved")
+- `state/current.md` (active priorities, last-updated entries — moderate evidence)
+- Last 14 days of `sessions/*.md` (episodic record — weakest individually, strong in aggregate)
+- `git log --since=14.days.ago --oneline` (commit-level evidence)
+
+You may NOT modify any of these. You produce a proposal artifact only.
+
+## What to look for
+
+For each `memory/project_*.md` and `memory/reference_*.md` (skip `env_`, `feedback_`, `user_`):
+
+1. Read the memory file's claims. Identify each load-bearing assertion (status, dates, who's involved, what's pending).
+2. Cross-reference each assertion against the inputs. Look for:
+   - **Direct contradiction** — memory says X, state file says NOT X
+   - **Status drift** — memory says "in progress / awaiting", state file or commits show "completed / shipped / approved / rejected"
+   - **Date drift** — memory says "this week" or "by Thursday", but the date has passed and no follow-up confirms
+   - **Person drift** — memory names someone in a role they've since left
+   - **Missing follow-through** — memory says "next: do X", and no evidence of X across 14d sessions or commits
+
+3. Classify each finding:
+   - **`modify`** — assertion is wrong; rewrite to current truth. Required: cite specific evidence line(s).
+   - **`archive`** — entire memory is now historical (project complete, decision moot). Required: confirm via 2+ evidence sources.
+   - **`flag`** — rot suspected but evidence ambiguous; surface to the user for decision. Required: explain what's ambiguous.
+
+4. **Do NOT propose anything you can't cite evidence for.** Empty-evidence proposals get rejected at apply time.
+
+## Output schema
+
+Produce two files in `memory/.dreams/{ISO-timestamp}/`:
+
+### `proposals.json`
+
+```json
+{
+  "curator": "rot",
+  "ran_at": "2026-05-11T00:42:00Z",
+  "inputs_summary": {
+    "memory_files_audited": 28,
+    "session_window_days": 14,
+    "commit_window_days": 14
+  },
+  "proposals": [
+    {
+      "id": "rot-001",
+      "action": "modify",
+      "target": "project_acme_migration.md",
+      "reasoning": "Memory says Acme migration awaiting approval. state/blockers.md (2026-03-04 entry under Recently Unblocked) shows it shipped. Update memory to reflect shipped status.",
+      "evidence": [
+        "state/blockers.md L26: 'Acme migration | 2026-03-04 | Shipped, monitoring stable.'"
+      ],
+      "current_excerpt": "Acme migration submitted for review. Chain: design ✓ → review → ship.",
+      "proposed_excerpt": "Acme migration shipped 2026-03-04. Monitoring stable. Chain: design ✓ → review ✓ → shipped ✓.",
+      "confidence": "high"
+    }
+  ],
+  "skipped": [
+    {
+      "target": "project_old_initiative.md",
+      "reason": "Static historical record. No moving parts to rot."
+    }
+  ]
+}
+```
+
+### `REPORT.md`
+
+Human-readable summary. Format:
+
+```markdown
+# Dream pass: rot — {ISO-timestamp}
+
+**Audited:** N project + M reference memories
+**Window:** sessions + commits since {date-14d-ago}
+
+## Findings
+
+### High confidence (N)
+
+1. **{target}** — {one-line summary}
+   - Evidence: {one line}
+   - Suggested action: {modify | archive}
+
+### Medium confidence (N)
+
+...
+
+### Flagged for review (N)
+
+...
+
+## Skipped
+
+- {target} — {one-line reason}
+
+## Apply
+
+Run `/dream-apply {ISO-timestamp}` to review and apply.
+```
+
+## What you must NOT do
+
+- Don't write to memory files directly. The artifact is the only output.
+- Don't propose changes to `feedback_*` or `env_*` unless the entry contains a dated assertion that has been superseded.
+- Don't speculate. If evidence is weak, classify `flag`, not `modify`.
+- Don't propose archiving a memory just because it's old. Old + still accurate = keep.


### PR DESCRIPTION
## Summary

Closes the biggest gap between this starter and the way Claude Code is actually used day-to-day: a **persistent, file-based auto-memory layer** plus a **`/dream` curator** that keeps it from rotting.

The starter has shipped the session loop (`/start` → `/end` → `/today`) since 0.6.0, but nothing was telling Claude *what* to remember across sessions or *how* to remember it. Adopters were left to figure out the memory shape themselves. This release ships that shape — typed entries (user / feedback / project / reference), a 100-line index, detail-on-demand files — and a curator that runs autonomous passes over the memory dir to catch rot, with every change gated on human review and committed under a local-only git repo.

### What's new

- **`docs/auto-memory.md`** — the spec. Four typed entries, what to save / what NOT to save, body structure with `**Why:**` + `**How to apply:**` lines so future-you can judge edge cases, two-step write (detail file + index pointer), `MEMORY.md` capped at ~100 lines.
- **`docs/memory-template.md`** — a seed `MEMORY.md` with one-line example pointers per type plus first-time setup.
- **`docs/dream-architecture.md`** — three-layer design (read-only inputs → curator pass → proposal artifact → human-gated apply), curator catalog (rot v0.1 ships; pattern / contradiction / untapped / audit planned), proposal schema, local-only memory git rationale, risk table.
- **`commands/dream.md`** — `/dream {curator}` (default: `rot`). Derives memory dir from `pwd`, gathers read-only inputs, writes `proposals.json` + `REPORT.md` + `inputs.json` to `memory/.dreams/{ISO}/`, commits.
- **`commands/dream-apply.md`** — `/dream-apply {ISO}` (or `latest`). Walks proposals via `AskUserQuestion`, supports Accept / Reject / Edit-then-accept / Skip-rest, applies `modify` / `archive` / `add` / `flag` actions, commits.
- **`scripts/dream/`** — curator prompts (rot ships; v0.2+ TBD) and a README covering first-time setup + how to add new curators.
- README + CLAUDE.md + CHANGELOG updated to surface this prominently.

### Why now

Memory is one of the most distinctive things you can build on top of Claude Code, but it's also one of the easiest to do badly (everything-goes piles, no rot strategy, stale entries that quietly mislead). Shipping a clean substrate beats waiting for any provider's GA — the file shapes (markdown + JSON proposals) port to whatever surface shows up later.

### Risk

Low. Markdown-only change. No code paths in the existing starter touched. The new commands all derive their own memory dir from `pwd` and won't run unless the user opts in by creating it. No remote is ever attached to the memory git repo.

## Test plan

- [ ] `bash scripts/validate-skills.sh` passes (verified locally — "All checks passed")
- [ ] `CLAUDE.md` still under 100 lines
- [ ] All new doc references resolve (`docs/auto-memory.md`, `docs/dream-architecture.md`, `docs/memory-template.md`, `scripts/dream/README.md`)
- [ ] `/dream` + `/dream-apply` slash commands parse (frontmatter + allowed-tools valid)
- [ ] Dry-run `/dream rot` against a populated memory dir produces a `proposals.json` with non-empty `evidence` arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)