### PR TITLE
dream: fix the archive procedure, which could not execute as published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- `commands/dream-apply.md` — the five-step archive procedure could not execute. `git mv` does not create its destination, and `$MEMORY_DIR` is its own git repo, so the move now runs `mkdir -p` then `git -C "$MEMORY_DIR" mv`. Without both it exits 128 *after* the tombstone row and stamp are written, producing the half-finished archive the procedure exists to prevent.
+- `commands/dream-apply.md` — the already-archived guard grepped `ARCHIVE.md` for a bare filename, which false-positives on merge survivors and split children (their slugs appear in their own tombstones while the files stay live), and grepped the root path for `^archived:`, which cannot match a correctly-archived file because it has moved.
+- `commands/dream-apply.md` — the moved file's own outbound links were never repointed, so every archived file's references silently broke on the move.
+
+### Changed
+- `docs/auto-memory.md`, `docs/memory-template.md` — storage layout and retirement steps updated for `archive/`; these are not in the fanout manifest and were missed by the previous publish.
+- `scripts/dream/prompts/{rot,merge,split}.md`, `docs/dream-architecture.md` — curator inputs now exclude `memory/archive/`.
 ### Added
 - `docs/assets/start-demo.gif` — animated `/start` demo embedded at the top of the README's "See it work" section. Representative VHS rendering of a `/start` session against the included example musician project (sample data): the state files load in the order `commands/start.md` specifies, then the session briefing comes back.
 - `scripts/check-links.sh` — deterministic broken-link checker. Walks every inline link in tracked markdown, skips fenced/inline code and external URLs, and fails on any local target that doesn't resolve. Pure bash + awk + git; catches SSOT drift when a cross-referenced file is renamed or moved. Wired into `.github/workflows/validate.yml`.

--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 x-source: skills-sync/commands/dream-apply.md
-x-source-version: 2d8b897
+x-source-version: 9b7b0a7
 ---
 
 # /dream-apply — review + apply a curator pass
@@ -68,10 +68,22 @@ b. Ask via `AskUserQuestion`:
 c. On `Accept`: apply the change.
    - For `modify` action: use Edit tool on `$MEMORY_DIR/{target}`, replacing `current_excerpt` with `proposed_excerpt`.
    - For `archive` action, all five steps — an archive that stops early leaves the file reading as live:
-     1. **Check it isn't already archived.** `grep "^archived:" $MEMORY_DIR/{target}` and grep `$MEMORY_DIR/ARCHIVE.md` for the filename. If either hits, stop and report — re-archiving an already-retired file is the symptom of a previous archive skipping steps 3-4, not a new finding.
+     1. **Check it isn't already archived.** `test -f "$MEMORY_DIR/archive/{target}"`, and `grep -F "](archive/{target})" "$MEMORY_DIR/ARCHIVE.md"`. A hit on either means it is already retired — stop and report.
+        **Do not grep `ARCHIVE.md` for the bare filename.** Merge tombstones name the *surviving* file and split tombstones name the *children*; those files are live, so a bare-name grep refuses legitimate archives.
+        Separately, if `$MEMORY_DIR/{target}` still exists **and** already carries an `^archived:` stamp, that is a half-finished archive from a crashed earlier run — finish steps 4-5 rather than starting over, and do not write a second tombstone row.
      2. Append a row to `$MEMORY_DIR/ARCHIVE.md`: `| {today} | [{target}](archive/{target}) | {one-line reason} |`.
      3. **Stamp the file**: insert `archived: {today}` as the last line of its frontmatter block. This is what stops a future session reading it as a live memory.
-     4. **Move it**: `git mv $MEMORY_DIR/{target} $MEMORY_DIR/archive/{target}`, then rewrite every inbound reference in the *live* set — `]({slug}.md)` → `](archive/{slug}.md)`, and `[[{slug}]]` → `[{slug}](archive/{slug}.md)` so wikilinks still resolve across the directory boundary. Grep the live files for the slug; don't assume the proposal enumerated them.
+     4. **Move it.** `git mv` does **not** create the destination, and `$MEMORY_DIR` is its own git repo — so run both, from inside it:
+        ```sh
+        mkdir -p "$MEMORY_DIR/archive"
+        git -C "$MEMORY_DIR" mv "{target}" "archive/{target}"
+        ```
+        Skipping either is how this step dies at exit 128 *after* steps 2-3 have already written the row and the stamp — producing the exact half-finished state this procedure exists to prevent.
+
+        Then fix links in three directions, where `{slug}` is `{target}` without its `.md`:
+        - **Inbound, live files except the index**: `]({slug}.md)` → `](archive/{slug}.md)`, and `[[{slug}]]` → `[{slug}](archive/{slug}.md)` so wikilinks resolve across the directory boundary. Grep for the slug; don't assume the proposal enumerated them. **Exclude `MEMORY.md`** — step 5 owns that line, and rewriting it here breaks step 5's excerpt match.
+        - **Outbound, inside the moved file**: its own relative links now resolve one level too deep. `](x.md)` → `](../x.md)` for targets still live; `](archive/x.md)` → `](x.md)` for targets already retired.
+        - Leave unresolved `[[links]]` that point at nothing — those are deliberate placeholders, not errors.
      5. Remove the corresponding line from `$MEMORY_DIR/MEMORY.md` — **unless** the reference is a sub-link inside another entry's line, in which case just add the `archive/` prefix. An archived file cited as evidence for a still-live rule is a legitimate reference.
 
      **Never `rm` an archived file.** It stays readable under `archive/` for on-demand recall; only `merge`/`split` remove files, and only because their content moved into a survivor.

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
 allowed-tools: Read, Bash, Write, Glob, Grep
 x-source: skills-sync/commands/dream.md
-x-source-version: 2d8b897
+x-source-version: 9b7b0a7
 ---
 
 # /dream — autonomous memory curator pass

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -9,7 +9,8 @@ This doc is the spec. Add it to your global `~/.claude/CLAUDE.md` (so every Clau
 ```
 ~/.claude/projects/<encoded-cwd>/memory/
 ├── MEMORY.md           ← index, loaded into every conversation (cap 100 lines)
-├── ARCHIVE.md          ← pruned / superseded entries
+├── ARCHIVE.md          ← tombstone rows, one per retired memory
+├── archive/            ← the retired files themselves, each stamped `archived: YYYY-MM-DD`
 └── <topic>.md          ← one detail file per memory, loaded on demand
 ```
 
@@ -104,7 +105,9 @@ Memories can become stale. Before acting on a memory that names a specific file,
 
 ## Memory budget
 
-`MEMORY.md` loads on every conversation. Cap it at ~100 lines. When approaching the cap, consolidate or move detail files to `ARCHIVE.md`. Detail files are exempt from the cap — they load on demand.
+`MEMORY.md` loads on every conversation. Cap it at ~100 lines. When approaching the cap, consolidate, or retire a memory: write a tombstone row in `ARCHIVE.md`, stamp `archived: <date>` into the file's frontmatter, and move the file to `archive/`. Detail files are exempt from the cap — they load on demand.
+
+An `ARCHIVE.md` row is not on its own an archive. A row without the stamp and the move leaves the file in the memory root, where every later session reads it as live.
 
 ## Curation: /dream
 

--- a/docs/dream-architecture.md
+++ b/docs/dream-architecture.md
@@ -120,7 +120,7 @@ Curators fall into two **classes**:
 
 **Questions:** merge — *"Do 2+ memories cover the same thing and always get recalled together?"* split — *"Has one file accreted 2+ unrelated concerns?"*
 
-**Inputs:** `memory/*.md` (all detail files) + `memory/MEMORY.md` (index) + `memory/ARCHIVE.md`. No state/session inputs.
+**Inputs:** `memory/*.md` (live detail files only — `memory/archive/**` is excluded) + `memory/MEMORY.md` (index) + `memory/ARCHIVE.md`. No state/session inputs.
 
 **Output actions:** `merge` (consolidate `targets` → `survivor`, write ARCHIVE tombstones, collapse index lines), `split` (divide `target` → `result_files`, expand index lines), `flag` (boundary is a judgment call).
 

--- a/docs/memory-template.md
+++ b/docs/memory-template.md
@@ -49,7 +49,7 @@ See `docs/auto-memory.md` for the full spec (what to save, what NOT to save, bod
 - **One detail file per memory.** Frontmatter: `name`, `description`, `type`.
 - **MEMORY.md is index-only.** One line per entry, under ~150 chars. No frontmatter on this file.
 - **Organize by type, then topic.** Not chronologically.
-- **Cap at ~100 lines.** When approaching, consolidate or move to `ARCHIVE.md`.
+- **Cap at ~100 lines.** When approaching, consolidate, or retire: tombstone row in `ARCHIVE.md` + `archived: <date>` stamp in the file + move it to `archive/`. All three, or the file keeps loading as live.
 
 ## First-time setup
 

--- a/scripts/dream/prompts/merge.md
+++ b/scripts/dream/prompts/merge.md
@@ -8,9 +8,9 @@ This is the inverse of the `split` curator, and it is also the main pressure-rel
 
 ## Inputs you'll be given
 
-- All files in `memory/` (the detail files under audit)
+- All files in `memory/` (the detail files under audit) — live files only, skip `memory/archive/**`
 - `memory/MEMORY.md` (the index — one line per memory; cap 100 lines)
-- `memory/ARCHIVE.md` (where superseded entries go — do NOT merge into a live file; check here to avoid re-merging something already retired)
+- `memory/ARCHIVE.md` (tombstone rows; the retired files themselves live in `memory/archive/` — do NOT merge into a live file; check here to avoid re-merging something already retired)
 
 You may NOT modify any of these. You produce a proposal artifact only.
 

--- a/scripts/dream/prompts/rot.md
+++ b/scripts/dream/prompts/rot.md
@@ -8,7 +8,7 @@
 
 You'll have access to:
 
-- All files in `memory/` (the memories under audit)
+- All files in `memory/` (the memories under audit) — **skip `memory/archive/`**, those are retired by design and are not rot
 - `state/decisions.md` (append-only history of decisions — strong evidence for "this happened")
 - `state/blockers.md` (current blockers + recently-unblocked — strong evidence for "this resolved")
 - `state/current.md` (active priorities, last-updated entries — moderate evidence)

--- a/scripts/dream/prompts/split.md
+++ b/scripts/dream/prompts/split.md
@@ -10,7 +10,7 @@ This is the inverse of the `merge` curator. Do not propose a split that `merge` 
 
 - All files in `memory/` (the detail files under audit)
 - `memory/MEMORY.md` (the index — one line per memory; cap 100 lines)
-- `memory/ARCHIVE.md` (pruned/superseded entries — context only, do not split)
+- `memory/ARCHIVE.md` (tombstone rows — context only, do not split; retired files live in `memory/archive/` and are never split candidates)
 
 You may NOT modify any of these. You produce a proposal artifact only.
 


### PR DESCRIPTION
Follow-up to #9. Adversarial review after merge found the five-step archive **inert as written** — and failing in the precise way it exists to prevent.

## P0-1 — `git mv` hard-fails on the first archive

```
$ git mv a.md archive/a.md
fatal: renaming 'a.md' failed: No such file or directory
EXIT=128
```

`git mv` does not create its destination, and `$MEMORY_DIR` is its own git repo, so the command must run inside it. Nothing created `archive/`.

The failure mode is the bug: steps 2-3 have already written the tombstone row and stamped the file, so step 4 dying leaves a row written, a file stamped, and the file still in the memory root — a **new** half-finished archive. Step 1's guard then refuses every attempt to finish it. Now `mkdir -p` + `git -C "$MEMORY_DIR" mv`.

## P0-2 — the guard was wrong in both halves

- Grepping `ARCHIVE.md` for a **bare filename** false-positives on merge survivors and split children: their slugs are written into their own tombstones while the files stay live. A later legitimate archive of one would be refused, and the refusal reported as a data-integrity incident.
- Grepping the **root path** for `^archived:` cannot match a correctly-archived file, because it has moved to `archive/`.

Now: `test -f archive/{target}` plus a grep anchored on `](archive/{target})`, with a separate branch for the genuine crashed-run case that resumes rather than restarting.

## P1 — outbound links broke on the move

Only inbound references were rewritten. The moved file's own `](x.md)` links resolve one level too deep afterwards, silently rotting every archived file's references — which defeats keeping them readable at all. Now fixed in three directions, with `MEMORY.md` excluded from the inbound sweep so step 5's excerpt match still works.

## The convention was half-applied

`docs/auto-memory.md` calls itself the spec and still described `ARCHIVE.md` as a content store with no `archive/` directory; `docs/memory-template.md` the same. **Neither is in the `dream` fanout manifest** — they don't exist in the core — so the first publish structurally could not reach them. Worth deciding whether they move into the core or onto a manual checklist, or this recurs.

Also: curator input lists now exclude `memory/archive/`. The globs are non-recursive so it worked by accident, but any agent reaching for `Glob **/*.md` would pull retired memories back into the live corpus.

CHANGELOG entry added, per `docs/repo-maintenance.md`.

## Note

I wrote the original procedure from recollection of what I had done rather than from the commands I actually ran. `mkdir -p` and `git -C` were the two steps I performed and failed to write down.