### PR TITLE
Fix the secret scan, which could never fire

### DIFF
--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -75,8 +75,19 @@ fi
 
 SECRET_PATTERNS='(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{48}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[a-zA-Z0-9-]+|-----BEGIN (RSA |EC )?PRIVATE KEY)'
 
+# -E only. `grep -qEP` is not "both engines" — it is a usage error: grep rejects
+# it with "conflicting matchers specified" and exits 2. Exit 2 is not 0, so the
+# `if` never fired, and `2>/dev/null` hid the message. This check reported clean
+# on every file since it was written, including files that did contain a key.
+# Demonstrated 2026-08-03 by planting a fake AWS-style access key in a tracked
+# file: the script printed "All checks passed". (No sample literal is written
+# here on purpose — a real one in this comment makes the file flag itself.)
+#
+# -P alone is not the fix either. Git Bash on Windows builds grep without PCRE,
+# so `grep -qP` also exits 2 there and would reintroduce the same silent pass on
+# the machine this repo is maintained from. -E covers every pattern above.
 while IFS= read -r tracked_file; do
-  if grep -qEP "$SECRET_PATTERNS" "$tracked_file" 2>/dev/null; then
+  if grep -qE "$SECRET_PATTERNS" "$tracked_file" 2>/dev/null; then
     ERRORS+=("POSSIBLE SECRET in $tracked_file — review before pushing")
   fi
 done < <(git ls-files 2>/dev/null)


### PR DESCRIPTION
Check 5 in `scripts/validate-skills.sh` used `grep -qEP`. That is not "both engines" — grep rejects it as a usage error:

```
$ grep -qEP 'AKIA[0-9A-Z]{16}' file-containing-a-key
grep: conflicting matchers specified
$ echo $?
2
```

Exit 2 is not 0, so the `if` never fired, and `2>/dev/null` hid the message. **The check has reported clean on every file since it was written.**

Proven end to end against `origin/main` before the fix — planted a fake AWS-style access key in a tracked file:

```
All checks passed
```

This is a public repo, so "CI passes" has not been evidence of no-secrets in it.

## `-P` alone is not the fix

Git Bash on Windows builds grep without PCRE, so `grep -qP` also exits 2 there and would reintroduce the same silent pass on the machine this repo is maintained from. Measured on that box:

| invocation | file with a key | file without |
|---|---|---|
| `grep -qEP` | exit 2 (usage error) | exit 2 |
| `grep -qP` | exit 2 (no PCRE) | exit 2 |
| **`grep -qE`** | **exit 0 (match)** | **exit 1 (no match)** |

`-E` covers every pattern in `SECRET_PATTERNS` — none of them use PCRE-only syntax.

## Verification — both controls

A check that has never fired cannot be trusted just because it passes, so this was tested in both directions:

```
clean tree                 -> All checks passed, exit 0
planted AWS-style key      -> POSSIBLE SECRET in secret-probe.md, exit 1
planted PRIVATE KEY block  -> POSSIBLE SECRET in k.md
```

The must-not-fire control earned its place immediately: the first version of the explanatory comment quoted a real sample key, which made `validate-skills.sh` match its own pattern and fail the clean tree. No sample literal is written in the comment now, and there's a note saying why.

## Note

`conorbronsdon/personal-context` hit and fixed this identical bug; its Check 6 carries the same reasoning in a comment. This brings the two scripts back in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)