### PR TITLE
README: add Chain of Thought podcast backlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ This is a template — the most useful contributions are structural: better exam
 
 ## Used by
 
-- [Conor Bronsdon](https://github.com/conorbronsdon) — Modular, Chain of Thought podcast
+- [Conor Bronsdon](https://github.com/conorbronsdon) — Modular, [Chain of Thought podcast](https://chainofthought.show)
 
 Using this template? Open a PR adding yourself.
 


### PR DESCRIPTION
Adds a clickable `chainofthought.show` backlink to the README, matching the other skill/MCP repos. Turns directory listings (hermesatlas, ClawHub, MCP registries) into real backlinks. Part of the open-source distribution / GEO pass.