### PR TITLE
Add UTM tags to chainofthought.show and conorbronsdon.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ This is a template — the most useful contributions are structural: better exam
 
 ## Used by
 
-- [Conor Bronsdon](https://github.com/conorbronsdon) host of [Chain of Thought podcast](https://chainofthought.show)
+- [Conor Bronsdon](https://github.com/conorbronsdon) host of [Chain of Thought podcast](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=claude-context-os)
 
 Using this template? Open a PR adding yourself.
 


### PR DESCRIPTION
Part of the repo-wide sweep in conorbronsdon/cot-production#115.

Tags the 1 link(s) in this repo's markdown so referral traffic to the show and to conorbronsdon.com is attributable:

```
?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=claude-context-os
```

Untagged, every repo's About footer and Chain of Thought badge lands in GA4's **Direct** bucket, indistinguishable from every other repo. `utm_content` carries the repo name so this one reports as its own row.

Applied by `scripts/utm-tag-links.py` in cot-production; `--check` exits 0 on this branch. Link targets and anchor text are unchanged — only the query string is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)