### PR TITLE
0.9.0: parallel-session hooks + /skill-creator

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,13 +1,24 @@
 # Claude Code Hooks
 
-These scripts run automatically during Claude Code sessions. They are **advisory** — they print warnings but never block actions.
+These scripts run automatically during Claude Code sessions. Most are **advisory** — they print warnings but never block. `worktree-guard.sh` is the exception: it blocks edits to a guarded repo's primary checkout when more than one Claude session is running.
 
 ## Files
 
-| Hook | Event | Purpose |
-|------|-------|---------|
-| `session-start.sh` | `SessionStart` | Surfaces stale state files, inbox items, overdue TODOs |
-| `ssot-guard.sh` | `PreToolUse` (Edit/Write) | Warns when editing SSOT files to prevent fact duplication |
+| Hook | Event | Purpose | Blocks? |
+|------|-------|---------|---------|
+| `session-start.sh` | `SessionStart` | Surfaces stale state files, inbox items, overdue TODOs | no |
+| `branch-hygiene.sh` | `SessionStart` | Surfaces non-default HEAD on guarded repos (catches silent branch-switches by parallel sessions) | no |
+| `ssot-guard.sh` | `PreToolUse` (Edit/Write) | Warns when editing SSOT files to prevent fact duplication | no |
+| `worktree-guard.sh` | `PreToolUse` (Edit/Write) | Blocks edits to a guarded repo's primary checkout when >1 Claude session is running | **yes** |
+| `guarded-repos.txt` | — | Config file listing repo basenames the parallel-session guards apply to | — |
+
+### Parallel-session guards: when to use
+
+Running multiple Claude Code sessions against the same repo simultaneously will eventually corrupt your tree — branch-switches happen silently, one session's `git add` lands in another session's commit, files get committed to the wrong branch. The fix is to use `git worktree` so each session gets its own checkout.
+
+`worktree-guard.sh` enforces that pattern: once a repo is listed in `guarded-repos.txt`, editing files in its primary checkout is blocked when ≥2 Claude sessions are running. Worktrees are still free to edit. An emergency override exists via `touch .allow-shared-edit` at the repo root.
+
+`branch-hygiene.sh` complements it: at session start, if you're on a non-default branch in a guarded repo, the hook surfaces what HEAD is and what's uncommitted. Stays quiet on freshly-created worktrees (clean tree + commit < 2 min old).
 
 ## Configuration
 
@@ -22,6 +33,10 @@ Hooks are configured in `.claude/settings.local.json`. See the example file in t
       {
         "type": "command",
         "command": "bash .claude/hooks/session-start.sh"
+      },
+      {
+        "type": "command",
+        "command": "bash .claude/hooks/branch-hygiene.sh"
       }
     ],
     "PreToolUse": [
@@ -29,14 +44,26 @@ Hooks are configured in `.claude/settings.local.json`. See the example file in t
         "matcher": "Edit|Write",
         "type": "command",
         "command": "bash .claude/hooks/ssot-guard.sh \"$CLAUDE_FILE_PATH\""
+      },
+      {
+        "matcher": "Edit|Write",
+        "type": "command",
+        "command": "bash .claude/hooks/worktree-guard.sh"
       }
     ]
   }
 }
 ```
 
+## Enabling the parallel-session guards
+
+1. Make the scripts executable: `chmod +x .claude/hooks/*.sh`
+2. Open `.claude/hooks/guarded-repos.txt` and add the basename of each repo you want guarded (one per line).
+3. The guards no-op until at least one repo is listed.
+
 ## Customizing
 
 - Edit the stale-days threshold in `session-start.sh` (default: 3 days)
 - Add your own SSOT patterns in `ssot-guard.sh`
+- Add/remove repos in `guarded-repos.txt` (no script edits needed)
 - Create new hooks for other events (`PreToolUse`, `PostToolUse`, etc.)

--- a/.claude/hooks/branch-hygiene.sh
+++ b/.claude/hooks/branch-hygiene.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# SessionStart hook: surface non-default-branch state on guarded repos so a
+# silent branch-switch by a parallel session (HEAD changed underneath us) is
+# noticed BEFORE any edits land in the wrong place.
+#
+# Stays quiet when:
+#   - on the default branch (main/master)
+#   - cwd is not in a guarded repo (see .claude/hooks/guarded-repos.txt)
+#   - branch is non-default but tree is clean AND last commit < 2 min ago
+#     (= almost certainly a worktree this session just created)
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+# Worktrees report their own dirname; resolve canonical repo via git-common-dir.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+case "$GIT_COMMON_DIR" in
+  /*|[A-Za-z]:*) CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR") ;;
+  *) CANONICAL_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" && pwd) ;;
+esac
+REPO_NAME=$(basename "$CANONICAL_ROOT")
+
+# Is this repo guarded?
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GUARD_LIST="$SCRIPT_DIR/guarded-repos.txt"
+[ ! -f "$GUARD_LIST" ] && exit 0
+
+if ! grep -v '^[[:space:]]*#' "$GUARD_LIST" | grep -v '^[[:space:]]*$' | grep -Fxq "$REPO_NAME"; then
+  exit 0
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ -z "$BRANCH" ] && exit 0
+
+# Resolve the repo's default branch via origin/HEAD; fall back to "main".
+DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+[ -z "$DEFAULT" ] && DEFAULT="main"
+[ "$BRANCH" = "$DEFAULT" ] && exit 0
+
+UNCOMMITTED=$(git status --porcelain 2>/dev/null | wc -l)
+LAST_COMMIT=$(git log -1 --format='%cr by %an' 2>/dev/null)
+AHEAD_BEHIND=$(git rev-list --left-right --count "$DEFAULT...HEAD" 2>/dev/null)
+BEHIND=${AHEAD_BEHIND%%[[:space:]]*}
+AHEAD=${AHEAD_BEHIND##*[[:space:]]}
+
+# Quiet path: clean tree + very recent commit = freshly created worktree.
+LAST_TS=$(git log -1 --format='%ct' 2>/dev/null)
+NOW=$(date +%s)
+if [ -n "$LAST_TS" ] && [ "$UNCOMMITTED" -eq 0 ]; then
+  AGE=$((NOW - LAST_TS))
+  [ "$AGE" -lt 120 ] && exit 0
+fi
+
+# Detect if HEAD is in a worktree vs primary checkout — useful for the message.
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+case "$GIT_DIR" in
+  *worktrees*) WHERE="worktree" ;;
+  *) WHERE="primary checkout" ;;
+esac
+
+echo "=== BRANCH HYGIENE ($REPO_NAME, $WHERE) ==="
+echo ""
+echo "  HEAD:        $BRANCH (not $DEFAULT)"
+echo "  Last commit: $LAST_COMMIT"
+echo "  Uncommitted: $UNCOMMITTED file(s)"
+echo "  vs $DEFAULT:  ahead $AHEAD, behind $BEHIND"
+echo ""
+echo "If this is unexpected (e.g. parallel session switched HEAD), reset before editing:"
+echo "    git -C \"$REPO_ROOT\" checkout $DEFAULT"
+echo "  or open a fresh worktree:"
+echo "    git -C \"$REPO_ROOT\" worktree add ../${REPO_NAME}-<task> -b claude/<task>"
+echo ""
+echo "=== END BRANCH HYGIENE ==="

--- a/.claude/hooks/guarded-repos.txt
+++ b/.claude/hooks/guarded-repos.txt
@@ -1,0 +1,11 @@
+# Repos guarded by worktree-guard.sh + branch-hygiene.sh.
+# One repo basename per line. Lines starting with `#` and blank lines are ignored.
+#
+# Add a repo here when you find yourself running multiple Claude sessions
+# against it and want the parallel-edit collision protection. Until a repo
+# is listed, both hooks no-op for it.
+#
+# Examples (uncomment / edit for your own repos):
+# my-personal-context
+# my-website
+# my-side-project

--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# PreToolUse hook: when >1 Claude session is running, block Edit/Write to
+# files that live inside the primary checkout of a guarded repo. Forces use
+# of git worktrees — the reliable way to prevent file-collision drift
+# between parallel sessions.
+#
+# The check is on the *target file path* (parsed from the tool input JSON
+# on stdin), not on cwd — so a session in one repo can still edit files in
+# another repo's worktree.
+#
+# Behavior:
+#   - allow if Claude session count <= 1
+#   - allow if target file is inside a git worktree (not the primary checkout)
+#   - allow if target's repo basename is NOT listed in .claude/hooks/guarded-repos.txt
+#   - allow if `.allow-shared-edit` exists at the target repo's root
+#   - otherwise block with exit code 2 and an instruction message
+
+# 1. Read tool input JSON from stdin to extract file_path.
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | python -c "
+import sys, json
+try:
+    data = json.loads(sys.stdin.read())
+    print(data.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+
+# If we can't determine a file path, don't block.
+[ -z "$FILE_PATH" ] && exit 0
+
+# 2. Session count. tasklist on Windows, ps elsewhere.
+SESSION_COUNT=$(tasklist //FI "IMAGENAME eq claude.exe" 2>/dev/null | grep -c "^claude.exe")
+if [ "$SESSION_COUNT" -eq 0 ]; then
+  SESSION_COUNT=$(ps aux 2>/dev/null | grep -E "\\bclaude(\\.exe)?\\b" | grep -v grep | wc -l)
+fi
+[ "$SESSION_COUNT" -le 1 ] && exit 0
+
+# 3. Find the git repo for the target file. Walk up from the file's directory
+#    (works whether the file exists yet or not).
+TARGET_DIR=$(dirname "$FILE_PATH")
+while [ ! -d "$TARGET_DIR" ] && [ "$TARGET_DIR" != "/" ] && [ "$TARGET_DIR" != "." ]; do
+  TARGET_DIR=$(dirname "$TARGET_DIR")
+done
+[ ! -d "$TARGET_DIR" ] && exit 0
+
+GIT_DIR=$(git -C "$TARGET_DIR" rev-parse --git-dir 2>/dev/null) || exit 0
+
+# 4. Inside a worktree? Allow.
+case "$GIT_DIR" in
+  *worktrees*) exit 0 ;;
+esac
+
+REPO_ROOT=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
+# Resolve canonical repo via git-common-dir (worktrees report their own dirname).
+GIT_COMMON_DIR=$(git -C "$TARGET_DIR" rev-parse --git-common-dir 2>/dev/null)
+case "$GIT_COMMON_DIR" in
+  /*|[A-Za-z]:*) CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR") ;;
+  *) CANONICAL_ROOT=$(cd "$TARGET_DIR/$(dirname "$GIT_COMMON_DIR")" 2>/dev/null && pwd) ;;
+esac
+[ -z "$CANONICAL_ROOT" ] && CANONICAL_ROOT="$REPO_ROOT"
+REPO_NAME=$(basename "$CANONICAL_ROOT")
+
+# 5. Is this repo guarded?
+#    Look for guarded-repos.txt next to this script (works in worktrees too).
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GUARD_LIST="$SCRIPT_DIR/guarded-repos.txt"
+[ ! -f "$GUARD_LIST" ] && exit 0
+
+if ! grep -v '^[[:space:]]*#' "$GUARD_LIST" | grep -v '^[[:space:]]*$' | grep -Fxq "$REPO_NAME"; then
+  exit 0
+fi
+
+# 6. Escape hatch.
+[ -f "$REPO_ROOT/.allow-shared-edit" ] && exit 0
+
+# 7. Block.
+echo "=== WORKTREE GUARD ==="
+echo ""
+echo "Blocked: $SESSION_COUNT Claude sessions are running and the target file"
+echo "is inside the primary checkout of '$REPO_NAME':"
+echo "  $FILE_PATH"
+echo ""
+echo "Parallel edits to the same checkout cause branch-switch drift."
+echo ""
+echo "Create a worktree before editing. Example:"
+echo ""
+echo "    git -C \"$REPO_ROOT\" worktree add ../${REPO_NAME}-<task> -b claude/<task-name>"
+echo "    cd ../${REPO_NAME}-<task>"
+echo ""
+echo "Override (rare, e.g. shared state files): touch \"$REPO_ROOT/.allow-shared-edit\""
+echo ""
+echo "Or remove '$REPO_NAME' from .claude/hooks/guarded-repos.txt to disable this guard."
+echo ""
+echo "=== END WORKTREE GUARD ==="
+exit 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.9.0] — Parallel-session hooks + skill-creator
+### Added
+- `.claude/hooks/worktree-guard.sh` — `PreToolUse` hook that blocks `Edit`/`Write` to a guarded repo's primary checkout when ≥2 Claude sessions are running. Allows worktrees. Emergency override via `.allow-shared-edit` at the repo root.
+- `.claude/hooks/branch-hygiene.sh` — `SessionStart` hook that surfaces non-default HEAD on guarded repos (last commit, uncommitted count, ahead/behind vs default). Stays quiet on freshly-created worktrees (clean tree + commit < 2 min old).
+- `.claude/hooks/guarded-repos.txt` — config file listing repo basenames the parallel-session guards apply to. Both hooks no-op until at least one repo is listed.
+- `skills/skill-creator/SKILL.md` — meta-skill that generates a new skill from a plain-language description: clarifies inputs/outputs, drafts the SKILL.md + command file + CLAUDE.md additions, runs a pre-ship checklist, asks before committing.
+- `commands/skill-creator.md` — `/skill-creator` slash command that loads the skill.
+### Changed
+- `.claude/hooks/README.md` — adds the parallel-session guards to the file table, adds an "enable" section, adds both new hooks to the `settings.local.json` example.
+- `README.md` — command table adds `/skill-creator`; file tree includes `skills/` and notes the parallel-session guards; new "Running multiple Claude sessions" section explains the hooks; "Skills work everywhere" promotes `/skill-creator` over manual scaffolding.
+- `CLAUDE.md` template — command table adds `/skill-creator`; "Parallel Sessions" section points at `.claude/hooks/guarded-repos.txt` and the two guard hooks.
+
+---
+
 ## [0.8.0] — Auto-memory + dream curator substrate
 ### Added
 - `docs/auto-memory.md` — spec for Claude Code's auto-memory: four typed entries (`user`, `feedback`, `project`, `reference`), what to save / NOT save, body structure with **Why:** + **How to apply:** lines, two-step write (detail file + index pointer), 100-line MEMORY.md cap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 | `/content-shipped` | Log a published piece of content |
 | `/dream` | Run an autonomous curator pass over the memory dir (default: rot detection) |
 | `/dream-apply` | Walk a curator proposal artifact, accept/reject/edit per item |
+| `/skill-creator` | Generate a new skill and command routing file from a plain-language description |
 
 Add more commands as you build out skills. See `docs/agent-template.md` for how.
 
@@ -61,6 +62,8 @@ When you add project-specific data (metrics, pipeline status, etc.), pick one fi
 ## Parallel Sessions
 
 When running parallel Claude Code sessions, use `claude --worktree <task-name>` so each gets its own branch. Merge to main when done. Run `/reconcile` after parallel work to catch drift.
+
+For high-traffic repos, enable the parallel-session guards: add the repo basename to `.claude/hooks/guarded-repos.txt` and `worktree-guard.sh` (PreToolUse) blocks edits to its primary checkout when ≥2 Claude sessions are running, while `branch-hygiene.sh` (SessionStart) surfaces non-default HEAD. See `.claude/hooks/README.md`.
 
 ## Claude Code vs claude.ai
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ claude
 | `/content-shipped` | After publishing | Logs a published piece to `content/log.md` |
 | `/dream` | Weekly-ish | Runs an autonomous curator pass over the memory dir (default: rot detection) |
 | `/dream-apply` | After `/dream` | Walks the proposal artifact, accept/reject/edit per item |
+| `/skill-creator` | Adding new skills | Generates the SKILL.md, command file, and CLAUDE.md additions from a plain-language description |
 
 ---
 
@@ -77,12 +78,13 @@ state/                            # Session state, priorities, decisions, blocke
 sessions/                         # Per-day session logs (created by /end)
 inbox/                            # Drop zone for raw notes (triaged by /capture)
 content/log.md                    # Published content log
-commands/                         # Slash command definitions (including /setup, /dream, /dream-apply)
+commands/                         # Slash command definitions (including /setup, /dream, /skill-creator)
+skills/                           # Cross-cutting / meta skills (e.g., skill-creator)
 scripts/                          # Setup, validation, repo map generation
 scripts/dream/                    # Curator prompts + how-to for the /dream substrate
 docs/                             # Architecture guides — auto-memory, dream, migration, safety
 references/                       # Integration setup (Google Workspace, Notion)
-.claude/hooks/                    # Session start + SSOT guard hooks
+.claude/hooks/                    # Session start + SSOT guard + parallel-session guards
 .github/                          # CI validation + PR template
 
 # Auto-memory lives outside the repo (per-machine, often confidential):
@@ -102,10 +104,8 @@ The `avoid-ai-writing` skill is included as a working example. In Claude Code: `
 
 To build your own:
 
-1. Read `docs/agent-template.md` for the scaffold
-2. Create `projects/your-project/skills/your-skill-name/SKILL.md`
-3. Add a command file in `commands/` and a row in `CLAUDE.md`
-4. Run `scripts/validate-skills.sh` to verify
+1. Run `/skill-creator` and describe what the skill should do — it generates the SKILL.md, the command file, and the CLAUDE.md additions for you to review.
+2. Or do it manually: read `docs/agent-template.md`, create `projects/<your-project>/skills/<your-skill-name>/SKILL.md`, add a command file in `commands/`, add a row to `CLAUDE.md`, then run `scripts/validate-skills.sh`.
 
 See `projects/README.md` for conventions and the example musician project for the full pattern.
 
@@ -129,6 +129,19 @@ Claude Code auto-loads `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md` at th
 Memory accumulates faster than humans review it. `/dream` runs an autonomous curator pass over the memory dir (default curator: **rot detection** — flags project memories that no longer match your state files or recent commits) and writes a reviewable proposal artifact. `/dream-apply` walks the artifact and applies accepted items, all under git on the memory dir so any pass is one `git revert` away.
 
 See [`docs/dream-architecture.md`](docs/dream-architecture.md) for the full design (curator catalog, proposal schema, scope guards).
+
+---
+
+## Running multiple Claude sessions
+
+Running more than one Claude Code session against the same repo simultaneously will eventually corrupt your tree — silent branch-switches, one session's `git add` landing in another session's commit, files committed to the wrong branch. The fix is `git worktree`: one checkout per session.
+
+The starter ships two hooks that enforce this pattern:
+
+- **`worktree-guard.sh`** (`PreToolUse`) — blocks `Edit`/`Write` to a guarded repo's primary checkout when ≥2 Claude sessions are running. Worktrees are still free. Emergency override: `touch .allow-shared-edit` at the repo root.
+- **`branch-hygiene.sh`** (`SessionStart`) — surfaces non-default HEAD on guarded repos so a silent branch-switch is noticed before any edits land.
+
+Both hooks no-op until you list a repo basename in `.claude/hooks/guarded-repos.txt`. See `.claude/hooks/README.md` for setup.
 
 ---
 

--- a/commands/skill-creator.md
+++ b/commands/skill-creator.md
@@ -1,0 +1,9 @@
+---
+name: skill-creator
+description: Generate a new skill and command routing file from a plain-language description.
+allowed-tools: Read, Bash, Write, Edit, Glob
+---
+
+# /skill-creator
+
+Load `docs/agent-template.md` and `skills/skill-creator/SKILL.md` and follow the skill-creator instructions.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: skill-creator
+description: Generate a new skill file and command routing file for this repo from a plain-language description of what the skill should do.
+---
+
+# skill-creator — Build New Skills Fast
+
+Takes a plain-language description of a task and generates a ready-to-ship skill: the SKILL.md, the command routing file, and the CLAUDE.md additions needed to wire it in.
+
+## When to Use
+
+- "I want a skill that does X"
+- "Build me a slash command for Y"
+- "Add a skill for [recurring task I do]"
+
+## Before You Start
+
+Read:
+
+- `docs/agent-template.md` — canonical file format and pre-ship checklist
+- `CLAUDE.md` — current routing, so the new skill doesn't duplicate an existing one
+- The most relevant existing skill in `writing/skills/` or `projects/*/skills/` — for style reference
+
+## Instructions
+
+### 1. Clarify the skill
+
+Ask (or infer from context):
+
+- **Name**: what should the slash command be called? (lowercase, hyphenated)
+- **Trigger**: when should this skill activate? What does the user say or ask?
+- **Input**: what does the skill need to work? (a link, a transcript, a filename, etc.)
+- **Output**: what does it produce? (a draft, a log entry, a summary, a file?)
+- **Tools needed**: Read, Write, Edit, Bash, Glob, WebFetch?
+
+### 2. Draft the SKILL.md
+
+Follow the template in `docs/agent-template.md` exactly. Include:
+
+- YAML frontmatter with `name` and `description` (60+ chars, specific enough that Claude can decide whether the skill is relevant from the description alone)
+- Clear "When to Use" section
+- Step-by-step instructions
+- Output format spec, if the skill produces something
+
+Place it at one of:
+
+- `writing/skills/<name>/SKILL.md` — writing/content skills
+- `projects/<project>/skills/<name>/SKILL.md` — project-scoped skills
+- `skills/<name>/SKILL.md` — general/meta skills (like this one)
+
+### 3. Draft the command routing file
+
+Short file in `commands/<name>.md` following the template in `docs/agent-template.md`. Frontmatter: `name`, `description`, `allowed-tools`. Body: one or two lines that load the SKILL.md.
+
+### 4. Draft the CLAUDE.md additions
+
+Two additions:
+
+1. A row in the slash command table: `| /<name> | <brief description> |`
+2. A routing rule in the appropriate section of "When to Load Additional Context" (if applicable)
+
+### 5. Pre-Ship Checklist
+
+Before presenting, verify the new skill satisfies all of these:
+
+- [ ] Frontmatter `description` is specific (60+ chars) — vague descriptions degrade routing
+- [ ] MCP calls (if any) have explicit limits — see `docs/mcp-efficiency.md`
+- [ ] Confirmation gate on any action that changes external state — see `docs/safety-contract.md`
+- [ ] Writing skills load `writing/skills/avoid-ai-writing/SKILL.md` when producing external content
+- [ ] Memory writes follow `docs/auto-memory.md` (typed entries, MEMORY.md cap)
+- [ ] Command stub created in `commands/`
+- [ ] CLAUDE.md slash command table updated
+- [ ] CHANGELOG.md entry added under `[Unreleased]`
+- [ ] Runs cleanly via `bash scripts/validate-skills.sh`
+
+### 6. Present for review
+
+Show all three artifacts in a single response. Ask: "Want me to commit these, or make any changes first?"
+
+### 7. On approval: commit and update CHANGELOG
+
+Create the files, run `bash scripts/validate-skills.sh`, then update CHANGELOG.md with a new entry listing all added files.
+
+## Output Format
+
+Present each file in a labeled fenced code block:
+
+````
+**skills/<name>/SKILL.md**
+```markdown
+[content]
+```
+
+**commands/<name>.md**
+```markdown
+[content]
+```
+
+**CLAUDE.md additions**
+```markdown
+[the two snippets to add]
+```
+````


### PR DESCRIPTION
## Summary

Closes the final two items from the gap audit that motivated 0.8.0: **parallel-session guard hooks** and a **`/skill-creator` meta-skill**. Both are patterns proven out in real daily use; this PR ports them to the starter in genericized form (no hardcoded repo names, no per-machine paths).

### 1. Parallel-session guards

Running >1 Claude Code session against the same repo eventually corrupts the tree — silent branch-switches, one session's `git add` landing in another's commit, files committed to the wrong branch. Worktrees are the only reliable fix; these hooks enforce that pattern.

- **`worktree-guard.sh`** (`PreToolUse`, `Edit`/`Write`) — when ≥2 Claude sessions are running, blocks edits to a guarded repo's primary checkout. Worktrees are still free to edit. Emergency override: `touch .allow-shared-edit` at the repo root. Walks up from the target file's path (not cwd), so a session in repo A can still edit files in repo B's worktree.
- **`branch-hygiene.sh`** (`SessionStart`) — surfaces non-default HEAD on guarded repos: branch, last commit, uncommitted count, ahead/behind vs default. Stays quiet on freshly-created worktrees (clean tree + commit < 2 min old). Resolves the default branch from `origin/HEAD`, falls back to `main`.
- **`guarded-repos.txt`** — config file listing repo basenames the guards apply to. Both hooks no-op until at least one repo is listed, so the starter ships safe-by-default. Comment out the example lines and add your own.

The original versions (which have been running in three repos for weeks) hardcoded the repo list and `/c/Users/conor` paths. The starter versions hardcode neither.

### 2. /skill-creator

A meta-skill that takes a plain-language description of a recurring task and produces a ready-to-ship skill: SKILL.md, command file, and the CLAUDE.md table/routing additions. Runs a pre-ship checklist (description specificity, MCP limits, safety gates, voice-skill chaining, CHANGELOG entry, validation script) and presents all artifacts in one response before asking to commit.

This is the highest-leverage addition for new starter users — the existing "read `docs/agent-template.md` and write three files by hand" path is the most common point where adopters bounce.

### Risk

Low.
- Markdown + bash. No existing code paths touched.
- Parallel-session guards are opt-in: both hooks return immediately unless a repo is explicitly listed in `guarded-repos.txt`. The shipped file only contains commented examples.
- The blocking hook (`worktree-guard.sh`) has an emergency override (`.allow-shared-edit`) for the rare case where you need to edit a shared file (e.g., `state/current.md`) without spinning up a worktree.

## Test plan

- [ ] `bash scripts/validate-skills.sh` passes (verified locally — "All checks passed")
- [ ] Hook scripts are executable (`chmod +x` applied)
- [ ] `worktree-guard.sh` no-ops when `guarded-repos.txt` is empty (default state) — verify by tailing stdout when running with `SESSION_COUNT=2`
- [ ] `branch-hygiene.sh` no-ops on `main` and on unlisted repos
- [ ] `.claude/hooks/README.md` example `settings.local.json` is valid JSON
- [ ] `/skill-creator` slash command frontmatter parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)