### PR TITLE
Fan-out: capture + dream from core @ 40f7149 (fixes live -mtime bug)

### DIFF
--- a/commands/capture.md
+++ b/commands/capture.md
@@ -3,7 +3,7 @@ name: capture
 description: Triage raw notes from inbox/ into the correct repo locations. Use when you drop unstructured content and need it routed.
 allowed-tools: Read, Write, Edit, Glob, Bash
 x-source: skills-sync/commands/capture.md
-x-source-version: 173c978
+x-source-version: 40f7149
 ---
 
 # /capture — Triage Inbox
@@ -26,6 +26,7 @@ For each item, determine its type and destination:
 | Priority change | `state/current.md` | Update priorities |
 | Writing idea or draft | project skill dir, or keep in `inbox/` | Move if ready, keep if raw |
 | Reference link or note | relevant context file | Append to the appropriate section |
+| ⚠️ Secret (password, PIN, seed phrase, recovery code, API key) | **NEVER commit to the repo** | Flag it for the user's password manager; quarantine outside git |
 | Unknown / multi-category | ask the user | Don't guess — present 1–2 options |
 
 ### 3. Present the triage plan (don't act yet)
@@ -64,3 +65,5 @@ inbox/ is clean.
 - **Bias toward existing files.** Append to `TODO.md`, `state/decisions.md`, etc. rather than creating new files when the content fits.
 - **Ask when unsure.** If an item could go several places, ask. One wrong routing is worse than a five-second question.
 - **No orphans.** Everything gets routed or explicitly deferred — nothing stays in `inbox/` after a run.
+- **Never commit secrets.** Passwords, PINs, seed phrases, recovery codes, and API keys never go into the repo. Flag them for the password manager and quarantine outside git.
+- **Delete-bias for one-off notes.** Many captured notes (bookmarks, dead ideas, one-off to-dos) are better deleted than filed. Ask "what happens if this is lost?" before creating a home for it.

--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 x-source: skills-sync/commands/dream-apply.md
-x-source-version: 60ba3e0
+x-source-version: 40f7149
 ---
 
 # /dream-apply — review + apply a curator pass

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
 allowed-tools: Read, Bash, Write, Glob, Grep
 x-source: skills-sync/commands/dream.md
-x-source-version: 60ba3e0
+x-source-version: 40f7149
 ---
 
 # /dream — autonomous memory curator pass
@@ -53,7 +53,12 @@ Read the **"Inputs you'll be given"** section of the loaded curator prompt and g
 
 - `ls $MEMORY_DIR/*.md` and read each `project_*.md` / `reference_*.md` (skip `env_`, `feedback_`, `user_` unless the curator asks)
 - Read `state/decisions.md`, `state/blockers.md`, `state/current.md`
-- `find sessions/ -name "*.md" -mtime -14` and read each
+- Select session logs **by filename date, never by mtime**, and read each:
+  ```
+  CUT=$(date -u -d '14 days ago' +%F 2>/dev/null || date -u -v-14d +%F)
+  ls sessions/*.md | sed 's|.*/||' | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' | sort | awk -v c="$CUT.md" '$0 >= c'
+  ```
+  **Why not `find -mtime -14`:** any git history rewrite resets mtime on every tracked file, after which `-mtime -14` matches the whole directory and silently blows up the input set. Session filenames are `YYYY-MM-DD.md` and sort lexically, so the date compare above stays exact through any rewrite.
 - `git log --since="14 days ago" --oneline` for the current repo
 
 **Structural curators** (`merge`, `split`) — examine the *shape of the memory set itself*; NO state/session inputs:
@@ -121,4 +126,5 @@ Review and apply: /dream-apply {ISO}
 
 - Curator MUST NOT modify any input file. Read-only on `memory/`, `state/`, `sessions/`.
 - Curator MUST NOT push the memory git repo to any remote. Local-only by design.
+- Curator outputs MUST NOT carry content the consuming repo's scope rules exclude (work-domain identifiers, internal project names, other repos' state). Session logs may contain residue that upstream filters missed — exclude it from proposals rather than propagating it into memory.
 - If `$ARGUMENTS` names a curator that hasn't been built yet, refuse politely and list what is available.


### PR DESCRIPTION
Publishes the two remaining queued fan-outs from the skills-sync core @ `40f7149` (post personal-context#183 fan-in batch), via `fanout-publish.sh` with all guards green (leak scan clean, public-in guard clear, x-source stamped).

- **`commands/capture.md`** — picks up the #14 ingest, including the secret-handling quarantine row.
- **`commands/dream.md` / `dream-apply.md`** — fixes a live bug: main still taught `find -mtime -14` session-log selection, which the core deprecated because a git history rewrite resets mtime on every tracked file and silently blows up the input set. Now selects by filename date, with the rationale inline. Also picks up the scope-guard bullet.

Verification: bodies are byte-identical to core modulo the provenance stamp (`diff` clean with `x-source` lines excluded); all three stamped files read `x-source-version: 40f7149`. The publish run flagged the usual hand-maintained parallel copies (ctxos docs/auto-memory.md + memory-template.md, amk set) — untouched by design; the amk `dream.md` `-mtime` copy is tracked separately.

After merge, the drift detector's fan-out queue drops 5 → 3 (only the agent-skills three remain, which are blocked on the SSOT-direction ruling in personal-context#183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
