### PR TITLE
Fan-out: dream @ 8ede26c — delivers the lint curator (skills-sync#9/#17)

### DIFF
--- a/commands/capture.md
+++ b/commands/capture.md
@@ -3,7 +3,7 @@ name: capture
 description: Triage raw notes from inbox/ into the correct repo locations. Use when you drop unstructured content and need it routed.
 allowed-tools: Read, Write, Edit, Glob, Bash
 x-source: skills-sync/commands/capture.md
-x-source-version: 173c978
+x-source-version: 40f7149
 ---
 
 # /capture — Triage Inbox
@@ -26,6 +26,7 @@ For each item, determine its type and destination:
 | Priority change | `state/current.md` | Update priorities |
 | Writing idea or draft | project skill dir, or keep in `inbox/` | Move if ready, keep if raw |
 | Reference link or note | relevant context file | Append to the appropriate section |
+| ⚠️ Secret (password, PIN, seed phrase, recovery code, API key) | **NEVER commit to the repo** | Flag it for the user's password manager; quarantine outside git |
 | Unknown / multi-category | ask the user | Don't guess — present 1–2 options |
 
 ### 3. Present the triage plan (don't act yet)
@@ -64,3 +65,5 @@ inbox/ is clean.
 - **Bias toward existing files.** Append to `TODO.md`, `state/decisions.md`, etc. rather than creating new files when the content fits.
 - **Ask when unsure.** If an item could go several places, ask. One wrong routing is worse than a five-second question.
 - **No orphans.** Everything gets routed or explicitly deferred — nothing stays in `inbox/` after a run.
+- **Never commit secrets.** Passwords, PINs, seed phrases, recovery codes, and API keys never go into the repo. Flag them for the password manager and quarantine outside git.
+- **Delete-bias for one-off notes.** Many captured notes (bookmarks, dead ideas, one-off to-dos) are better deleted than filed. Ask "what happens if this is lost?" before creating a home for it.

--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 x-source: skills-sync/commands/dream-apply.md
-x-source-version: 60ba3e0
+x-source-version: 40f7149
 ---
 
 # /dream-apply — review + apply a curator pass

--- a/commands/dream-apply.md
+++ b/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: Walk a dream proposal artifact, review each item, apply accepted ones to memory and commit.
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 x-source: skills-sync/commands/dream-apply.md
-x-source-version: 40f7149
+x-source-version: 8ede26c
 ---
 
 # /dream-apply — review + apply a curator pass

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
 allowed-tools: Read, Bash, Write, Glob, Grep
 x-source: skills-sync/commands/dream.md
-x-source-version: 60ba3e0
+x-source-version: 40f7149
 ---
 
 # /dream — autonomous memory curator pass
@@ -53,7 +53,12 @@ Read the **"Inputs you'll be given"** section of the loaded curator prompt and g
 
 - `ls $MEMORY_DIR/*.md` and read each `project_*.md` / `reference_*.md` (skip `env_`, `feedback_`, `user_` unless the curator asks)
 - Read `state/decisions.md`, `state/blockers.md`, `state/current.md`
-- `find sessions/ -name "*.md" -mtime -14` and read each
+- Select session logs **by filename date, never by mtime**, and read each:
+  ```
+  CUT=$(date -u -d '14 days ago' +%F 2>/dev/null || date -u -v-14d +%F)
+  ls sessions/*.md | sed 's|.*/||' | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}\.md$' | sort | awk -v c="$CUT.md" '$0 >= c'
+  ```
+  **Why not `find -mtime -14`:** any git history rewrite resets mtime on every tracked file, after which `-mtime -14` matches the whole directory and silently blows up the input set. Session filenames are `YYYY-MM-DD.md` and sort lexically, so the date compare above stays exact through any rewrite.
 - `git log --since="14 days ago" --oneline` for the current repo
 
 **Structural curators** (`merge`, `split`) — examine the *shape of the memory set itself*; NO state/session inputs:
@@ -121,4 +126,5 @@ Review and apply: /dream-apply {ISO}
 
 - Curator MUST NOT modify any input file. Read-only on `memory/`, `state/`, `sessions/`.
 - Curator MUST NOT push the memory git repo to any remote. Local-only by design.
+- Curator outputs MUST NOT carry content the consuming repo's scope rules exclude (work-domain identifiers, internal project names, other repos' state). Session logs may contain residue that upstream filters missed — exclude it from proposals rather than propagating it into memory.
 - If `$ARGUMENTS` names a curator that hasn't been built yet, refuse politely and list what is available.

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: Run a curator pass against the memory dir. Produces a proposal artifact for /dream-apply. Default curator: rot.
 allowed-tools: Read, Bash, Write, Glob, Grep
 x-source: skills-sync/commands/dream.md
-x-source-version: 40f7149
+x-source-version: 8ede26c
 ---
 
 # /dream — autonomous memory curator pass
@@ -17,10 +17,11 @@ Substrate background: `docs/dream-architecture.md`. Curator prompts: `scripts/dr
 /dream rot         # content class: memory vs. world — "is it still true?"
 /dream merge       # structural class: consolidate overlapping memories + collapse index lines
 /dream split       # structural class: divide multi-concern files into focused ones
-/dream pattern     # NOT YET BUILT (v0.3)
-/dream contradiction  # NOT YET BUILT (v0.4)
-/dream untapped    # NOT YET BUILT (v0.5)
-/dream audit       # NOT YET BUILT (v0.6)
+/dream lint        # structural class: index/file agreement, duplicates, misfiles, half-finished archives
+/dream pattern     # NOT YET BUILT (v0.4)
+/dream contradiction  # NOT YET BUILT (v0.5)
+/dream untapped    # NOT YET BUILT (v0.6)
+/dream audit       # NOT YET BUILT (v0.7)
 ```
 
 ## Steps
@@ -61,11 +62,12 @@ Read the **"Inputs you'll be given"** section of the loaded curator prompt and g
   **Why not `find -mtime -14`:** any git history rewrite resets mtime on every tracked file, after which `-mtime -14` matches the whole directory and silently blows up the input set. Session filenames are `YYYY-MM-DD.md` and sort lexically, so the date compare above stays exact through any rewrite.
 - `git log --since="14 days ago" --oneline` for the current repo
 
-**Structural curators** (`merge`, `split`) — examine the *shape of the memory set itself*; NO state/session inputs:
+**Structural curators** (`merge`, `split`, `lint`) — examine the *shape of the memory set itself*; no state/session file inputs (lint's extras below are existence probes and commit titles, not state):
 
 - Read every `$MEMORY_DIR/*.md` detail file
 - Read `$MEMORY_DIR/MEMORY.md` (the index) and `$MEMORY_DIR/ARCHIVE.md`
 - Optionally `git -C "$MEMORY_DIR" log --since="30 days ago" --oneline` (accretion signal)
+- `lint` additionally: cheap read-only existence checks for local paths memories name (`ls`, `test -e`, `git ls-files`), and optionally `git log --oneline -30` of the current work repo for its shipped-work heuristic — never URL fetches
 
 ### 5. Write `inputs.json` to the dream dir
 
@@ -94,6 +96,7 @@ Schema is defined in the curator prompt and varies by curator class. Every propo
 - **Content curators** (`rot`): `target`, `current_excerpt`, `proposed_excerpt`.
 - **`merge`**: `targets` (array), `survivor`, `merged_body`, `index_changes` ({remove[], add}), `archive_tombstones`, `net_index_lines`.
 - **`split`**: `target`, `result_files` (array of {name, purpose, index_line, body}), `original_index_line`.
+- **`lint`**: content-curator shape (`target`, `current_excerpt`, `proposed_excerpt`) plus a `check` field naming which of its ten checks fired.
 
 `/dream-apply` branches on `action` to apply each shape.
 

--- a/docs/dream-architecture.md
+++ b/docs/dream-architecture.md
@@ -1,6 +1,6 @@
 # Dream — autonomous memory curator
 
-**Status:** v0.2. Curators: rot (content), merge + split (structural).
+**Status:** v0.3. Curators: rot (content), merge + split + lint (structural).
 
 ## Why this exists
 
@@ -104,7 +104,7 @@ Apply step honors `confidence`: `high` defaults to accept, `medium` shows full d
 Curators fall into two **classes**:
 
 - **Content curators** ask *"is this memory still true?"* — they compare memory against the world (state files, sessions, commits). `rot`, `pattern`, `contradiction`, `audit`.
-- **Structural curators** ask *"is this memory well-shaped?"* — they examine the shape of the memory set itself (detail files + the `MEMORY.md` index) and read no state/session inputs. `merge`, `split`.
+- **Structural curators** ask *"is this memory well-shaped?"* — they examine the shape of the memory set itself (detail files + the `MEMORY.md` index) and read no state or session files (lint adds only read-only existence probes and an optional work-repo `git log`). `merge`, `split`, `lint`.
 
 ### v0.1: rot (content) — shipped
 
@@ -126,29 +126,39 @@ Curators fall into two **classes**:
 
 **Why second:** `MEMORY.md` drifts over its 100-line / loaded-budget cap; merge is the direct pressure-relief, and split enforces one-fact-per-file. Structural ops touch many files at once, so they lean hard on the git-revert safety net and human review. Guiding principle: **Focus Over Coverage** — never produce vaguer files just to hit a number; merge and split are opposing forces and a good pass leaves the other nothing to undo.
 
-### v0.3: pattern (content, later)
+### v0.3: lint (structural) — shipped
+
+**Question:** "Is the store well-formed and internally consistent — index and files in agreement, no duplicates, no contradictions, no half-finished archives?"
+
+**Inputs:** `memory/*.md` + `memory/MEMORY.md` + `memory/ARCHIVE.md` (live root only — `memory/archive/**` excluded), plus cheap read-only existence checks (`ls`, `test -e`, `git ls-files`) for local paths memories name, and optionally `git log --oneline -30` when run inside a work repo. No state/session inputs, no URL fetches — it runs standalone against any memory directory, which makes it the right first pass on an inherited or long-uncurated store.
+
+**Output actions:** `modify`, `archive`, `flag` (content-curator proposal shape plus a `check` field naming which of its ten checks fired: index drift, unresolved links, pattern-level staleness, duplicates, contradictions, unverifiable references, type misfiles, index-only content, duplicate archive rows, build-log bloat).
+
+**Why third:** rot compares memory against the world; lint catches the store drifting against *itself* — the class rot structurally cannot see. Sharpest case: a type misfile, where a project status filed as `feedback` escapes every rot pass because rot audits `project`/`reference` hardest. Ported from agent-memory-kit (`prompts/lint.md` @ `1bd9a14`, skills-sync#9), where it was capability the publication node had and the core lacked.
+
+### v0.4: pattern (content, later)
 
 **Question:** "What recurring frictions in the last 14 days of sessions don't have a memory entry yet?"
 
 **Output actions:** `add` (new memory candidate). Required-evidence floor: must appear in 3+ sessions to propose.
 
-### v0.4: contradiction (content, later)
+### v0.5: contradiction (content, later)
 
 **Question:** "Does memory contain rules that give conflicting guidance for the same situation?"
 
 **Output actions:** `flag` (always — never auto-resolve a contradiction; surface to the user).
 
-### v0.5: untapped (content, later)
+### v0.6: untapped (content, later)
 
 **Question:** "What recurring themes in session logs have never been raised into memory or a skill?"
 
 **Output actions:** `flag`.
 
-### v0.6: audit (content, later, possibly never)
+### v0.7: audit (content, later, possibly never)
 
 **Question:** "Did sessions in the last 7 days follow the rules in MEMORY.md?"
 
-**Risk:** Memory rules aren't structured enough to mechanically check adherence. May produce noise. Hold until v0.5 ships.
+**Risk:** Memory rules aren't structured enough to mechanically check adherence. May produce noise. Hold until `untapped` ships.
 
 ## What this deliberately doesn't do
 

--- a/scripts/dream/README.md
+++ b/scripts/dream/README.md
@@ -17,10 +17,11 @@ Curator catalog (build order):
 - `rot` (content, v0.1, ships with starter) — flag project memories that no longer match state files / recent commits
 - `merge` (structural, v0.2) — consolidate overlapping memories into one entry; collapse redundant index lines (main relief for the MEMORY.md 100-line budget)
 - `split` (structural, v0.2) — divide multi-concern files into focused, single-responsibility ones
-- `pattern` (content, v0.3, planned) — propose new memories from recurring session-log frictions
-- `contradiction` (content, v0.4, planned) — flag memory rules giving conflicting guidance
-- `untapped` (content, v0.5, planned) — surface session-log themes never raised to memory
-- `audit` (content, v0.6, maybe) — flag sessions that ignored MEMORY.md rules
+- `lint` (structural, v0.3) — structural-integrity audit: index/file agreement, duplicates, contradictions, type misfiles, half-finished archives, index-only content (ported from agent-memory-kit, skills-sync#9)
+- `pattern` (content, v0.4, planned) — propose new memories from recurring session-log frictions
+- `contradiction` (content, v0.5, planned) — flag memory rules giving conflicting guidance
+- `untapped` (content, v0.6, planned) — surface session-log themes never raised to memory
+- `audit` (content, v0.7, maybe) — flag sessions that ignored MEMORY.md rules
 
 ## First-time setup
 

--- a/scripts/dream/prompts/lint.md
+++ b/scripts/dream/prompts/lint.md
@@ -1,0 +1,206 @@
+# Curator prompt: lint (structural integrity)
+
+> Ported from agent-memory-kit `prompts/lint.md` @ `1bd9a14` (skills-sync#9). Spec citations reference that repo's docs; the operative rules are quoted inline so this prompt runs standalone.
+
+**Role:** You are a memory curator. Your single job this pass is **structural integrity**: is the memory store well-formed and internally consistent? You do not judge whether memories still match the world; that is the rot curator's job. Where the two overlap (an expired date, work that git says shipped), find it cheaply here and hand the world-check to a rot pass.
+
+**Where lint problems live:** everywhere rot does not. Rot is facts drifting against reality. Lint is the store drifting against itself: index lines pointing at files that no longer exist, the same fact captured twice under two names, two rules that cannot both be followed, a "revisit next week" that never became a date, a working rule filed as a `reference`. A store can be rot-free and still unusable. Capture only ever adds; lint is the pass that notices what adding left behind.
+
+## Inputs (read-only; you may NOT modify any of these)
+
+- Every file in the **root** of `$MEMORY_DIR`: the live detail files, `MEMORY.md` (the index), and `ARCHIVE.md` if present. **Skip `$MEMORY_DIR/archive/` entirely** — retired files have no index line by design, so scanning them turns every past archive into a false finding.
+- Cheap existence checks for local paths that memories name: `ls`, `test -e`, `git ls-files`. Read-only shell only. Do not fetch URLs.
+- Optional, when run inside a work repo: `git log --oneline -30`, for the shipped-work heuristic in check 3.
+
+Unlike rot, lint does not need `state/` or `sessions/`. It runs standalone against any memory directory, which is why it is the right first pass on a store you inherited or have not curated in a while.
+
+## The checks
+
+Run all ten, in order. Every finding needs: action, evidence (file plus line), confidence.
+
+### 1. Index drift
+
+The index (`MEMORY.md`) and the detail files must agree. Four sub-checks:
+
+- **Index line, no file.** A `[Title](slug.md)` line whose file does not exist. Includes archived memories whose index line was never dropped (cross-check `ARCHIVE.md`). Action: `modify` targeting `MEMORY.md`, dropping the line. Confidence: high (mechanical).
+- **File, no index line.** A live detail file with no line in the index. It is invisible at recall time, which defeats the point of capturing it. Action: `modify` targeting `MEMORY.md`, adding a line under the right type heading. Confidence: high. **Files under `archive/` are exempt** — losing the index line is the last step of retiring one.
+- **Half-finished archive.** A file listed in `ARCHIVE.md` that is still sitting in the memory root, with no `archived:` stamp in its frontmatter. It fails in the wrong direction: nothing was lost, so no backup flags it, and every session keeps reading a retired memory as current. The tell is a curator proposing to archive something that was retired weeks ago, with no way to see the earlier row. Action: `archive` — **not** `modify`. A `modify` is only an excerpt swap, so it would write the `archived:` stamp without the move, leaving the file live AND hiding it from this very sub-check, which keys off the stamp being absent. `archive` resumes: `commands/dream-apply.md` step 1 decides from the filesystem: a target still in the memory root **with a row already in `ARCHIVE.md`** is the crashed-run case, so it skips the row append and finishes stamp + move + repoint + index-drop. (Root with no row is an ordinary archive and does append its row — the two are not the same case.) Stamp with the row's date, not today. Confidence: high (mechanical — the row and the missing stamp are both greppable).
+- **Hook does not match the file.** The index hook and the file's frontmatter `description` say materially different things (not paraphrase; different facts). The detail file is the authority; the hook follows it. Action: `modify` targeting `MEMORY.md`, rewriting the hook from the description. Confidence: medium. If the file looks wrong and the hook looks right, `flag` instead; that is a content question, not an index question.
+
+Mechanics for index proposals: `target` is `MEMORY.md`, `current_excerpt` is the exact existing line (or the placeholder comment / section heading when adding a line), `proposed_excerpt` is the replacement. That keeps the proposal applyable by `/dream-apply`'s excerpt-swap.
+
+### 2. Unresolved [[links]]
+
+A `[[slug]]` resolves if some memory file's frontmatter `name` matches it, or a filename stem matches with `-` and `_` treated as equivalent. Per the memory-format spec (agent-memory-kit `docs/memory-format.md`), an unresolved link is **not an error**: "it marks a memory worth writing later." So this check is informational only. List unresolved links so the human can see what is still unwritten. Action: `flag`. Confidence: low. Never propose deleting a link. Put these in their own report section so they do not pad the real findings.
+
+### 3. Staleness (the cheap, pattern-level kind)
+
+Grep for date patterns, then judge tense and intent. Three flavors:
+
+- **Relative dates that never became absolute.** "next week," "tomorrow," "this month," "by the 1st." The writing rules say absolute dates only; relative dates are rot waiting to happen. If the file carries an anchor (a `Status (YYYY-MM-DD)` line, a dated capture), convert: action `modify`, confidence medium. No anchor to convert from: `flag`, confidence low.
+- **Past dates attached to future-tense claims.** "scheduled for {date}," "expires {date}," "check back {date}," where the date has passed and nothing in the file records the outcome. Lint cannot know what happened; that needs world evidence. Action: `flag`, confidence medium, and say in the reasoning that a `/dream rot` pass should cross-check it.
+- **Shipped work still described as in-flight.** Only when a work repo is at hand: a `project` memory says "in progress" and `git log` shows the matching work merged. Cite the commit. Action: `flag`, confidence medium. Rewriting status from git evidence alone is rot's job with fuller inputs.
+
+### 4. Duplicates and overlap
+
+One fact per file is the rule; capture violates it over time because `/end` sometimes misses that a fact already has a home. Detection: compare frontmatter descriptions and index hooks pairwise for near-duplicates (same distinctive nouns, same subject), then read both bodies to confirm same-fact versus adjacent-facts. When confirmed:
+
+- Pick a survivor (the better-named, richer file). Fold any detail unique to the duplicate into it: action `modify`, confidence medium.
+- Archive the duplicate: action `archive`, confidence medium-to-high. Cross-reference the paired proposal id in the reasoning so the human reviews them together.
+
+The inverse defect counts too: one file holding two unrelated facts (the "and" test). Action: `flag` with a proposed split. Lint never splits files itself.
+
+### 5. Contradictions
+
+Two memories that cannot both be followed: one says "always X," another says "never X" or carves an exception the first does not acknowledge. Both are indexed, so both load, and the agent obeys whichever it read last. Detection is judgment, not grep: read `feedback` and `user` memories as a set and look for incompatible instructions about the same situation. Quote both files in the evidence. Action: always `flag`, per the curation contract (agent-memory-kit `docs/curation.md`): contradictions are never auto-resolved. You may sketch a reconciliation in `proposed_excerpt` (often the two rules merge into one rule with an explicit exception), but the human decides which memory is right, because the agent cannot know which one reflects what the user actually wants.
+
+### 6. Unverifiable references
+
+Memories that name local paths, scripts, or files: verify each with `test -e` / `git ls-files` from the repo root. Missing path: action `flag`, confidence high (high that the path is dead; what to do about it is the human's call). Evidence must show the check: "checked {date}: `git ls-files scripts/` has no rotate-keys.sh". Propose `modify` only when the replacement is evident (the file clearly moved and you found it). URLs and CLI flags: do not fetch or execute; flag only when another memory or the repo contradicts them.
+
+### 7. Type misfiles
+
+The four types drive curation (see the format spec): `user` is who the user is, `feedback` is how the agent should work, `project` is in-flight work, `reference` is pointers to external resources. A misfiled memory gets the wrong curation treatment; rot audits `project`/`reference` hardest and mostly skips `feedback`/`user`, so a project status filed as `feedback` escapes every rot pass. Common misfiles: a working rule filed as `reference`; in-flight status filed as `user` or `feedback`; an external pointer filed as `project`. Action: `modify` the frontmatter `type` line, confidence medium. Note in the reasoning the manual follow-ups the apply step cannot do: the filename keeps its old prefix until the human renames it, and the index line should move to the right section.
+
+### 8. Index-only content
+
+An index line that carries the fact itself instead of pointing at a detail file — a `- ` line with no `](…)` link in it. Detection:
+
+```sh
+grep -E '^ *[-*] ' MEMORY.md | grep -vE '\]\([^)]*\.md\)' | grep -vE '^ *[-*] *\[\[[^]]*\]\] *$'
+```
+
+Three details matter. `[-*]` catches both bullet styles and the leading `^ *` catches indented sub-bullets, which are index content too. The link test is `](….md)`, not a bare `](`: a bullet whose only link is a URL has no **detail file** behind it, so every word of the rationale below applies to it — there is nothing to stamp, nothing to move, and nothing for a tombstone to point at. And a bullet whose **entire content** is a `[[slug]]` wikilink is not a finding here — check 2 owns those, calling an unresolved link "not an error" because "it marks a memory worth writing later." Match the whole line, not merely the presence of `[[`: a bullet that states a fact *and* links a related memory as an aside is still index-only content, and excluding it on the `[[` alone would silence a real finding.
+
+**Anchor on `^- `.** Without the anchor this check is unusable, because `grep -cv '](' MEMORY.md` counts headings, the blockquote, and every blank line. Measured, not asserted:
+
+| | unanchored | anchored |
+|---|---|---|
+| agent-memory-kit `context-starter/memory/` (pristine, no defect) | **11** | **0** |
+| agent-memory-kit `examples/lint-pass/memory/` (one seeded defect) | **14** | **1** |
+
+The pristine row is the point: unanchored, this check reports 11 findings against a scaffold that contains nothing. The fixture row is the check working — 1 is the seeded defect, and it is the only thing anchored counting finds. Anchor first, then count.
+
+Why this is worth a finding, and none of it depends on which agent or runner loads the store: the index is the one file every session reads, and the format spec states the rule outright — "The `MEMORY.md` index holds **one line per memory**, never memory content" — against a hard line budget (~100 lines in the kit's spec; a consuming repo may set its own). Every other memory survives that trim, because all three things that make a retirement recoverable key off a *file* — `ARCHIVE.md`'s tombstone row links one, the `archived:` stamp is written into one, `archive/` holds one. A fact that exists only as an index line has nothing to stamp and nothing to move, so the trim is a plain delete with no tombstone behind it. It is also invisible to the rest of curation: rot iterates `project_*.md` and `reference_*.md` **files** (`scripts/dream/prompts/rot.md`, "What to look for"), and an index line is not a file, so nothing ever re-checks it.
+
+Action: `flag`. The fix is to write the detail file and shorten the line to a pointer, and where that split falls is the human's call. Confidence: high — the missing link is mechanical, even though the remedy is not.
+
+### 9. Duplicate archive rows
+
+The same memory tombstoned more than once in `ARCHIVE.md`. Detection is mechanical: extract the link target from every row, then count duplicates.
+
+```sh
+grep '^| 20' ARCHIVE.md | cut -d'|' -f3 | grep -o '](archive/[^)]*)' | sort | uniq -d
+```
+
+**Scope to the memory column, not the whole file.** The `reason` column is free prose and routinely cites another memory — and most naturally an *archived* one ("superseded by …"), so narrowing the pattern to `](archive/` is not enough either: two rows retiring two *different* files whose reasons both link the same retired doc still read as a duplicate. Cut to field 3, the memory link, and the prose cannot reach it. One known blind spot, and it is the safe direction: a memory whose *title* contains an escaped `\|` splits across fields, so its row drops out and a genuine duplicate can be missed. A miss costs a re-run; a false positive would delete a legitimate tombstone. That matters more here than elsewhere, because this check's action is a high-confidence `modify` that DELETES a row — a false positive destroys a legitimate tombstone.
+
+A duplicate row is **never a new finding**. It means an earlier archive stopped after writing the row: the `archived:` stamp and the move to `archive/` never happened. The guard that should have caught the second attempt lives in `commands/dream-apply.md` step 1, and its problem was the opposite of missing the row — it *saw* the row and read it as "already retired, stop," while its resume path required an `archived:` stamp the crashed run had never written. So a half-finished archive could be neither completed nor re-attempted cleanly, and a later pass that bypassed the guard appended a second row. Step 1 now refuses only on where the file is; the row still matters, but as the thing that tells an ordinary archive from a resume rather than as grounds to stop (`commands/dream-apply.md`; history in agent-memory-kit#23). The duplicate row is the only surviving trace of that, which is what makes it worth a check: the half-finished archive it points back to is otherwise silent.
+
+Action: `modify` `ARCHIVE.md`, keeping the **earliest** row and dropping the later ones. The earliest is the true retirement date; the later rows are re-runs, and their `reason` text is a second guess at a decision already recorded. Confidence: high. Then file the underlying half-finished archive under check 1 so the stamp and the move actually complete — dropping the extra row alone leaves the file live in the memory root.
+
+### 10. Build-log bloat
+
+A `project` memory that has turned into a changelog: a running list of what shipped when, rather than one fact. Found twice in a ~330-file store, about 9KB between them.
+
+**This one is judgment, not grep** — the same footing as checks 4 and 5. "Is this file a changelog?" is a question about what the text *is*, and no pattern decides it. Read every `project_*.md`; a grep only tells you where to start reading.
+
+A starting hint, deliberately labelled non-exhaustive:
+
+```sh
+for f in project_*.md; do
+  [ -e "$f" ] || break                      # a fresh store has none; do not error
+  n=$(awk '/^```/{fence=!fence; next} !fence' "$f"       | grep -cE '^[-*#[:space:]]*(\*\*)?(Session|Sprint|Release|v?[0-9]+\.[0-9]+)')
+  [ "$n" -ge 2 ] && echo "$f (~$n markers — READ IT, do not file on the count)"
+done
+```
+
+**Do not treat a count as a finding.** Every threshold here is arbitrary and both error directions are real, so the hint is tuned loose and the reading decides:
+
+- **It over-fires.** A memory whose one fact *is* about versioning ("one pin per quarter", three bullets naming v1.4/v1.5/v1.6) trips it, and so did a fenced code sample containing a changelog before the `awk` fence-strip above. Neither is a log.
+- **It under-fires.** Real logs use styles no list anticipates: `## Sprint 4`, `## Release 2026-03`, `## 1.2.0` with no `v`, bare `- #101 merged` PR lists. A genuine two-release log has only two markers. Earlier drafts of this check missed all of these while confidently matching the one style the fixture happened to use — a fixture written alongside its own grep proves nothing.
+
+What actually identifies a log, on reading: **repeated dated or versioned entries, each about a different event**, with no single durable claim the file is *for*. One fact plus version numbers in it is not a log.
+
+Two tiers, and keeping them apart is the whole point:
+
+- **Standalone (always available).** A log is many facts in one file, which the format spec rules out ("One fact per file... if you're tempted to use 'and,' it's two memories"), and it drifts against *itself*: one block says v2.3 shipped, a later line still calls v2.2 current. Both cannot be true, and neither needs the repo to see. Say which paragraphs are log and which are the durable rule worth keeping.
+- **Duplication (only when a work repo is at hand).** The stronger finding — "the repo already records this, and the format spec says don't save what the repo already records" — is a claim *about the repo*, so it needs one. Cite the path: `git ls-files CHANGELOG.md docs/releases`. Lint runs standalone against any memory directory, so with no repo in reach, **do not assert the duplication**; report the shape and say the duplication was not checked. This is the same hedge check 3's shipped-work heuristic carries, for the same reason.
+
+Action: `flag` naming log paragraphs versus durable ones. Never `modify` — deciding what survives a rewrite is a content judgment, and a wrong cut deletes the one durable rule buried in the log. Confidence: medium; the shape is mechanical, the split is not.
+
+## Output
+
+Write `proposals.json` and `REPORT.md` to `{MEMORY_DIR}/.dreams/{ISO-timestamp}/`.
+
+### `proposals.json`
+
+Same schema as every curator (the proposal-shape list in `commands/dream.md`), plus a `check` field naming which of the ten checks fired, so findings group cleanly:
+
+```json
+{
+  "curator": "lint",
+  "ran_at": "{ISO}",
+  "inputs_summary": { "memory_files_audited": 0, "index_entries": 0, "local_paths_verified": 0 },
+  "proposals": [
+    {
+      "id": "lint-001",
+      "check": "index_drift",
+      "action": "modify",
+      "target": "MEMORY.md",
+      "reasoning": "Index line points at reference_build_flags.md, which does not exist and is not in ARCHIVE.md. Dead index lines waste recall budget and erode trust in the index.",
+      "evidence": ["MEMORY.md L22: '- [Legacy build flags](reference_build_flags.md): compiler flags for the legacy build.'", "ls: reference_build_flags.md not found; ARCHIVE.md has no row for it"],
+      "current_excerpt": "- [Legacy build flags](reference_build_flags.md): compiler flags for the legacy build.",
+      "proposed_excerpt": "",
+      "confidence": "high"
+    }
+  ],
+  "skipped": [
+    { "target": "user_timezone.md", "reason": "Content is clean; its only issue (missing index line) is filed against MEMORY.md." }
+  ]
+}
+```
+
+An empty `proposed_excerpt` on a `modify` means "delete the excerpt" (used for dropping dead index lines).
+
+### `REPORT.md`
+
+House format: counts, findings grouped by confidence (highest-confidence wins first, so the report is actionable in one sitting), then the informational link list, then skipped. Within each confidence group, order mechanical index fixes first, content edits second, flags last.
+
+```markdown
+# Dream pass: lint — {ISO-timestamp}
+
+**Audited:** N memory files + the index
+**Checks:** index sync, links, dates, duplicates, contradictions, references, types, index-only content, duplicate archive rows, build-log bloat
+
+## Findings
+
+### High confidence (N)
+1. **{target}** [{check}] — {one-line summary}
+   - Evidence: {one line}
+   - Suggested action: {modify | archive | flag}
+
+### Medium confidence (N)
+...
+
+### Flagged for review (N)
+...
+
+## Info: unresolved [[links]] (N)
+Placeholders, not errors. Each marks a memory worth writing later.
+- [[{slug}]] referenced from {file}
+
+## Skipped
+- {target} — {one-line reason}
+
+## Apply
+Run `/dream-apply {ISO-timestamp}` to review and apply.
+```
+
+## What you must NOT do
+
+- Don't write to memory files directly. The artifact is the only output. Nothing applies without the human at `/dream-apply`.
+- Don't resolve contradictions. Flag, quote both sides, stop.
+- Don't treat unresolved `[[links]]` as errors. They are placeholders by design.
+- Don't judge whether a fact is still true of the world. Suspected world-drift gets a `flag` that names rot as the follow-up, not a rewrite.
+- Don't propose anything you can't cite evidence for. Empty-evidence proposals get rejected at apply time.


### PR DESCRIPTION
Routine queue publish after skills-sync#17 landed the lint curator in the core: `scripts/dream/prompts/lint.md` arrives here for the first time (this repo previously had only merge/rot/split — the live gap named in skills-sync#18), plus dream/dream-apply restamped @ `8ede26c`. Guards green (leak scan clean, public-in clear); dream.md body verified byte-identical to core modulo the provenance stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)