### PR TITLE
dream: setup block must create archive/ before the first retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- `scripts/dream/README.md` — first-time setup created `$MEMORY_DIR` but not `archive/`, so anyone following it by hand hit the same exit-128 the apply step was fixed for, after the tombstone row and stamp were already written.
 - `commands/dream-apply.md` — the five-step archive procedure could not execute. `git mv` does not create its destination, and `$MEMORY_DIR` is its own git repo, so the move now runs `mkdir -p` then `git -C "$MEMORY_DIR" mv`. Without both it exits 128 *after* the tombstone row and stamp are written, producing the half-finished archive the procedure exists to prevent.
 - `commands/dream-apply.md` — the already-archived guard grepped `ARCHIVE.md` for a bare filename, which false-positives on merge survivors and split children (their slugs appear in their own tombstones while the files stay live), and grepped the root path for `^archived:`, which cannot match a correctly-archived file because it has moved.
 - `commands/dream-apply.md` — the moved file's own outbound links were never repointed, so every archived file's references silently broke on the move.

--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 x-source: skills-sync/commands/dream-apply.md
-x-source-version: 9b7b0a7
+x-source-version: 60ba3e0
 ---
 
 # /dream-apply — review + apply a curator pass

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
 allowed-tools: Read, Bash, Write, Glob, Grep
 x-source: skills-sync/commands/dream.md
-x-source-version: 9b7b0a7
+x-source-version: 60ba3e0
 ---
 
 # /dream — autonomous memory curator pass

--- a/scripts/dream/README.md
+++ b/scripts/dream/README.md
@@ -29,12 +29,18 @@ The memory dir is created automatically by Claude Code, but the git repo on it i
 ```bash
 PROJECT_KEY=$(pwd | sed 's|[:\\/]|-|g')
 MEMORY_DIR="$HOME/.claude/projects/$PROJECT_KEY/memory"
-mkdir -p "$MEMORY_DIR"
+mkdir -p "$MEMORY_DIR/archive"        # retired memories move here
 cd "$MEMORY_DIR"
+touch archive/.gitkeep                # git does not track empty dirs
 git init
 git add -A
 git commit -m "initial memory snapshot"
 ```
+
+`archive/` has to exist before the first retirement: `git mv x.md archive/x.md`
+does **not** create it, and fails at exit 128 *after* the tombstone row and the
+`archived:` stamp are already written — leaving the half-finished state the
+archive procedure exists to prevent.
 
 No remote. The memory dir often contains personal or confidential context.
 


### PR DESCRIPTION
Follow-up to #10, from the same review.

#10 fixed the *apply* step to `mkdir -p` before `git mv`. But `scripts/dream/README.md`'s first-time setup still created only `$MEMORY_DIR` and git-init'd it — so a user following the documented setup by hand lands in exactly the failure #10 repaired: `git mv x.md archive/x.md` exits 128, *after* the tombstone row and the `archived:` stamp are already written.

Fixing the procedure and leaving the setup that feeds it is a half-fix.

Also documents what `x-source-version` means — the SHA of the publish run, not of the last change to that file. Every stamped file in a run gets the same SHA, so an unchanged file's stamp still moves, and files without frontmatter carry no stamp at all. Worth stating, since a bumped stamp on an unchanged file reads as a claim that it changed.

CHANGELOG entry included.