### PR TITLE
dream: archiving must complete — stamp + move + link rewrite

### DIFF
--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 x-source: skills-sync/commands/dream-apply.md
-x-source-version: 10497e0
+x-source-version: 2d8b897
 ---
 
 # /dream-apply — review + apply a curator pass
@@ -67,7 +67,16 @@ b. Ask via `AskUserQuestion`:
 
 c. On `Accept`: apply the change.
    - For `modify` action: use Edit tool on `$MEMORY_DIR/{target}`, replacing `current_excerpt` with `proposed_excerpt`.
-   - For `archive` action: append a row to `$MEMORY_DIR/ARCHIVE.md` (`| {today} | {target} | {one-line reason} |`), then remove the corresponding line from `$MEMORY_DIR/MEMORY.md` index, then leave the file in place (don't delete the .md).
+   - For `archive` action, all five steps — an archive that stops early leaves the file reading as live:
+     1. **Check it isn't already archived.** `grep "^archived:" $MEMORY_DIR/{target}` and grep `$MEMORY_DIR/ARCHIVE.md` for the filename. If either hits, stop and report — re-archiving an already-retired file is the symptom of a previous archive skipping steps 3-4, not a new finding.
+     2. Append a row to `$MEMORY_DIR/ARCHIVE.md`: `| {today} | [{target}](archive/{target}) | {one-line reason} |`.
+     3. **Stamp the file**: insert `archived: {today}` as the last line of its frontmatter block. This is what stops a future session reading it as a live memory.
+     4. **Move it**: `git mv $MEMORY_DIR/{target} $MEMORY_DIR/archive/{target}`, then rewrite every inbound reference in the *live* set — `]({slug}.md)` → `](archive/{slug}.md)`, and `[[{slug}]]` → `[{slug}](archive/{slug}.md)` so wikilinks still resolve across the directory boundary. Grep the live files for the slug; don't assume the proposal enumerated them.
+     5. Remove the corresponding line from `$MEMORY_DIR/MEMORY.md` — **unless** the reference is a sub-link inside another entry's line, in which case just add the `archive/` prefix. An archived file cited as evidence for a still-live rule is a legitimate reference.
+
+     **Never `rm` an archived file.** It stays readable under `archive/` for on-demand recall; only `merge`/`split` remove files, and only because their content moved into a survivor.
+
+     ⚠️ **Before archiving, count how many live memories link to the target.** Heavy inbound linkage is evidence the file is still load-bearing — re-read its *current body* against the archive rationale before proceeding. A file archived on a premise that has since gone stale, while live memories still depend on it, is a worse outcome than one left live too long.
    - For `add` action (pattern curator): create new memory file with proposed content, add an index line to `$MEMORY_DIR/MEMORY.md`.
    - For `merge` action (structural):
      1. Write the survivor: if `survivor` matches an existing file in `targets`, Edit/overwrite it with `merged_body`; if it's a new name, Write `$MEMORY_DIR/{survivor}`.
@@ -76,7 +85,7 @@ c. On `Accept`: apply the change.
      4. Redirect dangling `[[wikilinks]]`: for any link the proposal flagged as pointing at an absorbed file, Edit it to point at the survivor. If the proposal didn't enumerate them, grep `$MEMORY_DIR` for the absorbed slugs and fix what you find.
    - For `split` action (structural):
      1. For each entry in `result_files`: Write `$MEMORY_DIR/{name}` with its `body`. If a child's `name` equals `target`, overwrite the original in place.
-     2. If `target` is **not** among the `result_files` names, `git rm` it (content redistributed; recoverable from history).
+     2. If `target` is **not** among the `result_files` names, `git rm` it (content redistributed; recoverable from history) **and append a tombstone row to `$MEMORY_DIR/ARCHIVE.md`** naming the children it split into. Never remove a memory file without a tombstone — a silent deletion is unrecoverable except by git archaeology, and any live file still linking the old slug is left pointing at nothing. Then grep the live set for the removed slug and repoint each hit at whichever child now carries that fact; if none does, de-link it but keep the sentence.
      3. Apply index changes to `$MEMORY_DIR/MEMORY.md`: remove `original_index_line`, add each child's `index_line`.
    - For `flag` action: write nothing — flags are just surfacing.
 

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
 allowed-tools: Read, Bash, Write, Glob, Grep
 x-source: skills-sync/commands/dream.md
-x-source-version: 10497e0
+x-source-version: 2d8b897
 ---
 
 # /dream — autonomous memory curator pass

--- a/docs/dream-architecture.md
+++ b/docs/dream-architecture.md
@@ -78,8 +78,10 @@ Three load-bearing benefits once a curator runs autonomously:
 ~/.claude/projects/<encoded-cwd>/memory/
 ├── .git/                   ← local-only repo
 ├── MEMORY.md               ← index (cap 100 lines)
-├── ARCHIVE.md              ← pruned/superseded entries
-├── {topic}.md              ← detail files
+├── ARCHIVE.md              ← tombstone rows, one per retired file
+├── {topic}.md              ← LIVE detail files only
+├── archive/                ← retired files, moved here on archive
+│   └── {topic}.md          ← each stamped `archived: YYYY-MM-DD` in frontmatter
 └── .dreams/                ← curator artifacts
     └── {ISO-timestamp}/
         ├── REPORT.md       ← human review surface
@@ -166,7 +168,13 @@ The curator never auto-applies, so automating the *propose* step is safe; apply 
 
 ## Backup & recovery
 
-Two distinct failure modes; only one needs new infra.
+Three distinct failure modes; only one needs new infra.
+
+0. **Failure to forget** (the inverse of the two below) — an `archive` that writes the tombstone row and stops. The file stays in the memory root, unstamped and unchanged, so every later session reads it as a live memory. Git backups do not help, because nothing was lost: the corpus is quietly asserting stale things as current. The tell is a curator proposing to archive something that was archived weeks ago — it has no way to see the earlier row.
+
+   Fix it structurally, not by discipline: archiving is stamp + move to `archive/` + inbound-link rewrite, and the apply step refuses to re-archive a file already carrying an `archived:` stamp. The refusal *is* the tripwire.
+
+   Same root cause, adjacent gap: a `split` that removes its target without writing a tombstone deletes a memory silently, and leaves any live file that linked the old slug pointing at nothing.
 
 1. **Mistaken forgetting** (a bad `merge`/`split`/`archive` drops a fact) — **already covered by memory git.** Every `/dream-apply` commits before it changes anything, and structural ops use `git rm` (not destructive deletion), so absorbed/split-away content stays in history. Recovery is `git revert HEAD` or `git show HEAD~N:<file>`.
 2. **Machine loss** — local git can't help; you need an off-machine copy. Keep the no-remote rule (memory may hold confidential context) and use a `git bundle` instead of a hosted remote: `git bundle create memory-<date>.bundle --all` produces one restorable file (`git clone <bundle> memory`) you copy to private storage. Cadence: periodic, or after a large `/dream-apply`.

--- a/scripts/dream/prompts/rot.md
+++ b/scripts/dream/prompts/rot.md
@@ -31,7 +31,7 @@ For each `memory/project_*.md` and `memory/reference_*.md` (skip `env_`, `feedba
 
 3. Classify each finding:
    - **`modify`** — assertion is wrong; rewrite to current truth. Required: cite specific evidence line(s).
-   - **`archive`** — entire memory is now historical (project complete, decision moot). Required: confirm via 2+ evidence sources.
+   - **`archive`** — entire memory is now historical (project complete, decision moot). Required: confirm via 2+ evidence sources, **and count how many live memories link to it**. Heavy inbound linkage is evidence the file is still load-bearing — when you find it, re-read the target's *current body* against the archive rationale before proposing. A file archived on a stale premise while live memories still depend on it is worse than one left live too long.
    - **`flag`** — rot suspected but evidence ambiguous; surface to the user for decision. Required: explain what's ambiguous.
 
 4. **Do NOT propose anything you can't cite evidence for.** Empty-evidence proposals get rejected at apply time.


### PR DESCRIPTION
Published from skills-sync @ `2d8b897`. Fan-out of a fix found and applied downstream today.

## The bug

The `archive` action wrote a tombstone row to `ARCHIVE.md` and stopped — "leave the file in place" was documented as the convention. The retired file stayed in the memory root, unstamped and unchanged, so every later session read it as a live memory.

It is a quiet failure. Nothing is lost, so git backups do not help; the corpus simply keeps asserting stale things as current. Downstream this had accumulated to **54 files**, and a session re-archived 17 of them because it had no way to tell they were already retired.

## The fix

`archive` is now five steps, guard first:

1. **Refuse if already stamped** — and treat that refusal as the tripwire. A re-archive attempt means an earlier archive stopped early.
2. Write the tombstone row.
3. Stamp `archived: <date>` into frontmatter.
4. `git mv` to `archive/` and rewrite inbound links; wikilinks become explicit paths so they resolve across the directory boundary.
5. Fix the index — but keep sub-links where an archived file is cited as evidence for a still-live rule.

Two adjacent gaps from the same root cause:

- **`split` may no longer remove a file without a tombstone.** A silent deletion is unrecoverable except by git archaeology and leaves live files pointing at nothing.
- **`rot` must count inbound links before proposing an archive.** Heavy linkage is evidence the file is still load-bearing. This check is what caught a file archived on a premise that had since gone stale while two live memories still depended on it.

## Docs

`dream-architecture.md` gains the storage layout (`archive/` + stamps) and a third failure mode. The existing two both describe *losing* information, which git covers. This one is the inverse — failure **to** forget — and no backup can catch it.