### PR TITLE
Add reviewed workspace and capture integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - A validated, opt-in integrations catalog with generated documentation, explicit credential/data/side-effect boundaries, and no automatic installation or activation. Initial links cover Agent Skills, Agent Workspace, AI Tools for Creators, and Substack MCP.
-- Reviewed optional entries for Tolaria, the official Obsidian CLI, Beads for Gemini CLI, and Granola's hosted MCP, with conservative overwrite, publish, destructive, OAuth, remote-sync, and transcript gates.
+- Reviewed optional entries for Tolaria MCP, the official Obsidian CLI, Beads for Gemini CLI, and Granola's hosted MCP, with conservative sensitive-read, remote-write, overwrite, deletion, arbitrary-execution, publish, destructive, OAuth, retention, residency, and transcript gates.
 
 ### Fixed
 - Moved project slash commands from the undiscovered root `commands/` directory to `.claude/commands/`; moved the native meta-skill to `.claude/skills/`; renamed `/context` to `/find-context` to avoid the Claude Code built-in.
@@ -22,6 +22,7 @@
 - `.claude/commands/dream-apply.md` — the moved file's own outbound links were never repointed, so every archived file's references silently broke on the move.
 
 ### Changed
+- Integration catalog schema v2 adds typed safety capabilities and matching confirmations/risk tags, structured uninstall data-loss declarations, non-empty auditable evidence links, a remote-write/sensitive-read summary, and hostile regression cases. CI validates internal claims and generated documentation; it does not certify upstream source truth.
 - CI now runs one aggregate validator covering command discovery/name parity, links, shell syntax, hook behavior, JSON, and Python unit tests.
 - `.claude/commands/{start,end,update,today,reconcile,recover}.md` + `.claude/skills/skill-creator/SKILL.md` — republished from the shared core after it ingested its standalone upstreams (core @ `7ae9852`). What rides in: a `workspace.yaml` config layer with per-file staleness thresholds (`/start`, `/update`, `/today`), a decision log with a rejected-alternatives column and a git safety check (`/end`), "prefer evidence of intent over recency" (`/reconcile`), "recent activity means *unknown*, not orphaned" plus a working dirty-worktree removal path (`/recover`), and a never-silently-clobber-an-existing-`SKILL.md` guard (`skill-creator`). `x-source-version` restamped on all seven; `recover` keeps its downstream `allowed-tools` declaration. The republished `skill-creator` links a pinned frontmatter-spec snapshot, so `.claude/skills/skill-creator/references/claude-code-frontmatter.md` now ships alongside it (verbatim from the canonical agent-skill-builder copy).
 - `state/decisions.md` — starter rewritten from a `## [DATE]` prose template ("Newest first") to the four-column table `/end` step 5 actually appends (`| Date | Decision | Context / rationale | Rejected alternatives |`, oldest first). Same failure class #12 fixed for `content/log.md`: the starter and the command described two different formats, so anyone following the starter produced a log the command's table append would then break.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - A validated, opt-in integrations catalog with generated documentation, explicit credential/data/side-effect boundaries, and no automatic installation or activation. Initial links cover Agent Skills, Agent Workspace, AI Tools for Creators, and Substack MCP.
+- Reviewed optional entries for Tolaria, the official Obsidian CLI, Beads for Gemini CLI, and Granola's hosted MCP, with conservative overwrite, publish, destructive, OAuth, remote-sync, and transcript gates.
 
 ### Fixed
 - Moved project slash commands from the undiscovered root `commands/` directory to `.claude/commands/`; moved the native meta-skill to `.claude/skills/`; renamed `/context` to `/find-context` to avoid the Claude Code built-in.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Both hooks no-op until you list a repo basename in `.claude/hooks/guarded-repos.
 
 The generated [optional integrations catalog](references/integrations.md) links compatible add-ons without installing, activating, authenticating, or expanding permissions for any of them. Its source of truth is [`integrations/catalog.json`](integrations/catalog.json), enforced by `scripts/integrations.py`; CI rejects missing safety fields, contradictory capability claims, unsafe source metadata, and documentation drift. `listed` and `experimental` entries are leads, not verified endorsements.
 
-Current catalog entries include [Agent Skills](https://github.com/conorbronsdon/agent-skills), [Agent Workspace](https://github.com/conorbronsdon/agent-workspace), [AI Tools for Creators](https://github.com/conorbronsdon/ai-tools-for-creators), and [Substack MCP](https://github.com/conorbronsdon/substack-mcp). Substack Notes publish immediately, so the catalog marks that capability and its confirmation boundary explicitly.
+Current catalog entries include portable skills and workspace add-ons plus reviewed paths for [Tolaria](https://github.com/refactoringhq/tolaria), [Obsidian CLI](https://obsidian.md/help/cli), [Beads for Gemini CLI](https://beads.gascity.com/integrations/gemini), and [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp). Each entry distinguishes local data, credentials, remote sync, overwrite, publish, destructive, and transcript boundaries where they apply.
 
 **Google Workspace MCP** — lets Claude read your calendar, email, Drive, and Sheets mid-session:
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ scripts/                          # Setup, validation, repo map generation
 scripts/dream/                    # Curator prompts + how-to for the /dream substrate
 docs/                             # Architecture guides — auto-memory, dream, migration, safety
 references/                       # Integration setup (Google Workspace, Notion)
-integrations/                     # Validated catalog of opt-in add-ons and risk boundaries
+integrations/                     # Machine-checked catalog of opt-in add-ons and risk boundaries
 .claude/hooks/                    # Session start + SSOT guard + parallel-session guards
 .github/                          # CI validation + PR template
 
@@ -193,9 +193,9 @@ Both hooks no-op until you list a repo basename in `.claude/hooks/guarded-repos.
 
 ## Optional integrations
 
-The generated [optional integrations catalog](references/integrations.md) links compatible add-ons without installing, activating, authenticating, or expanding permissions for any of them. Its source of truth is [`integrations/catalog.json`](integrations/catalog.json), enforced by `scripts/integrations.py`; CI rejects missing safety fields, contradictory capability claims, unsafe source metadata, and documentation drift. `listed` and `experimental` entries are leads, not verified endorsements.
+The generated [optional integrations catalog](references/integrations.md) links compatible add-ons without installing, activating, authenticating, or expanding permissions for any of them. Its source of truth is [`integrations/catalog.json`](integrations/catalog.json), enforced by `scripts/integrations.py`; CI rejects missing typed safety gates, contradictory declared capabilities, unsafe source metadata, empty evidence, and documentation drift. This is structural and semantic validation of the catalog entry—not proof that an upstream source remains correct. Follow each entry's dated evidence links before enabling it. `listed` and `experimental` entries are leads, not endorsements.
 
-Current catalog entries include portable skills and workspace add-ons plus reviewed paths for [Tolaria](https://github.com/refactoringhq/tolaria), [Obsidian CLI](https://obsidian.md/help/cli), [Beads for Gemini CLI](https://beads.gascity.com/integrations/gemini), and [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp). Each entry distinguishes local data, credentials, remote sync, overwrite, publish, destructive, and transcript boundaries where they apply.
+Current catalog entries include portable skills and workspace add-ons plus reviewed paths for [Tolaria MCP](https://github.com/refactoringhq/tolaria), [Obsidian CLI](https://obsidian.md/help/cli), [Beads for Gemini CLI](https://beads.gascity.com/integrations/gemini), and [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp). Each entry distinguishes sensitive reads, local writes, remote writes, OAuth, overwrite, deletion, arbitrary execution, publish, and destructive boundaries where they apply.
 
 **Google Workspace MCP** — lets Claude read your calendar, email, Drive, and Sheets mid-session:
 

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -104,6 +104,108 @@
       "uninstall": "No installation is performed by this catalog entry."
     },
     {
+      "id": "beads-gemini",
+      "name": "Beads for Gemini CLI",
+      "summary": "A project-scoped Gemini integration for Beads issue graphs and persistent agent coordination state.",
+      "source_url": "https://beads.gascity.com/integrations/gemini",
+      "kind": "agent_extension",
+      "supported_agents": ["gemini_cli"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["The bd CLI", "A deliberately initialized Beads project", "Gemini CLI"]
+      },
+      "data_boundary": {
+        "credentials": ["Optional Dolt, Git, or cloud remote credentials stay with their configured clients"],
+        "reads": ["Local issue descriptions, comments, dependencies, memories, readiness, and coordination state"],
+        "writes": ["The project Beads database", "Project or user Gemini hooks and instructions", "Optional remote issue-history sync or push", "Issue deletion, purge, migration, repair, or reset when explicitly invoked"]
+      },
+      "capabilities": {
+        "read": true,
+        "write": true,
+        "publish": false,
+        "destructive": true,
+        "details": ["Prefer project-scoped bd setup gemini --project over the global default", "bd init can modify agent instructions and configure a remote", "Remote sync and reset operations need separate review"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install", "write", "destructive"],
+        "notes": "Confirm initialization and setup after showing the project diff; separately confirm remote sync, migrations, fixes, delete or purge, and every reset operation."
+      },
+      "risk_tags": ["local-state", "hooks", "project-config", "remote-sync", "destructive-capable"],
+      "maturity": "verified",
+      "last_verified": "2026-08-15",
+      "health_check": "Run bd version, bd doctor, bd setup gemini --check, and a bounded bd ready --json query.",
+      "uninstall": "Remove only the Gemini integration with the documented project or user --remove command; back up first and require separate confirmation before a full project reset."
+    },
+    {
+      "id": "granola-mcp",
+      "name": "Granola MCP",
+      "summary": "Granola's official hosted, read-only MCP for meeting notes and plan-dependent transcripts.",
+      "source_url": "https://docs.granola.ai/help-center/sharing/integrations/mcp",
+      "kind": "mcp_server",
+      "supported_agents": ["claude_code", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "user",
+        "prerequisites": ["A Granola account with notes", "An MCP client supporting Streamable HTTP and browser OAuth"]
+      },
+      "data_boundary": {
+        "credentials": ["Per-user browser OAuth bearer token; never copy it into repository configuration or logs"],
+        "reads": ["Owned, directly shared, private-folder-shared, or workspace-public notes allowed by the active account and plan", "Account information, meeting folders, meeting notes, searches, and plan-dependent transcripts that enter the connected model context"],
+        "writes": []
+      },
+      "capabilities": {
+        "read": true,
+        "write": false,
+        "publish": false,
+        "destructive": false,
+        "details": ["Do not ingest meeting data automatically at startup", "Ask before raw transcript retrieval or broad multi-meeting search", "Free and Business plans may use anonymized data for Granola model improvement by default, with an account opt-out documented", "Voice-memo transcript availability through MCP is not guaranteed by current documentation"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install"],
+        "notes": "Require explicit OAuth, verify the active account and workspace, and ask before transcript retrieval, broad searches, or moving meeting content elsewhere."
+      },
+      "risk_tags": ["sensitive-read", "oauth", "hosted", "transcripts", "plan-limited"],
+      "maturity": "verified",
+      "last_verified": "2026-08-15",
+      "health_check": "After OAuth, call get_account_info to verify the exact account and workspace, then run a narrowly bounded list_meetings request.",
+      "uninstall": "Disconnect Granola in the client and remove the MCP entry; do not claim token revocation unless the current client documents it."
+    },
+    {
+      "id": "obsidian",
+      "name": "Obsidian CLI",
+      "summary": "Obsidian's official desktop CLI for scoped access to local Markdown vaults; no MCP server is required.",
+      "source_url": "https://obsidian.md/help/cli",
+      "kind": "editor_guide",
+      "supported_agents": ["claude_code", "codex", "gemini_cli", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["Obsidian desktop 1.12.7 or newer", "The command line interface enabled on PATH", "Obsidian running for CLI calls"]
+      },
+      "data_boundary": {
+        "credentials": ["Optional Obsidian Sync or Publish credentials remain inside Obsidian"],
+        "reads": ["Explicitly selected local vault notes, properties, tasks, backlinks, and history"],
+        "writes": ["Vault notes, properties, tasks, moves, and renames", "Trash or permanent deletion", "Publish or unpublish actions", "Plugin changes and arbitrary Obsidian command or eval execution"]
+      },
+      "capabilities": {
+        "read": true,
+        "write": true,
+        "publish": true,
+        "destructive": true,
+        "details": ["Prefer exact vault and path parameters over ambiguous file resolution", "Use the Obsidian CLI for link-aware moves and renames", "Deny arbitrary eval and command by default"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install", "write", "publish", "destructive"],
+        "notes": "Confirm overwrites, bulk or link-affecting moves, sync control, deletion, publish or unpublish, plugin changes, arbitrary command, and eval; use the normal local-edit gate for a single bounded note edit."
+      },
+      "risk_tags": ["local-data", "read-write", "publish-capable", "destructive-capable", "arbitrary-eval"],
+      "maturity": "verified",
+      "last_verified": "2026-08-15",
+      "health_check": "Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1.",
+      "uninstall": "Disable the CLI or remove the harness allowlist; do not delete, unregister, or alter the vault unless separately requested."
+    },
+    {
       "id": "substack-mcp",
       "name": "Substack MCP",
       "summary": "An MCP server for reading Substack publication data, managing private drafts, and publishing short-form Notes.",
@@ -136,6 +238,40 @@
       "last_verified": "2026-08-15",
       "health_check": "After explicit authentication, run the documented subscriber-count read and verify the expected publication account.",
       "uninstall": "Remove the MCP client entry and, if used, review then remove the local browser-login session file."
+    },
+    {
+      "id": "tolaria",
+      "name": "Tolaria",
+      "summary": "A local-first Markdown vault desktop app with a bundled stdio MCP and embedded coding-agent interface.",
+      "source_url": "https://github.com/refactoringhq/tolaria",
+      "kind": "local_workspace",
+      "supported_agents": ["claude_code", "codex", "opencode", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["Tolaria for macOS, Windows, or Linux", "A mounted local vault", "The separately installed and authenticated agent CLI selected by the user"]
+      },
+      "data_boundary": {
+        "credentials": ["Agent or API credentials remain with the selected CLI or provider", "Optional Git remote credentials remain with system Git"],
+        "reads": ["Markdown and YAML frontmatter in explicitly mounted vaults"],
+        "writes": ["Create, append, or full-content update of notes in mounted vaults", "Attach an additional vault or clone one through system Git"]
+      },
+      "capabilities": {
+        "read": true,
+        "write": true,
+        "publish": false,
+        "destructive": true,
+        "details": ["Treat full-content update_note as overwrite-capable even though its MCP annotation says non-destructive", "Prefer get_note, diff review, and expectedMtime before update_note", "Git can replicate vault contents and direct cloud-agent targets may send selected note context to their provider", "Bundled MCP documents no delete or publish tool, but a native agent can have broader file or shell access"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install", "write", "destructive"],
+        "notes": "Use normal approval for a single create or append; show a diff or confirm full replacement, bulk edits, vault attachment or clone, Power User mode, Git push, and broader native-agent actions."
+      },
+      "risk_tags": ["local-data", "read-write", "optional-network", "agent-execution", "overwrite-capable"],
+      "maturity": "verified",
+      "last_verified": "2026-08-15",
+      "health_check": "Start Tolaria, list mounted vaults, read vault context, run a bounded search, then use a disposable note for any write smoke test.",
+      "uninstall": "Remove any manually added MCP entry and uninstall the app; preserve all vaults unless deletion is separately confirmed."
     }
   ]
 }

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -161,16 +161,16 @@
         "arbitrary_execution": false,
         "oauth": false,
         "destructive": true,
-        "details": ["bd setup gemini writes user-global hooks by default; prefer bd setup gemini --project for repository scope", "bd init can modify agent instructions and configure a remote", "bd dolt push --force can overwrite remote history, and bd init --discard-remote discards remote state"]
+        "details": ["bd setup gemini writes user-global hooks by default; prefer bd setup gemini --project for repository scope", "bd init can modify agent instructions and configure a remote", "bd dolt push --force can overwrite remote history", "bd init --discard-remote authorizes a divergent local initialization; a later Dolt push is the separate remote-history replacement"]
       },
       "confirmation": {
         "required_for": ["credential_setup", "external_install", "write", "write_remote", "overwrite", "delete", "destructive"],
-        "notes": "Confirm initialization and setup after showing the project or user-config diff; separately confirm every remote sync or push, force push, discard-remote operation, migration, fix, delete, purge, and reset."
+        "notes": "Confirm initialization and setup after showing the project or user-config diff; separately confirm divergent local initialization with discard-remote and any later remote sync or push, especially force push, plus migration, fix, delete, purge, and reset."
       },
       "risk_tags": ["local-state", "hooks", "project-config", "remote-write", "overwrite-capable", "delete-capable", "destructive-capable"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
-      "evidence": ["https://beads.gascity.com/integrations/gemini", "https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/cli-reference/dolt.md"],
+      "evidence": ["https://beads.gascity.com/integrations/gemini", "https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/cli-reference/dolt.md", "https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/recovery/init-safety.md"],
       "health_check": "Run bd version, bd doctor, bd setup gemini --check, and a bounded bd ready --json query.",
       "uninstall": {
         "instructions": "Remove only the Gemini integration with the documented project or user --remove command; preserve the Beads project database unless separate deletion is approved.",
@@ -190,7 +190,7 @@
         "prerequisites": ["A Granola account with notes", "An MCP client supporting Streamable HTTP and browser OAuth"]
       },
       "data_boundary": {
-        "credentials": ["Per-user browser OAuth bearer token; never copy it into repository configuration or logs"],
+        "credentials": ["Per-user browser OAuth bearer token stays outside repository configuration and logs"],
         "reads": ["Owned, directly shared, private-folder-shared, or workspace-public notes allowed by the active account and plan", "Account information, meeting folders, meeting notes, searches, and plan-dependent transcripts that enter the connected model context"],
         "writes": []
       },
@@ -224,18 +224,18 @@
     {
       "id": "obsidian",
       "name": "Obsidian CLI",
-      "summary": "Obsidian's official desktop CLI exposes broad local application and vault capabilities; scope is enforceable only through an exact external command allowlist.",
+      "summary": "Obsidian's official desktop CLI exposes broad local application and vault capabilities; scope is enforceable only through an exact external command-and-argument policy.",
       "source_url": "https://obsidian.md/help/cli",
       "kind": "editor_guide",
       "supported_agents": ["claude_code", "codex", "gemini_cli", "generic"],
       "installation": {
         "automatic": false,
         "scope": "project_or_user",
-        "prerequisites": ["Obsidian desktop 1.12.7 or newer", "The command line interface enabled on PATH", "Obsidian running for CLI calls", "An exact command allowlist enforced by the calling harness"]
+        "prerequisites": ["Obsidian desktop 1.12.7 or newer", "The command line interface enabled on PATH", "Obsidian running for CLI calls", "An exact command-and-argument policy enforced by the calling harness"]
       },
       "data_boundary": {
         "credentials": ["Optional Obsidian Sync or Publish credentials remain inside Obsidian"],
-        "reads": ["The active vault and active file by default, or explicitly targeted vault notes, properties, tasks, backlinks, history, workspaces, plugins, and themes"],
+        "reads": ["The current-working-directory vault when the shell is inside a vault, otherwise the active vault; many file commands then default to the active file unless vault= and path= are explicit", "Explicitly targeted notes, properties, tasks, backlinks, history, workspaces, plugins, and themes"],
         "writes": ["Vault notes, properties, tasks, moves, renames, overwrites, and link-aware mutations", "Trash or permanent deletion, workspace deletion, and Sync restore or other mutating Sync actions", "Publish or unpublish actions, plugin or theme installation and changes, URL opening, arbitrary registered command execution, and JavaScript eval"]
       },
       "capabilities": {
@@ -249,11 +249,11 @@
         "arbitrary_execution": true,
         "oauth": false,
         "destructive": true,
-        "details": ["No enforcement wrapper ships here; the calling harness must default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations", "Prefer exact vault and path parameters because omitted targets can resolve to the active vault or file", "Treat plugin commands and JavaScript eval as open-world execution with possible filesystem and network effects"]
+        "details": ["No enforcement wrapper ships here; the calling harness must constrain commands, arguments, and flags, and default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations", "For bounded file operations require explicit vault= plus path= and reject dangerous flags such as overwrite unless separately approved", "Treat plugin commands and JavaScript eval as open-world execution with possible filesystem and network effects"]
       },
       "confirmation": {
         "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "publish", "overwrite", "delete", "arbitrary_execution", "destructive"],
-        "notes": "Confirm broad reads, overwrites, bulk or link-affecting moves, Sync control or restore, deletion, publish or unpublish, URL opening, plugin or theme changes, arbitrary command, and eval; use the normal local-edit gate only for a single bounded note edit."
+        "notes": "Confirm broad or implicit-target reads, overwrites or overwrite flags, bulk or link-affecting moves, Sync control or restore, deletion, publish or unpublish, URL opening, plugin or theme changes, arbitrary command, and eval; use the normal local-edit gate only when vault= and path= bound a single note edit."
       },
       "risk_tags": ["local-data", "sensitive-read", "read-write", "remote-write", "publish-capable", "overwrite-capable", "delete-capable", "arbitrary-execution", "destructive-capable", "open-world", "network-capable"],
       "maturity": "verified",
@@ -319,12 +319,12 @@
       "installation": {
         "automatic": false,
         "scope": "project_or_user",
-        "prerequisites": ["Tolaria for macOS, Windows, or Linux", "A mounted local vault", "A supported MCP client configured manually"]
+        "prerequisites": ["Tolaria for macOS, Windows, or Linux", "A mounted local vault", "A supported external MCP client configured manually"]
       },
       "data_boundary": {
         "credentials": ["Optional Git credentials for cloning an additional vault remain with system Git"],
         "reads": ["Markdown and YAML frontmatter in explicitly mounted local vaults"],
-        "writes": ["Create, append, or full-content update of notes in mounted vaults", "Attach an existing vault or clone one into a local directory through system Git", "Selected MCP client configuration during manual setup"]
+        "writes": ["Create, append, or full-content update of notes in mounted vaults", "Attach an existing vault or clone one into a local directory through system Git", "Transient Tolaria UI state through open_note, highlight_editor, and refresh_vault", "Selected MCP client configuration during manual setup"]
       },
       "capabilities": {
         "read": true,
@@ -337,7 +337,7 @@
         "arbitrary_execution": false,
         "oauth": false,
         "destructive": true,
-        "details": ["Treat full-content update_note as overwrite-capable even though its MCP annotation says non-destructive", "Prefer get_note, diff review, and expectedMtime before update_note", "The MCP mutation surface is limited to create, append, update, attach, and local clone operations", "Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them"]
+        "details": ["Treat full-content update_note as overwrite-capable even though its MCP annotation says non-destructive", "Prefer get_note, diff review, and expectedMtime before update_note", "The MCP content-mutation surface is limited to create, append, update, attach, and local clone operations; open, highlight, and refresh also change transient UI state", "Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them"]
       },
       "confirmation": {
         "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "overwrite", "destructive"],
@@ -346,7 +346,7 @@
       "risk_tags": ["local-data", "sensitive-read", "read-write", "overwrite-capable", "destructive-capable", "mcp-config"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
-      "evidence": ["https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/site/guides/use-ai-panel.md", "https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/mcp-server/index.js", "https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/docs/adr/0158-vault-write-mcp-tools-update-and-append.md"],
+      "evidence": ["https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/site/concepts/ai.md", "https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/mcp-server/index.js", "https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/docs/adr/0158-vault-write-mcp-tools-update-and-append.md"],
       "health_check": "Start Tolaria, list mounted vaults, read vault context, run a bounded search, then use a disposable note for any write smoke test.",
       "uninstall": {
         "instructions": "Remove the Tolaria MCP entry from each configured client; preserve the Tolaria application and every vault unless separate removal is requested.",

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "integrations": [
     {
       "id": "agent-skills",
@@ -20,20 +20,30 @@
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": false,
         "write": true,
+        "remote_write": false,
         "publish": false,
+        "overwrite": true,
+        "delete": true,
+        "arbitrary_execution": false,
+        "oauth": false,
         "destructive": true,
         "details": ["Install and diff explicitly selected skills", "Update can replace an installed skill directory; uninstall removes it"]
       },
       "confirmation": {
-        "required_for": ["external_install", "write", "destructive"],
+        "required_for": ["external_install", "write", "overwrite", "delete", "destructive"],
         "notes": "Review the selected skill, destination, diff, and local modifications before installation, replacement, or removal."
       },
-      "risk_tags": ["external-install", "project-files", "replacement", "removal"],
+      "risk_tags": ["external-install", "project-files", "replacement", "removal", "overwrite-capable", "delete-capable", "destructive-capable"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
+      "evidence": ["https://github.com/conorbronsdon/agent-skills"],
       "health_check": "Use the repository's documented diff and validation workflow for the selected skill.",
-      "uninstall": "Remove only the installed skill directory after reviewing local modifications."
+      "uninstall": {
+        "instructions": "Remove only the installed skill directory after reviewing and preserving any local modifications.",
+        "removes_user_data": true
+      }
     },
     {
       "id": "agent-workspace",
@@ -54,20 +64,30 @@
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": false,
         "write": true,
+        "remote_write": false,
         "publish": false,
+        "overwrite": false,
+        "delete": true,
+        "arbitrary_execution": false,
+        "oauth": false,
         "destructive": true,
-        "details": ["Session lifecycle", "State reconciliation", "Optional stale worktree cleanup"]
+        "details": ["Session lifecycle", "State reconciliation", "Optional stale worktree cleanup and removal"]
       },
       "confirmation": {
-        "required_for": ["external_install", "write", "destructive"],
+        "required_for": ["external_install", "write", "delete", "destructive"],
         "notes": "Recovery is read-only by default; require approval before cleanup or state mutation."
       },
-      "risk_tags": ["local-state", "git", "cleanup"],
+      "risk_tags": ["local-state", "git", "cleanup", "delete-capable", "destructive-capable"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
+      "evidence": ["https://github.com/conorbronsdon/agent-workspace"],
       "health_check": "Run the package's documented validation and a read-only start or reconcile workflow.",
-      "uninstall": "Remove the installed adapters only after preserving any workspace state the user wants to keep."
+      "uninstall": {
+        "instructions": "Remove the installed adapters only after preserving any workspace state the user wants to keep.",
+        "removes_user_data": false
+      }
     },
     {
       "id": "ai-tools-for-creators",
@@ -88,8 +108,14 @@
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": false,
         "write": false,
+        "remote_write": false,
         "publish": false,
+        "overwrite": false,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": false,
         "destructive": false,
         "details": ["Discovery links only; every linked tool needs separate review"]
       },
@@ -100,13 +126,17 @@
       "risk_tags": ["catalog", "third-party-links", "drift-prone"],
       "maturity": "listed",
       "last_verified": "2026-08-15",
+      "evidence": ["https://github.com/conorbronsdon/ai-tools-for-creators"],
       "health_check": "Open the linked project's current source and verify its own installation and safety claims.",
-      "uninstall": "No installation is performed by this catalog entry."
+      "uninstall": {
+        "instructions": "No installation is performed by this catalog entry.",
+        "removes_user_data": false
+      }
     },
     {
       "id": "beads-gemini",
       "name": "Beads for Gemini CLI",
-      "summary": "A project-scoped Gemini integration for Beads issue graphs and persistent agent coordination state.",
+      "summary": "A Gemini integration for Beads issue graphs and persistent coordination state; project scope is available, but the documented setup default is user-global.",
       "source_url": "https://beads.gascity.com/integrations/gemini",
       "kind": "agent_extension",
       "supported_agents": ["gemini_cli"],
@@ -122,25 +152,35 @@
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": false,
         "write": true,
+        "remote_write": true,
         "publish": false,
+        "overwrite": true,
+        "delete": true,
+        "arbitrary_execution": false,
+        "oauth": false,
         "destructive": true,
-        "details": ["Prefer project-scoped bd setup gemini --project over the global default", "bd init can modify agent instructions and configure a remote", "Remote sync and reset operations need separate review"]
+        "details": ["bd setup gemini writes user-global hooks by default; prefer bd setup gemini --project for repository scope", "bd init can modify agent instructions and configure a remote", "bd dolt push --force can overwrite remote history, and bd init --discard-remote discards remote state"]
       },
       "confirmation": {
-        "required_for": ["credential_setup", "external_install", "write", "destructive"],
-        "notes": "Confirm initialization and setup after showing the project diff; separately confirm remote sync, migrations, fixes, delete or purge, and every reset operation."
+        "required_for": ["credential_setup", "external_install", "write", "write_remote", "overwrite", "delete", "destructive"],
+        "notes": "Confirm initialization and setup after showing the project or user-config diff; separately confirm every remote sync or push, force push, discard-remote operation, migration, fix, delete, purge, and reset."
       },
-      "risk_tags": ["local-state", "hooks", "project-config", "remote-sync", "destructive-capable"],
+      "risk_tags": ["local-state", "hooks", "project-config", "remote-write", "overwrite-capable", "delete-capable", "destructive-capable"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
+      "evidence": ["https://beads.gascity.com/integrations/gemini", "https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/cli-reference/dolt.md"],
       "health_check": "Run bd version, bd doctor, bd setup gemini --check, and a bounded bd ready --json query.",
-      "uninstall": "Remove only the Gemini integration with the documented project or user --remove command; back up first and require separate confirmation before a full project reset."
+      "uninstall": {
+        "instructions": "Remove only the Gemini integration with the documented project or user --remove command; preserve the Beads project database unless separate deletion is approved.",
+        "removes_user_data": false
+      }
     },
     {
       "id": "granola-mcp",
       "name": "Granola MCP",
-      "summary": "Granola's official hosted, read-only MCP for meeting notes and plan-dependent transcripts.",
+      "summary": "Granola's official hosted, read-only MCP for sensitive meeting notes and plan-dependent transcripts.",
       "source_url": "https://docs.granola.ai/help-center/sharing/integrations/mcp",
       "kind": "mcp_server",
       "supported_agents": ["claude_code", "generic"],
@@ -156,54 +196,74 @@
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": true,
         "write": false,
+        "remote_write": false,
         "publish": false,
+        "overwrite": false,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": true,
         "destructive": false,
-        "details": ["Do not ingest meeting data automatically at startup", "Ask before raw transcript retrieval or broad multi-meeting search", "Free and Business plans may use anonymized data for Granola model improvement by default, with an account opt-out documented", "Voice-memo transcript availability through MCP is not guaranteed by current documentation"]
+        "details": ["Do not ingest meeting data automatically at startup; ask before raw transcript retrieval or broad multi-meeting search", "Notes and transcripts are retained indefinitely by default and stored in AWS in the United States", "Granola states it is not currently HIPAA or FERPA compliant, and meeting-participant consent remains the user's responsibility", "Basic access is limited to personal notes from the last 30 days; folder, search, and transcript tools can require a paid plan", "Free and Business plans may use anonymized data for model improvement by default, with an account opt-out documented", "Granola can transcribe voice memos, but current MCP documentation guarantees meeting-note and transcript tools rather than voice-memo coverage"]
       },
       "confirmation": {
-        "required_for": ["credential_setup", "external_install"],
-        "notes": "Require explicit OAuth, verify the active account and workspace, and ask before transcript retrieval, broad searches, or moving meeting content elsewhere."
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "oauth"],
+        "notes": "Require explicit OAuth, verify the active account and workspace, and ask before transcript retrieval, broad searches, or moving meeting content elsewhere; confirm participant-consent obligations before use."
       },
-      "risk_tags": ["sensitive-read", "oauth", "hosted", "transcripts", "plan-limited"],
+      "risk_tags": ["sensitive-read", "oauth", "hosted", "transcripts", "plan-limited", "us-data-residency", "indefinite-retention", "consent-required"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
+      "evidence": ["https://docs.granola.ai/help-center/sharing/integrations/mcp", "https://docs.granola.ai/help-center/consent-security-privacy/security-privacy-data-faqs", "https://docs.granola.ai/help-center/getting-started/setting-up-granola-for-the-first-time"],
       "health_check": "After OAuth, call get_account_info to verify the exact account and workspace, then run a narrowly bounded list_meetings request.",
-      "uninstall": "Disconnect Granola in the client and remove the MCP entry; do not claim token revocation unless the current client documents it."
+      "uninstall": {
+        "instructions": "Disconnect Granola in the client and remove the MCP entry; do not claim token revocation unless the current client documents it.",
+        "removes_user_data": false
+      }
     },
     {
       "id": "obsidian",
       "name": "Obsidian CLI",
-      "summary": "Obsidian's official desktop CLI for scoped access to local Markdown vaults; no MCP server is required.",
+      "summary": "Obsidian's official desktop CLI exposes broad local application and vault capabilities; scope is enforceable only through an exact external command allowlist.",
       "source_url": "https://obsidian.md/help/cli",
       "kind": "editor_guide",
       "supported_agents": ["claude_code", "codex", "gemini_cli", "generic"],
       "installation": {
         "automatic": false,
         "scope": "project_or_user",
-        "prerequisites": ["Obsidian desktop 1.12.7 or newer", "The command line interface enabled on PATH", "Obsidian running for CLI calls"]
+        "prerequisites": ["Obsidian desktop 1.12.7 or newer", "The command line interface enabled on PATH", "Obsidian running for CLI calls", "An exact command allowlist enforced by the calling harness"]
       },
       "data_boundary": {
         "credentials": ["Optional Obsidian Sync or Publish credentials remain inside Obsidian"],
-        "reads": ["Explicitly selected local vault notes, properties, tasks, backlinks, and history"],
-        "writes": ["Vault notes, properties, tasks, moves, and renames", "Trash or permanent deletion", "Publish or unpublish actions", "Plugin changes and arbitrary Obsidian command or eval execution"]
+        "reads": ["The active vault and active file by default, or explicitly targeted vault notes, properties, tasks, backlinks, history, workspaces, plugins, and themes"],
+        "writes": ["Vault notes, properties, tasks, moves, renames, overwrites, and link-aware mutations", "Trash or permanent deletion, workspace deletion, and Sync restore or other mutating Sync actions", "Publish or unpublish actions, plugin or theme installation and changes, URL opening, arbitrary registered command execution, and JavaScript eval"]
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": true,
         "write": true,
+        "remote_write": true,
         "publish": true,
+        "overwrite": true,
+        "delete": true,
+        "arbitrary_execution": true,
+        "oauth": false,
         "destructive": true,
-        "details": ["Prefer exact vault and path parameters over ambiguous file resolution", "Use the Obsidian CLI for link-aware moves and renames", "Deny arbitrary eval and command by default"]
+        "details": ["No enforcement wrapper ships here; the calling harness must default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations", "Prefer exact vault and path parameters because omitted targets can resolve to the active vault or file", "Treat plugin commands and JavaScript eval as open-world execution with possible filesystem and network effects"]
       },
       "confirmation": {
-        "required_for": ["credential_setup", "external_install", "write", "publish", "destructive"],
-        "notes": "Confirm overwrites, bulk or link-affecting moves, sync control, deletion, publish or unpublish, plugin changes, arbitrary command, and eval; use the normal local-edit gate for a single bounded note edit."
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "publish", "overwrite", "delete", "arbitrary_execution", "destructive"],
+        "notes": "Confirm broad reads, overwrites, bulk or link-affecting moves, Sync control or restore, deletion, publish or unpublish, URL opening, plugin or theme changes, arbitrary command, and eval; use the normal local-edit gate only for a single bounded note edit."
       },
-      "risk_tags": ["local-data", "read-write", "publish-capable", "destructive-capable", "arbitrary-eval"],
+      "risk_tags": ["local-data", "sensitive-read", "read-write", "remote-write", "publish-capable", "overwrite-capable", "delete-capable", "arbitrary-execution", "destructive-capable", "open-world", "network-capable"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
-      "health_check": "Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1.",
-      "uninstall": "Disable the CLI or remove the harness allowlist; do not delete, unregister, or alter the vault unless separately requested."
+      "evidence": ["https://obsidian.md/help/cli"],
+      "health_check": "Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1 through the enforced allowlist.",
+      "uninstall": {
+        "instructions": "Disable the Obsidian CLI or remove its executable from the calling client's configuration or PATH; leave the vault, Sync, Publish, plugins, and themes unchanged.",
+        "removes_user_data": false
+      }
     },
     {
       "id": "substack-mcp",
@@ -224,54 +284,74 @@
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": true,
         "write": true,
+        "remote_write": true,
         "publish": true,
+        "overwrite": false,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": false,
         "destructive": false,
-        "details": ["No long-form publish, delete, or schedule mutation", "Note creation publishes immediately and has no server-side undo"]
+        "details": ["Long-form tooling is draft-only; scheduling and public-post mutation are unavailable", "Note creation publishes immediately and has no server-side undo"]
       },
       "confirmation": {
-        "required_for": ["credential_setup", "external_install", "write", "publish"],
-        "notes": "Always confirm Note creation as an immediate public publish action; private draft writes use the normal external-write gate."
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "publish"],
+        "notes": "Always confirm Note creation as an immediate public publish action; private draft writes use the normal external-write gate, and broad analytics or subscriber reads require a sensitive-read gate."
       },
-      "risk_tags": ["credentials", "external-data", "public-publish", "unofficial-api"],
+      "risk_tags": ["credentials", "external-data", "sensitive-read", "remote-write", "publish-capable", "public-publish", "unofficial-api"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
+      "evidence": ["https://github.com/conorbronsdon/substack-mcp"],
       "health_check": "After explicit authentication, run the documented subscriber-count read and verify the expected publication account.",
-      "uninstall": "Remove the MCP client entry and, if used, review then remove the local browser-login session file."
+      "uninstall": {
+        "instructions": "Remove the MCP client entry and, if used, review then remove the local browser-login session file.",
+        "removes_user_data": false
+      }
     },
     {
       "id": "tolaria",
-      "name": "Tolaria",
-      "summary": "A local-first Markdown vault desktop app with a bundled stdio MCP and embedded coding-agent interface.",
+      "name": "Tolaria MCP",
+      "summary": "Tolaria's bundled stdio MCP for bounded Markdown-vault reads and note mutations; this entry excludes Tolaria's embedded agents, direct provider models, and AutoGit.",
       "source_url": "https://github.com/refactoringhq/tolaria",
       "kind": "local_workspace",
-      "supported_agents": ["claude_code", "codex", "opencode", "generic"],
+      "supported_agents": ["claude_code", "cursor", "opencode", "generic"],
       "installation": {
         "automatic": false,
         "scope": "project_or_user",
-        "prerequisites": ["Tolaria for macOS, Windows, or Linux", "A mounted local vault", "The separately installed and authenticated agent CLI selected by the user"]
+        "prerequisites": ["Tolaria for macOS, Windows, or Linux", "A mounted local vault", "A supported MCP client configured manually"]
       },
       "data_boundary": {
-        "credentials": ["Agent or API credentials remain with the selected CLI or provider", "Optional Git remote credentials remain with system Git"],
-        "reads": ["Markdown and YAML frontmatter in explicitly mounted vaults"],
-        "writes": ["Create, append, or full-content update of notes in mounted vaults", "Attach an additional vault or clone one through system Git"]
+        "credentials": ["Optional Git credentials for cloning an additional vault remain with system Git"],
+        "reads": ["Markdown and YAML frontmatter in explicitly mounted local vaults"],
+        "writes": ["Create, append, or full-content update of notes in mounted vaults", "Attach an existing vault or clone one into a local directory through system Git", "Selected MCP client configuration during manual setup"]
       },
       "capabilities": {
         "read": true,
+        "sensitive_read": true,
         "write": true,
+        "remote_write": false,
         "publish": false,
+        "overwrite": true,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": false,
         "destructive": true,
-        "details": ["Treat full-content update_note as overwrite-capable even though its MCP annotation says non-destructive", "Prefer get_note, diff review, and expectedMtime before update_note", "Git can replicate vault contents and direct cloud-agent targets may send selected note context to their provider", "Bundled MCP documents no delete or publish tool, but a native agent can have broader file or shell access"]
+        "details": ["Treat full-content update_note as overwrite-capable even though its MCP annotation says non-destructive", "Prefer get_note, diff review, and expectedMtime before update_note", "The MCP mutation surface is limited to create, append, update, attach, and local clone operations", "Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them"]
       },
       "confirmation": {
-        "required_for": ["credential_setup", "external_install", "write", "destructive"],
-        "notes": "Use normal approval for a single create or append; show a diff or confirm full replacement, bulk edits, vault attachment or clone, Power User mode, Git push, and broader native-agent actions."
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "overwrite", "destructive"],
+        "notes": "Use normal approval for a single create or append; confirm broad vault reads, show a diff before full replacement, and separately approve vault attachment, cloning, or MCP client-configuration writes."
       },
-      "risk_tags": ["local-data", "read-write", "optional-network", "agent-execution", "overwrite-capable"],
+      "risk_tags": ["local-data", "sensitive-read", "read-write", "overwrite-capable", "destructive-capable", "mcp-config"],
       "maturity": "verified",
       "last_verified": "2026-08-15",
+      "evidence": ["https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/site/guides/use-ai-panel.md", "https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/mcp-server/index.js", "https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/docs/adr/0158-vault-write-mcp-tools-update-and-append.md"],
       "health_check": "Start Tolaria, list mounted vaults, read vault context, run a bounded search, then use a disposable note for any write smoke test.",
-      "uninstall": "Remove any manually added MCP entry and uninstall the app; preserve all vaults unless deletion is separately confirmed."
+      "uninstall": {
+        "instructions": "Remove the Tolaria MCP entry from each configured client; preserve the Tolaria application and every vault unless separate removal is requested.",
+        "removes_user_data": false
+      }
     }
   ]
 }

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -3,16 +3,16 @@
 
 These add-ons are **references, not bundled dependencies**. Setup does not install, activate, authenticate, or expand permissions for any entry. Review the current source, data boundary, and side effects before opting in. `verified` means the catalog metadata was checked against the linked source on the stated date; it is not a live authentication or end-to-end test. `listed` and `experimental` are leads, not endorsements.
 
-| Integration | Kind | Maturity | Writes | Publishes | Destructive | Last verified |
-|---|---|---|---:|---:|---:|---|
-| [Agent Skills](https://github.com/conorbronsdon/agent-skills) | `skill_catalog` | verified | Yes | No | Yes | 2026-08-15 |
-| [Agent Workspace](https://github.com/conorbronsdon/agent-workspace) | `workspace_template` | verified | Yes | No | Yes | 2026-08-15 |
-| [AI Tools for Creators](https://github.com/conorbronsdon/ai-tools-for-creators) | `resource_catalog` | listed | No | No | No | 2026-08-15 |
-| [Beads for Gemini CLI](https://beads.gascity.com/integrations/gemini) | `agent_extension` | verified | Yes | No | Yes | 2026-08-15 |
-| [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp) | `mcp_server` | verified | No | No | No | 2026-08-15 |
-| [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | 2026-08-15 |
-| [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | No | 2026-08-15 |
-| [Tolaria](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | Yes | 2026-08-15 |
+| Integration | Kind | Maturity | Writes | Remote writes | Publishes | Sensitive reads | Destructive | Last verified |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| [Agent Skills](https://github.com/conorbronsdon/agent-skills) | `skill_catalog` | verified | Yes | No | No | No | Yes | 2026-08-15 |
+| [Agent Workspace](https://github.com/conorbronsdon/agent-workspace) | `workspace_template` | verified | Yes | No | No | No | Yes | 2026-08-15 |
+| [AI Tools for Creators](https://github.com/conorbronsdon/ai-tools-for-creators) | `resource_catalog` | listed | No | No | No | No | No | 2026-08-15 |
+| [Beads for Gemini CLI](https://beads.gascity.com/integrations/gemini) | `agent_extension` | verified | Yes | Yes | No | No | Yes | 2026-08-15 |
+| [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-15 |
+| [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-15 |
+| [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
+| [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
 
 ## Agent Skills
 
@@ -24,10 +24,13 @@ A source catalog and installer for portable agent skills.
 - **Credentials:** None
 - **Reads:** Selected public skill source files
 - **Writes / external effects:** Chosen skill files in an agent-specific project or user directory, including replacement or removal of an existing installation
+- **Typed safety signals:** overwrite, delete
+- **Required confirmation gates:** `external_install`, `write`, `overwrite`, `delete`, `destructive`
 - **Confirmation:** Review the selected skill, destination, diff, and local modifications before installation, replacement, or removal.
-- **Risk tags:** `external-install`, `project-files`, `replacement`, `removal`
+- **Risk tags:** `external-install`, `project-files`, `replacement`, `removal`, `overwrite-capable`, `delete-capable`, `destructive-capable`
+- **Evidence:** [1](https://github.com/conorbronsdon/agent-skills)
 - **Health check:** Use the repository's documented diff and validation workflow for the selected skill.
-- **Uninstall:** Remove only the installed skill directory after reviewing local modifications.
+- **Uninstall:** Remove only the installed skill directory after reviewing and preserving any local modifications. (removes user data: Yes)
 
 Capabilities and limits:
 
@@ -45,16 +48,19 @@ A slim standalone package for agent lifecycle, state, reconciliation, and recove
 - **Credentials:** None
 - **Reads:** Local workspace state, sessions, branches, and worktrees
 - **Writes / external effects:** Local workspace state and session files after workflow approval; Optional removal of explicitly approved stale worktrees or branches
+- **Typed safety signals:** delete
+- **Required confirmation gates:** `external_install`, `write`, `delete`, `destructive`
 - **Confirmation:** Recovery is read-only by default; require approval before cleanup or state mutation.
-- **Risk tags:** `local-state`, `git`, `cleanup`
+- **Risk tags:** `local-state`, `git`, `cleanup`, `delete-capable`, `destructive-capable`
+- **Evidence:** [1](https://github.com/conorbronsdon/agent-workspace)
 - **Health check:** Run the package's documented validation and a read-only start or reconcile workflow.
-- **Uninstall:** Remove the installed adapters only after preserving any workspace state the user wants to keep.
+- **Uninstall:** Remove the installed adapters only after preserving any workspace state the user wants to keep. (removes user data: No)
 
 Capabilities and limits:
 
 - Session lifecycle
 - State reconciliation
-- Optional stale worktree cleanup
+- Optional stale worktree cleanup and removal
 
 
 ## AI Tools for Creators
@@ -67,10 +73,13 @@ A discovery catalog for creator skills, MCP servers, benchmarks, and publishing 
 - **Credentials:** None
 - **Reads:** Public catalog documentation
 - **Writes / external effects:** None
+- **Typed safety signals:** None
+- **Required confirmation gates:** None
 - **Confirmation:** A listing is not verification. Re-check the linked source before installing or authorizing it.
 - **Risk tags:** `catalog`, `third-party-links`, `drift-prone`
+- **Evidence:** [1](https://github.com/conorbronsdon/ai-tools-for-creators)
 - **Health check:** Open the linked project's current source and verify its own installation and safety claims.
-- **Uninstall:** No installation is performed by this catalog entry.
+- **Uninstall:** No installation is performed by this catalog entry. (removes user data: No)
 
 Capabilities and limits:
 
@@ -79,7 +88,7 @@ Capabilities and limits:
 
 ## Beads for Gemini CLI
 
-A project-scoped Gemini integration for Beads issue graphs and persistent agent coordination state.
+A Gemini integration for Beads issue graphs and persistent coordination state; project scope is available, but the documented setup default is user-global.
 
 - **Supported agents:** `gemini_cli`
 - **Install scope:** `project_or_user`; never automatic
@@ -87,21 +96,24 @@ A project-scoped Gemini integration for Beads issue graphs and persistent agent 
 - **Credentials:** Optional Dolt, Git, or cloud remote credentials stay with their configured clients
 - **Reads:** Local issue descriptions, comments, dependencies, memories, readiness, and coordination state
 - **Writes / external effects:** The project Beads database; Project or user Gemini hooks and instructions; Optional remote issue-history sync or push; Issue deletion, purge, migration, repair, or reset when explicitly invoked
-- **Confirmation:** Confirm initialization and setup after showing the project diff; separately confirm remote sync, migrations, fixes, delete or purge, and every reset operation.
-- **Risk tags:** `local-state`, `hooks`, `project-config`, `remote-sync`, `destructive-capable`
+- **Typed safety signals:** remote write, overwrite, delete
+- **Required confirmation gates:** `credential_setup`, `external_install`, `write`, `write_remote`, `overwrite`, `delete`, `destructive`
+- **Confirmation:** Confirm initialization and setup after showing the project or user-config diff; separately confirm every remote sync or push, force push, discard-remote operation, migration, fix, delete, purge, and reset.
+- **Risk tags:** `local-state`, `hooks`, `project-config`, `remote-write`, `overwrite-capable`, `delete-capable`, `destructive-capable`
+- **Evidence:** [1](https://beads.gascity.com/integrations/gemini); [2](https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/cli-reference/dolt.md)
 - **Health check:** Run bd version, bd doctor, bd setup gemini --check, and a bounded bd ready --json query.
-- **Uninstall:** Remove only the Gemini integration with the documented project or user --remove command; back up first and require separate confirmation before a full project reset.
+- **Uninstall:** Remove only the Gemini integration with the documented project or user --remove command; preserve the Beads project database unless separate deletion is approved. (removes user data: No)
 
 Capabilities and limits:
 
-- Prefer project-scoped bd setup gemini --project over the global default
+- bd setup gemini writes user-global hooks by default; prefer bd setup gemini --project for repository scope
 - bd init can modify agent instructions and configure a remote
-- Remote sync and reset operations need separate review
+- bd dolt push --force can overwrite remote history, and bd init --discard-remote discards remote state
 
 
 ## Granola MCP
 
-Granola's official hosted, read-only MCP for meeting notes and plan-dependent transcripts.
+Granola's official hosted, read-only MCP for sensitive meeting notes and plan-dependent transcripts.
 
 - **Supported agents:** `claude_code`, `generic`
 - **Install scope:** `user`; never automatic
@@ -109,39 +121,47 @@ Granola's official hosted, read-only MCP for meeting notes and plan-dependent tr
 - **Credentials:** Per-user browser OAuth bearer token; never copy it into repository configuration or logs
 - **Reads:** Owned, directly shared, private-folder-shared, or workspace-public notes allowed by the active account and plan; Account information, meeting folders, meeting notes, searches, and plan-dependent transcripts that enter the connected model context
 - **Writes / external effects:** None
-- **Confirmation:** Require explicit OAuth, verify the active account and workspace, and ask before transcript retrieval, broad searches, or moving meeting content elsewhere.
-- **Risk tags:** `sensitive-read`, `oauth`, `hosted`, `transcripts`, `plan-limited`
+- **Typed safety signals:** sensitive read, oauth
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `oauth`
+- **Confirmation:** Require explicit OAuth, verify the active account and workspace, and ask before transcript retrieval, broad searches, or moving meeting content elsewhere; confirm participant-consent obligations before use.
+- **Risk tags:** `sensitive-read`, `oauth`, `hosted`, `transcripts`, `plan-limited`, `us-data-residency`, `indefinite-retention`, `consent-required`
+- **Evidence:** [1](https://docs.granola.ai/help-center/sharing/integrations/mcp); [2](https://docs.granola.ai/help-center/consent-security-privacy/security-privacy-data-faqs); [3](https://docs.granola.ai/help-center/getting-started/setting-up-granola-for-the-first-time)
 - **Health check:** After OAuth, call get\_account\_info to verify the exact account and workspace, then run a narrowly bounded list\_meetings request.
-- **Uninstall:** Disconnect Granola in the client and remove the MCP entry; do not claim token revocation unless the current client documents it.
+- **Uninstall:** Disconnect Granola in the client and remove the MCP entry; do not claim token revocation unless the current client documents it. (removes user data: No)
 
 Capabilities and limits:
 
-- Do not ingest meeting data automatically at startup
-- Ask before raw transcript retrieval or broad multi-meeting search
-- Free and Business plans may use anonymized data for Granola model improvement by default, with an account opt-out documented
-- Voice-memo transcript availability through MCP is not guaranteed by current documentation
+- Do not ingest meeting data automatically at startup; ask before raw transcript retrieval or broad multi-meeting search
+- Notes and transcripts are retained indefinitely by default and stored in AWS in the United States
+- Granola states it is not currently HIPAA or FERPA compliant, and meeting-participant consent remains the user's responsibility
+- Basic access is limited to personal notes from the last 30 days; folder, search, and transcript tools can require a paid plan
+- Free and Business plans may use anonymized data for model improvement by default, with an account opt-out documented
+- Granola can transcribe voice memos, but current MCP documentation guarantees meeting-note and transcript tools rather than voice-memo coverage
 
 
 ## Obsidian CLI
 
-Obsidian's official desktop CLI for scoped access to local Markdown vaults; no MCP server is required.
+Obsidian's official desktop CLI exposes broad local application and vault capabilities; scope is enforceable only through an exact external command allowlist.
 
 - **Supported agents:** `claude_code`, `codex`, `gemini_cli`, `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** Obsidian desktop 1.12.7 or newer; The command line interface enabled on PATH; Obsidian running for CLI calls
+- **Prerequisites:** Obsidian desktop 1.12.7 or newer; The command line interface enabled on PATH; Obsidian running for CLI calls; An exact command allowlist enforced by the calling harness
 - **Credentials:** Optional Obsidian Sync or Publish credentials remain inside Obsidian
-- **Reads:** Explicitly selected local vault notes, properties, tasks, backlinks, and history
-- **Writes / external effects:** Vault notes, properties, tasks, moves, and renames; Trash or permanent deletion; Publish or unpublish actions; Plugin changes and arbitrary Obsidian command or eval execution
-- **Confirmation:** Confirm overwrites, bulk or link-affecting moves, sync control, deletion, publish or unpublish, plugin changes, arbitrary command, and eval; use the normal local-edit gate for a single bounded note edit.
-- **Risk tags:** `local-data`, `read-write`, `publish-capable`, `destructive-capable`, `arbitrary-eval`
-- **Health check:** Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1.
-- **Uninstall:** Disable the CLI or remove the harness allowlist; do not delete, unregister, or alter the vault unless separately requested.
+- **Reads:** The active vault and active file by default, or explicitly targeted vault notes, properties, tasks, backlinks, history, workspaces, plugins, and themes
+- **Writes / external effects:** Vault notes, properties, tasks, moves, renames, overwrites, and link-aware mutations; Trash or permanent deletion, workspace deletion, and Sync restore or other mutating Sync actions; Publish or unpublish actions, plugin or theme installation and changes, URL opening, arbitrary registered command execution, and JavaScript eval
+- **Typed safety signals:** sensitive read, remote write, overwrite, delete, arbitrary execution
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `publish`, `overwrite`, `delete`, `arbitrary_execution`, `destructive`
+- **Confirmation:** Confirm broad reads, overwrites, bulk or link-affecting moves, Sync control or restore, deletion, publish or unpublish, URL opening, plugin or theme changes, arbitrary command, and eval; use the normal local-edit gate only for a single bounded note edit.
+- **Risk tags:** `local-data`, `sensitive-read`, `read-write`, `remote-write`, `publish-capable`, `overwrite-capable`, `delete-capable`, `arbitrary-execution`, `destructive-capable`, `open-world`, `network-capable`
+- **Evidence:** [1](https://obsidian.md/help/cli)
+- **Health check:** Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1 through the enforced allowlist.
+- **Uninstall:** Disable the Obsidian CLI or remove its executable from the calling client's configuration or PATH; leave the vault, Sync, Publish, plugins, and themes unchanged. (removes user data: No)
 
 Capabilities and limits:
 
-- Prefer exact vault and path parameters over ambiguous file resolution
-- Use the Obsidian CLI for link-aware moves and renames
-- Deny arbitrary eval and command by default
+- No enforcement wrapper ships here; the calling harness must default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations
+- Prefer exact vault and path parameters because omitted targets can resolve to the active vault or file
+- Treat plugin commands and JavaScript eval as open-world execution with possible filesystem and network effects
 
 
 ## Substack MCP
@@ -154,36 +174,42 @@ An MCP server for reading Substack publication data, managing private drafts, an
 - **Credentials:** Publication URL; Session token; User ID; Optional machine-bound browser-login session file
 - **Reads:** Subscriber count, posts, drafts, comments, sections, analytics, and schedules
 - **Writes / external effects:** Private long-form drafts; Publicly fetchable image uploads; Immediately public Notes
-- **Confirmation:** Always confirm Note creation as an immediate public publish action; private draft writes use the normal external-write gate.
-- **Risk tags:** `credentials`, `external-data`, `public-publish`, `unofficial-api`
+- **Typed safety signals:** sensitive read, remote write
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `publish`
+- **Confirmation:** Always confirm Note creation as an immediate public publish action; private draft writes use the normal external-write gate, and broad analytics or subscriber reads require a sensitive-read gate.
+- **Risk tags:** `credentials`, `external-data`, `sensitive-read`, `remote-write`, `publish-capable`, `public-publish`, `unofficial-api`
+- **Evidence:** [1](https://github.com/conorbronsdon/substack-mcp)
 - **Health check:** After explicit authentication, run the documented subscriber-count read and verify the expected publication account.
-- **Uninstall:** Remove the MCP client entry and, if used, review then remove the local browser-login session file.
+- **Uninstall:** Remove the MCP client entry and, if used, review then remove the local browser-login session file. (removes user data: No)
 
 Capabilities and limits:
 
-- No long-form publish, delete, or schedule mutation
+- Long-form tooling is draft-only; scheduling and public-post mutation are unavailable
 - Note creation publishes immediately and has no server-side undo
 
 
-## Tolaria
+## Tolaria MCP
 
-A local-first Markdown vault desktop app with a bundled stdio MCP and embedded coding-agent interface.
+Tolaria's bundled stdio MCP for bounded Markdown-vault reads and note mutations; this entry excludes Tolaria's embedded agents, direct provider models, and AutoGit.
 
-- **Supported agents:** `claude_code`, `codex`, `opencode`, `generic`
+- **Supported agents:** `claude_code`, `cursor`, `opencode`, `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** Tolaria for macOS, Windows, or Linux; A mounted local vault; The separately installed and authenticated agent CLI selected by the user
-- **Credentials:** Agent or API credentials remain with the selected CLI or provider; Optional Git remote credentials remain with system Git
-- **Reads:** Markdown and YAML frontmatter in explicitly mounted vaults
-- **Writes / external effects:** Create, append, or full-content update of notes in mounted vaults; Attach an additional vault or clone one through system Git
-- **Confirmation:** Use normal approval for a single create or append; show a diff or confirm full replacement, bulk edits, vault attachment or clone, Power User mode, Git push, and broader native-agent actions.
-- **Risk tags:** `local-data`, `read-write`, `optional-network`, `agent-execution`, `overwrite-capable`
+- **Prerequisites:** Tolaria for macOS, Windows, or Linux; A mounted local vault; A supported MCP client configured manually
+- **Credentials:** Optional Git credentials for cloning an additional vault remain with system Git
+- **Reads:** Markdown and YAML frontmatter in explicitly mounted local vaults
+- **Writes / external effects:** Create, append, or full-content update of notes in mounted vaults; Attach an existing vault or clone one into a local directory through system Git; Selected MCP client configuration during manual setup
+- **Typed safety signals:** sensitive read, overwrite
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `overwrite`, `destructive`
+- **Confirmation:** Use normal approval for a single create or append; confirm broad vault reads, show a diff before full replacement, and separately approve vault attachment, cloning, or MCP client-configuration writes.
+- **Risk tags:** `local-data`, `sensitive-read`, `read-write`, `overwrite-capable`, `destructive-capable`, `mcp-config`
+- **Evidence:** [1](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/site/guides/use-ai-panel.md); [2](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/mcp-server/index.js); [3](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/docs/adr/0158-vault-write-mcp-tools-update-and-append.md)
 - **Health check:** Start Tolaria, list mounted vaults, read vault context, run a bounded search, then use a disposable note for any write smoke test.
-- **Uninstall:** Remove any manually added MCP entry and uninstall the app; preserve all vaults unless deletion is separately confirmed.
+- **Uninstall:** Remove the Tolaria MCP entry from each configured client; preserve the Tolaria application and every vault unless separate removal is requested. (removes user data: No)
 
 Capabilities and limits:
 
 - Treat full-content update\_note as overwrite-capable even though its MCP annotation says non-destructive
 - Prefer get\_note, diff review, and expectedMtime before update\_note
-- Git can replicate vault contents and direct cloud-agent targets may send selected note context to their provider
-- Bundled MCP documents no delete or publish tool, but a native agent can have broader file or shell access
+- The MCP mutation surface is limited to create, append, update, attach, and local clone operations
+- Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them
 

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -98,9 +98,9 @@ A Gemini integration for Beads issue graphs and persistent coordination state; p
 - **Writes / external effects:** The project Beads database; Project or user Gemini hooks and instructions; Optional remote issue-history sync or push; Issue deletion, purge, migration, repair, or reset when explicitly invoked
 - **Typed safety signals:** remote write, overwrite, delete
 - **Required confirmation gates:** `credential_setup`, `external_install`, `write`, `write_remote`, `overwrite`, `delete`, `destructive`
-- **Confirmation:** Confirm initialization and setup after showing the project or user-config diff; separately confirm every remote sync or push, force push, discard-remote operation, migration, fix, delete, purge, and reset.
+- **Confirmation:** Confirm initialization and setup after showing the project or user-config diff; separately confirm divergent local initialization with discard-remote and any later remote sync or push, especially force push, plus migration, fix, delete, purge, and reset.
 - **Risk tags:** `local-state`, `hooks`, `project-config`, `remote-write`, `overwrite-capable`, `delete-capable`, `destructive-capable`
-- **Evidence:** [1](https://beads.gascity.com/integrations/gemini); [2](https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/cli-reference/dolt.md)
+- **Evidence:** [1](https://beads.gascity.com/integrations/gemini); [2](https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/cli-reference/dolt.md); [3](https://github.com/steveyegge/beads/blob/7505e173f2659ba6e1f955b86d81a4f9e21810ca/docs/recovery/init-safety.md)
 - **Health check:** Run bd version, bd doctor, bd setup gemini --check, and a bounded bd ready --json query.
 - **Uninstall:** Remove only the Gemini integration with the documented project or user --remove command; preserve the Beads project database unless separate deletion is approved. (removes user data: No)
 
@@ -108,7 +108,8 @@ Capabilities and limits:
 
 - bd setup gemini writes user-global hooks by default; prefer bd setup gemini --project for repository scope
 - bd init can modify agent instructions and configure a remote
-- bd dolt push --force can overwrite remote history, and bd init --discard-remote discards remote state
+- bd dolt push --force can overwrite remote history
+- bd init --discard-remote authorizes a divergent local initialization; a later Dolt push is the separate remote-history replacement
 
 
 ## Granola MCP
@@ -118,7 +119,7 @@ Granola's official hosted, read-only MCP for sensitive meeting notes and plan-de
 - **Supported agents:** `claude_code`, `generic`
 - **Install scope:** `user`; never automatic
 - **Prerequisites:** A Granola account with notes; An MCP client supporting Streamable HTTP and browser OAuth
-- **Credentials:** Per-user browser OAuth bearer token; never copy it into repository configuration or logs
+- **Credentials:** Per-user browser OAuth bearer token stays outside repository configuration and logs
 - **Reads:** Owned, directly shared, private-folder-shared, or workspace-public notes allowed by the active account and plan; Account information, meeting folders, meeting notes, searches, and plan-dependent transcripts that enter the connected model context
 - **Writes / external effects:** None
 - **Typed safety signals:** sensitive read, oauth
@@ -141,17 +142,17 @@ Capabilities and limits:
 
 ## Obsidian CLI
 
-Obsidian's official desktop CLI exposes broad local application and vault capabilities; scope is enforceable only through an exact external command allowlist.
+Obsidian's official desktop CLI exposes broad local application and vault capabilities; scope is enforceable only through an exact external command-and-argument policy.
 
 - **Supported agents:** `claude_code`, `codex`, `gemini_cli`, `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** Obsidian desktop 1.12.7 or newer; The command line interface enabled on PATH; Obsidian running for CLI calls; An exact command allowlist enforced by the calling harness
+- **Prerequisites:** Obsidian desktop 1.12.7 or newer; The command line interface enabled on PATH; Obsidian running for CLI calls; An exact command-and-argument policy enforced by the calling harness
 - **Credentials:** Optional Obsidian Sync or Publish credentials remain inside Obsidian
-- **Reads:** The active vault and active file by default, or explicitly targeted vault notes, properties, tasks, backlinks, history, workspaces, plugins, and themes
+- **Reads:** The current-working-directory vault when the shell is inside a vault, otherwise the active vault; many file commands then default to the active file unless vault= and path= are explicit; Explicitly targeted notes, properties, tasks, backlinks, history, workspaces, plugins, and themes
 - **Writes / external effects:** Vault notes, properties, tasks, moves, renames, overwrites, and link-aware mutations; Trash or permanent deletion, workspace deletion, and Sync restore or other mutating Sync actions; Publish or unpublish actions, plugin or theme installation and changes, URL opening, arbitrary registered command execution, and JavaScript eval
 - **Typed safety signals:** sensitive read, remote write, overwrite, delete, arbitrary execution
 - **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `publish`, `overwrite`, `delete`, `arbitrary_execution`, `destructive`
-- **Confirmation:** Confirm broad reads, overwrites, bulk or link-affecting moves, Sync control or restore, deletion, publish or unpublish, URL opening, plugin or theme changes, arbitrary command, and eval; use the normal local-edit gate only for a single bounded note edit.
+- **Confirmation:** Confirm broad or implicit-target reads, overwrites or overwrite flags, bulk or link-affecting moves, Sync control or restore, deletion, publish or unpublish, URL opening, plugin or theme changes, arbitrary command, and eval; use the normal local-edit gate only when vault= and path= bound a single note edit.
 - **Risk tags:** `local-data`, `sensitive-read`, `read-write`, `remote-write`, `publish-capable`, `overwrite-capable`, `delete-capable`, `arbitrary-execution`, `destructive-capable`, `open-world`, `network-capable`
 - **Evidence:** [1](https://obsidian.md/help/cli)
 - **Health check:** Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1 through the enforced allowlist.
@@ -159,8 +160,8 @@ Obsidian's official desktop CLI exposes broad local application and vault capabi
 
 Capabilities and limits:
 
-- No enforcement wrapper ships here; the calling harness must default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations
-- Prefer exact vault and path parameters because omitted targets can resolve to the active vault or file
+- No enforcement wrapper ships here; the calling harness must constrain commands, arguments, and flags, and default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations
+- For bounded file operations require explicit vault= plus path= and reject dangerous flags such as overwrite unless separately approved
 - Treat plugin commands and JavaScript eval as open-world execution with possible filesystem and network effects
 
 
@@ -194,15 +195,15 @@ Tolaria's bundled stdio MCP for bounded Markdown-vault reads and note mutations;
 
 - **Supported agents:** `claude_code`, `cursor`, `opencode`, `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** Tolaria for macOS, Windows, or Linux; A mounted local vault; A supported MCP client configured manually
+- **Prerequisites:** Tolaria for macOS, Windows, or Linux; A mounted local vault; A supported external MCP client configured manually
 - **Credentials:** Optional Git credentials for cloning an additional vault remain with system Git
 - **Reads:** Markdown and YAML frontmatter in explicitly mounted local vaults
-- **Writes / external effects:** Create, append, or full-content update of notes in mounted vaults; Attach an existing vault or clone one into a local directory through system Git; Selected MCP client configuration during manual setup
+- **Writes / external effects:** Create, append, or full-content update of notes in mounted vaults; Attach an existing vault or clone one into a local directory through system Git; Transient Tolaria UI state through open\_note, highlight\_editor, and refresh\_vault; Selected MCP client configuration during manual setup
 - **Typed safety signals:** sensitive read, overwrite
 - **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `overwrite`, `destructive`
 - **Confirmation:** Use normal approval for a single create or append; confirm broad vault reads, show a diff before full replacement, and separately approve vault attachment, cloning, or MCP client-configuration writes.
 - **Risk tags:** `local-data`, `sensitive-read`, `read-write`, `overwrite-capable`, `destructive-capable`, `mcp-config`
-- **Evidence:** [1](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/site/guides/use-ai-panel.md); [2](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/mcp-server/index.js); [3](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/docs/adr/0158-vault-write-mcp-tools-update-and-append.md)
+- **Evidence:** [1](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/site/concepts/ai.md); [2](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/mcp-server/index.js); [3](https://github.com/refactoringhq/tolaria/blob/c63a672a25c7450a8baf4bfbf548fe6b62964b69/docs/adr/0158-vault-write-mcp-tools-update-and-append.md)
 - **Health check:** Start Tolaria, list mounted vaults, read vault context, run a bounded search, then use a disposable note for any write smoke test.
 - **Uninstall:** Remove the Tolaria MCP entry from each configured client; preserve the Tolaria application and every vault unless separate removal is requested. (removes user data: No)
 
@@ -210,6 +211,6 @@ Capabilities and limits:
 
 - Treat full-content update\_note as overwrite-capable even though its MCP annotation says non-destructive
 - Prefer get\_note, diff review, and expectedMtime before update\_note
-- The MCP mutation surface is limited to create, append, update, attach, and local clone operations
+- The MCP content-mutation surface is limited to create, append, update, attach, and local clone operations; open, highlight, and refresh also change transient UI state
 - Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them
 

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -8,7 +8,11 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Agent Skills](https://github.com/conorbronsdon/agent-skills) | `skill_catalog` | verified | Yes | No | Yes | 2026-08-15 |
 | [Agent Workspace](https://github.com/conorbronsdon/agent-workspace) | `workspace_template` | verified | Yes | No | Yes | 2026-08-15 |
 | [AI Tools for Creators](https://github.com/conorbronsdon/ai-tools-for-creators) | `resource_catalog` | listed | No | No | No | 2026-08-15 |
+| [Beads for Gemini CLI](https://beads.gascity.com/integrations/gemini) | `agent_extension` | verified | Yes | No | Yes | 2026-08-15 |
+| [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp) | `mcp_server` | verified | No | No | No | 2026-08-15 |
+| [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | 2026-08-15 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | No | 2026-08-15 |
+| [Tolaria](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | Yes | 2026-08-15 |
 
 ## Agent Skills
 
@@ -73,6 +77,73 @@ Capabilities and limits:
 - Discovery links only; every linked tool needs separate review
 
 
+## Beads for Gemini CLI
+
+A project-scoped Gemini integration for Beads issue graphs and persistent agent coordination state.
+
+- **Supported agents:** `gemini_cli`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** The bd CLI; A deliberately initialized Beads project; Gemini CLI
+- **Credentials:** Optional Dolt, Git, or cloud remote credentials stay with their configured clients
+- **Reads:** Local issue descriptions, comments, dependencies, memories, readiness, and coordination state
+- **Writes / external effects:** The project Beads database; Project or user Gemini hooks and instructions; Optional remote issue-history sync or push; Issue deletion, purge, migration, repair, or reset when explicitly invoked
+- **Confirmation:** Confirm initialization and setup after showing the project diff; separately confirm remote sync, migrations, fixes, delete or purge, and every reset operation.
+- **Risk tags:** `local-state`, `hooks`, `project-config`, `remote-sync`, `destructive-capable`
+- **Health check:** Run bd version, bd doctor, bd setup gemini --check, and a bounded bd ready --json query.
+- **Uninstall:** Remove only the Gemini integration with the documented project or user --remove command; back up first and require separate confirmation before a full project reset.
+
+Capabilities and limits:
+
+- Prefer project-scoped bd setup gemini --project over the global default
+- bd init can modify agent instructions and configure a remote
+- Remote sync and reset operations need separate review
+
+
+## Granola MCP
+
+Granola's official hosted, read-only MCP for meeting notes and plan-dependent transcripts.
+
+- **Supported agents:** `claude_code`, `generic`
+- **Install scope:** `user`; never automatic
+- **Prerequisites:** A Granola account with notes; An MCP client supporting Streamable HTTP and browser OAuth
+- **Credentials:** Per-user browser OAuth bearer token; never copy it into repository configuration or logs
+- **Reads:** Owned, directly shared, private-folder-shared, or workspace-public notes allowed by the active account and plan; Account information, meeting folders, meeting notes, searches, and plan-dependent transcripts that enter the connected model context
+- **Writes / external effects:** None
+- **Confirmation:** Require explicit OAuth, verify the active account and workspace, and ask before transcript retrieval, broad searches, or moving meeting content elsewhere.
+- **Risk tags:** `sensitive-read`, `oauth`, `hosted`, `transcripts`, `plan-limited`
+- **Health check:** After OAuth, call get\_account\_info to verify the exact account and workspace, then run a narrowly bounded list\_meetings request.
+- **Uninstall:** Disconnect Granola in the client and remove the MCP entry; do not claim token revocation unless the current client documents it.
+
+Capabilities and limits:
+
+- Do not ingest meeting data automatically at startup
+- Ask before raw transcript retrieval or broad multi-meeting search
+- Free and Business plans may use anonymized data for Granola model improvement by default, with an account opt-out documented
+- Voice-memo transcript availability through MCP is not guaranteed by current documentation
+
+
+## Obsidian CLI
+
+Obsidian's official desktop CLI for scoped access to local Markdown vaults; no MCP server is required.
+
+- **Supported agents:** `claude_code`, `codex`, `gemini_cli`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** Obsidian desktop 1.12.7 or newer; The command line interface enabled on PATH; Obsidian running for CLI calls
+- **Credentials:** Optional Obsidian Sync or Publish credentials remain inside Obsidian
+- **Reads:** Explicitly selected local vault notes, properties, tasks, backlinks, and history
+- **Writes / external effects:** Vault notes, properties, tasks, moves, and renames; Trash or permanent deletion; Publish or unpublish actions; Plugin changes and arbitrary Obsidian command or eval execution
+- **Confirmation:** Confirm overwrites, bulk or link-affecting moves, sync control, deletion, publish or unpublish, plugin changes, arbitrary command, and eval; use the normal local-edit gate for a single bounded note edit.
+- **Risk tags:** `local-data`, `read-write`, `publish-capable`, `destructive-capable`, `arbitrary-eval`
+- **Health check:** Run obsidian version, resolve the exact vault path, then perform a bounded JSON search with limit 1.
+- **Uninstall:** Disable the CLI or remove the harness allowlist; do not delete, unregister, or alter the vault unless separately requested.
+
+Capabilities and limits:
+
+- Prefer exact vault and path parameters over ambiguous file resolution
+- Use the Obsidian CLI for link-aware moves and renames
+- Deny arbitrary eval and command by default
+
+
 ## Substack MCP
 
 An MCP server for reading Substack publication data, managing private drafts, and publishing short-form Notes.
@@ -92,4 +163,27 @@ Capabilities and limits:
 
 - No long-form publish, delete, or schedule mutation
 - Note creation publishes immediately and has no server-side undo
+
+
+## Tolaria
+
+A local-first Markdown vault desktop app with a bundled stdio MCP and embedded coding-agent interface.
+
+- **Supported agents:** `claude_code`, `codex`, `opencode`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** Tolaria for macOS, Windows, or Linux; A mounted local vault; The separately installed and authenticated agent CLI selected by the user
+- **Credentials:** Agent or API credentials remain with the selected CLI or provider; Optional Git remote credentials remain with system Git
+- **Reads:** Markdown and YAML frontmatter in explicitly mounted vaults
+- **Writes / external effects:** Create, append, or full-content update of notes in mounted vaults; Attach an additional vault or clone one through system Git
+- **Confirmation:** Use normal approval for a single create or append; show a diff or confirm full replacement, bulk edits, vault attachment or clone, Power User mode, Git push, and broader native-agent actions.
+- **Risk tags:** `local-data`, `read-write`, `optional-network`, `agent-execution`, `overwrite-capable`
+- **Health check:** Start Tolaria, list mounted vaults, read vault context, run a bounded search, then use a disposable note for any write smoke test.
+- **Uninstall:** Remove any manually added MCP entry and uninstall the app; preserve all vaults unless deletion is separately confirmed.
+
+Capabilities and limits:
+
+- Treat full-content update\_note as overwrite-capable even though its MCP annotation says non-destructive
+- Prefer get\_note, diff review, and expectedMtime before update\_note
+- Git can replicate vault contents and direct cloud-agent targets may send selected note context to their provider
+- Bundled MCP documents no delete or publish tool, but a native agent can have broader file or shell access
 

--- a/scripts/integrations.py
+++ b/scripts/integrations.py
@@ -238,6 +238,12 @@ def validate_catalog(catalog: Any) -> None:
         if not set(confirmation["required_for"]) <= CONFIRMATIONS:
             raise CatalogError(f"{location}.confirmation.required_for: unsupported boundary")
         require_safe_text(confirmation["notes"], f"{location}.confirmation.notes")
+        if re.search(
+            r"\b(?:no|without) (?:confirmation|approval|review|permission)\b|"
+            r"\b(?:confirmation|approval|review|permission) (?:is |are )?not (?:needed|required)\b",
+            confirmation["notes"].casefold(),
+        ):
+            raise CatalogError(f"{location}.confirmation.notes: may not waive structured confirmation gates")
         for capability, confirmation_name in CONFIRMATION_BY_CAPABILITY.items():
             if capabilities[capability] and confirmation_name not in confirmation["required_for"]:
                 raise CatalogError(
@@ -279,10 +285,10 @@ def validate_catalog(catalog: Any) -> None:
         ).casefold()
         semantic_requirements = {
             "sensitive_read": r"\btranscripts?\b|\bsensitive-read\b",
-            "remote_write": r"\b(?:git|dolt) push\b|\bremote (?:sync|push|write)\b|\bunattended pushes?\b|\bpublish(?:es|ing)?\b|\bunpublish\b|\bpublicly fetchable\b|\bimmediately public\b",
+            "remote_write": r"\b(?:git|dolt) push\b|\bremote (?:sync|push|write)\b|\bunattended pushes?\b|\bpublish(?:es|ing)?\b|\bunpublish\b|\bpublicly fetchable\b|\bimmediately public\b|\b(?:sync|upload|send|push|write|copy)\b.{0,80}\b(?:cloud|remote|server|repository)\b",
             "overwrite": r"\boverwrite\b|\breplacement\b|\bfull-content\b|--force\b|\bdiscard-remote\b|\breset operations?\b",
             "delete": r"\bdelet(?:e|ion)\b|\bpurge\b|\btrash\b|\bremoval\b|\buninstall removes\b",
-            "arbitrary_execution": r"\barbitrary (?:registered )?(?:command|eval|execution)\b|\barbitrary-(?:eval|execution)\b|\bshell access\b",
+            "arbitrary_execution": r"\barbitrary (?:registered )?(?:command|eval|execution)\b|\barbitrary-(?:eval|execution)\b|\bshell access\b|\b(?:run|execute) any (?:javascript|js|code|command)\b|\bjavascript supplied by\b",
             "oauth": r"\boauth\b",
         }
         for capability, pattern in semantic_requirements.items():
@@ -297,7 +303,7 @@ def validate_catalog(catalog: Any) -> None:
         if type(uninstall["removes_user_data"]) is not bool:
             raise CatalogError(f"{location}.uninstall.removes_user_data: expected a boolean")
         data_loss_language = re.search(
-            r"\b(?:delete|purge|reset) (?:all |the )?(?:data|history|notes|project|vault)\b|\bremove all (?:project |user )?files\b",
+            r"\b(?:delete|erase|wipe|destroy|purge|reset)\b.{0,80}\b(?:data|history|notes|project|vault|files|records)\b|\bremove all (?:project |user )?files\b",
             uninstall["instructions"].casefold(),
         )
         if data_loss_language and not uninstall["removes_user_data"]:

--- a/scripts/integrations.py
+++ b/scripts/integrations.py
@@ -31,8 +31,54 @@ KINDS = {
 AGENTS = {"claude_code", "codex", "gemini_cli", "cursor", "opencode", "generic"}
 SCOPES = {"none", "project", "user", "project_or_user"}
 MATURITY = {"verified", "listed", "experimental"}
-CONFIRMATIONS = {"credential_setup", "external_install", "write", "publish", "destructive"}
+CONFIRMATIONS = {
+    "credential_setup",
+    "external_install",
+    "read_sensitive",
+    "write",
+    "write_remote",
+    "publish",
+    "overwrite",
+    "delete",
+    "arbitrary_execution",
+    "oauth",
+    "destructive",
+}
 ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+CAPABILITY_FIELDS = {
+    "read",
+    "sensitive_read",
+    "write",
+    "remote_write",
+    "publish",
+    "overwrite",
+    "delete",
+    "arbitrary_execution",
+    "oauth",
+    "destructive",
+    "details",
+}
+CONFIRMATION_BY_CAPABILITY = {
+    "sensitive_read": "read_sensitive",
+    "write": "write",
+    "remote_write": "write_remote",
+    "publish": "publish",
+    "overwrite": "overwrite",
+    "delete": "delete",
+    "arbitrary_execution": "arbitrary_execution",
+    "oauth": "oauth",
+    "destructive": "destructive",
+}
+RISK_TAG_BY_CAPABILITY = {
+    "sensitive_read": "sensitive-read",
+    "remote_write": "remote-write",
+    "publish": "publish-capable",
+    "overwrite": "overwrite-capable",
+    "delete": "delete-capable",
+    "arbitrary_execution": "arbitrary-execution",
+    "oauth": "oauth",
+    "destructive": "destructive-capable",
+}
 
 
 class CatalogError(ValueError):
@@ -111,10 +157,10 @@ def validate_catalog(catalog: Any) -> None:
     if not isinstance(catalog, dict):
         raise CatalogError("catalog: expected an object")
     require_exact_keys(catalog, {"schema_version", "integrations"}, "catalog")
-    if catalog["schema_version"] != 1 or type(catalog["schema_version"]) is not int:
-        raise CatalogError("catalog.schema_version: expected integer 1")
-    if not isinstance(catalog["integrations"], list):
-        raise CatalogError("catalog.integrations: expected an array")
+    if catalog["schema_version"] != 2 or type(catalog["schema_version"]) is not int:
+        raise CatalogError("catalog.schema_version: expected integer 2")
+    if not isinstance(catalog["integrations"], list) or not catalog["integrations"]:
+        raise CatalogError("catalog.integrations: expected a non-empty array")
 
     ids: set[str] = set()
     names: set[str] = set()
@@ -122,14 +168,14 @@ def validate_catalog(catalog: Any) -> None:
     expected = {
         "id", "name", "summary", "source_url", "kind", "supported_agents",
         "installation", "data_boundary", "capabilities", "confirmation", "risk_tags",
-        "maturity", "last_verified", "health_check", "uninstall",
+        "maturity", "last_verified", "evidence", "health_check", "uninstall",
     }
     for index, item in enumerate(catalog["integrations"]):
         location = f"catalog.integrations[{index}]"
         if not isinstance(item, dict):
             raise CatalogError(f"{location}: expected an object")
         require_exact_keys(item, expected, location)
-        for field in ("name", "summary", "health_check", "uninstall"):
+        for field in ("name", "summary", "health_check"):
             require_safe_text(item[field], f"{location}.{field}")
         if any(character in item["name"] for character in "|[]"):
             raise CatalogError(f"{location}.name: Markdown table/link delimiters are not allowed")
@@ -149,6 +195,9 @@ def validate_catalog(catalog: Any) -> None:
         if normalized_url in source_urls:
             raise CatalogError(f"{location}.source_url: duplicate canonical source URL")
         source_urls.add(normalized_url)
+        require_string_list(item["evidence"], f"{location}.evidence", nonempty=True)
+        for evidence_index, evidence_url in enumerate(item["evidence"]):
+            require_https_url(evidence_url, f"{location}.evidence[{evidence_index}]")
         if not isinstance(item["kind"], str) or item["kind"] not in KINDS:
             raise CatalogError(f"{location}.kind: unsupported integration kind")
         require_string_list(item["supported_agents"], f"{location}.supported_agents", nonempty=True)
@@ -175,8 +224,8 @@ def validate_catalog(catalog: Any) -> None:
         capabilities = item["capabilities"]
         if not isinstance(capabilities, dict):
             raise CatalogError(f"{location}.capabilities: expected an object")
-        require_exact_keys(capabilities, {"read", "write", "publish", "destructive", "details"}, f"{location}.capabilities")
-        for field in ("read", "write", "publish", "destructive"):
+        require_exact_keys(capabilities, CAPABILITY_FIELDS, f"{location}.capabilities")
+        for field in CAPABILITY_FIELDS - {"details"}:
             if type(capabilities[field]) is not bool:
                 raise CatalogError(f"{location}.capabilities.{field}: expected a boolean")
         require_string_list(capabilities["details"], f"{location}.capabilities.details", nonempty=True)
@@ -189,16 +238,26 @@ def validate_catalog(catalog: Any) -> None:
         if not set(confirmation["required_for"]) <= CONFIRMATIONS:
             raise CatalogError(f"{location}.confirmation.required_for: unsupported boundary")
         require_safe_text(confirmation["notes"], f"{location}.confirmation.notes")
-        for capability in ("write", "publish", "destructive"):
-            if capabilities[capability] and capability not in confirmation["required_for"]:
-                raise CatalogError(f"{location}: {capability} capability requires an explicit confirmation boundary")
+        for capability, confirmation_name in CONFIRMATION_BY_CAPABILITY.items():
+            if capabilities[capability] and confirmation_name not in confirmation["required_for"]:
+                raise CatalogError(
+                    f"{location}: {capability} capability requires {confirmation_name!r} confirmation"
+                )
         if bool(boundary["reads"]) != capabilities["read"]:
             raise CatalogError(f"{location}: data reads and read capability must agree")
         if bool(boundary["writes"]) != capabilities["write"]:
             raise CatalogError(f"{location}: data writes and write capability must agree")
-        for capability in ("publish", "destructive"):
+        for capability in ("remote_write", "publish", "overwrite", "delete", "arbitrary_execution"):
             if capabilities[capability] and not capabilities["write"]:
                 raise CatalogError(f"{location}: {capability} capability requires write capability")
+        if capabilities["publish"] and not capabilities["remote_write"]:
+            raise CatalogError(f"{location}: publish capability requires remote_write capability")
+        if capabilities["sensitive_read"] and not capabilities["read"]:
+            raise CatalogError(f"{location}: sensitive_read capability requires read capability")
+        if any(capabilities[field] for field in ("overwrite", "delete", "arbitrary_execution")) and not capabilities["destructive"]:
+            raise CatalogError(f"{location}: overwrite, delete, and arbitrary_execution require destructive capability")
+        if capabilities["oauth"] and not boundary["credentials"]:
+            raise CatalogError(f"{location}: oauth capability requires a credential boundary")
         if installation["scope"] != "none" and "external_install" not in confirmation["required_for"]:
             raise CatalogError(f"{location}: installable entries require an external_install boundary")
         if boundary["credentials"] and "credential_setup" not in confirmation["required_for"]:
@@ -207,6 +266,46 @@ def validate_catalog(catalog: Any) -> None:
         require_string_list(item["risk_tags"], f"{location}.risk_tags", nonempty=True)
         if not all(ID_PATTERN.fullmatch(tag) for tag in item["risk_tags"]):
             raise CatalogError(f"{location}.risk_tags: expected kebab-case tags")
+        for capability, risk_tag in RISK_TAG_BY_CAPABILITY.items():
+            if capabilities[capability] and risk_tag not in item["risk_tags"]:
+                raise CatalogError(f"{location}: {capability} capability requires {risk_tag!r} risk tag")
+
+        semantic_text = " ".join(
+            boundary["credentials"]
+            + boundary["reads"]
+            + boundary["writes"]
+            + capabilities["details"]
+            + item["risk_tags"]
+        ).casefold()
+        semantic_requirements = {
+            "sensitive_read": r"\btranscripts?\b|\bsensitive-read\b",
+            "remote_write": r"\b(?:git|dolt) push\b|\bremote (?:sync|push|write)\b|\bunattended pushes?\b|\bpublish(?:es|ing)?\b|\bunpublish\b|\bpublicly fetchable\b|\bimmediately public\b",
+            "overwrite": r"\boverwrite\b|\breplacement\b|\bfull-content\b|--force\b|\bdiscard-remote\b|\breset operations?\b",
+            "delete": r"\bdelet(?:e|ion)\b|\bpurge\b|\btrash\b|\bremoval\b|\buninstall removes\b",
+            "arbitrary_execution": r"\barbitrary (?:registered )?(?:command|eval|execution)\b|\barbitrary-(?:eval|execution)\b|\bshell access\b",
+            "oauth": r"\boauth\b",
+        }
+        for capability, pattern in semantic_requirements.items():
+            if re.search(pattern, semantic_text) and not capabilities[capability]:
+                raise CatalogError(f"{location}: metadata describes {capability} but the typed capability is false")
+
+        uninstall = item["uninstall"]
+        if not isinstance(uninstall, dict):
+            raise CatalogError(f"{location}.uninstall: expected an object")
+        require_exact_keys(uninstall, {"instructions", "removes_user_data"}, f"{location}.uninstall")
+        require_safe_text(uninstall["instructions"], f"{location}.uninstall.instructions")
+        if type(uninstall["removes_user_data"]) is not bool:
+            raise CatalogError(f"{location}.uninstall.removes_user_data: expected a boolean")
+        data_loss_language = re.search(
+            r"\b(?:delete|purge|reset) (?:all |the )?(?:data|history|notes|project|vault)\b|\bremove all (?:project |user )?files\b",
+            uninstall["instructions"].casefold(),
+        )
+        if data_loss_language and not uninstall["removes_user_data"]:
+            raise CatalogError(f"{location}.uninstall: data-loss instructions require removes_user_data=true")
+        if uninstall["removes_user_data"] and not (
+            capabilities["delete"] and capabilities["destructive"]
+        ):
+            raise CatalogError(f"{location}.uninstall: user-data removal requires delete and destructive capabilities")
         if not isinstance(item["maturity"], str) or item["maturity"] not in MATURITY:
             raise CatalogError(f"{location}.maturity: unsupported maturity")
         try:
@@ -243,7 +342,8 @@ def render_reference(catalog: dict[str, Any]) -> str:
         name = markdown_text(item["name"])
         rows.append(
             f"| [{name}]({item['source_url']}) | `{item['kind']}` | "
-            f"{item['maturity']} | {yes_no(caps['write'])} | {yes_no(caps['publish'])} | "
+            f"{item['maturity']} | {yes_no(caps['write'])} | {yes_no(caps['remote_write'])} | "
+            f"{yes_no(caps['publish'])} | {yes_no(caps['sensitive_read'])} | "
             f"{yes_no(caps['destructive'])} | {item['last_verified']} |"
         )
         agents = ", ".join(f"`{agent}`" for agent in item["supported_agents"])
@@ -252,6 +352,13 @@ def render_reference(catalog: dict[str, Any]) -> str:
         reads = "; ".join(map(markdown_text, item["data_boundary"]["reads"])) or "None"
         writes = "; ".join(map(markdown_text, item["data_boundary"]["writes"])) or "None"
         details = "\n".join(f"- {markdown_text(detail)}" for detail in caps["details"])
+        signals = ", ".join(
+            name.replace("_", " ")
+            for name in ("sensitive_read", "remote_write", "overwrite", "delete", "arbitrary_execution", "oauth")
+            if caps[name]
+        ) or "None"
+        evidence = "; ".join(f"[{index + 1}]({url})" for index, url in enumerate(item["evidence"]))
+        required_for = ", ".join(f"`{gate}`" for gate in item["confirmation"]["required_for"]) or "None"
         sections.append(
             f"## {name}\n\n"
             f"{markdown_paragraph(item['summary'])}\n\n"
@@ -261,10 +368,14 @@ def render_reference(catalog: dict[str, Any]) -> str:
             f"- **Credentials:** {credentials}\n"
             f"- **Reads:** {reads}\n"
             f"- **Writes / external effects:** {writes}\n"
+            f"- **Typed safety signals:** {signals}\n"
+            f"- **Required confirmation gates:** {required_for}\n"
             f"- **Confirmation:** {markdown_text(item['confirmation']['notes'])}\n"
             f"- **Risk tags:** {', '.join(f'`{tag}`' for tag in item['risk_tags'])}\n"
+            f"- **Evidence:** {evidence}\n"
             f"- **Health check:** {markdown_text(item['health_check'])}\n"
-            f"- **Uninstall:** {markdown_text(item['uninstall'])}\n\n"
+            f"- **Uninstall:** {markdown_text(item['uninstall']['instructions'])} "
+            f"(removes user data: {yes_no(item['uninstall']['removes_user_data'])})\n\n"
             f"Capabilities and limits:\n\n{details}\n"
         )
     return (
@@ -275,8 +386,8 @@ def render_reference(catalog: dict[str, Any]) -> str:
         "data boundary, and side effects before opting in. `verified` means the catalog metadata "
         "was checked against the linked source on the stated date; it is not a live authentication "
         "or end-to-end test. `listed` and `experimental` are leads, not endorsements.\n\n"
-        "| Integration | Kind | Maturity | Writes | Publishes | Destructive | Last verified |\n"
-        "|---|---|---|---:|---:|---:|---|\n"
+        "| Integration | Kind | Maturity | Writes | Remote writes | Publishes | Sensitive reads | Destructive | Last verified |\n"
+        "|---|---|---|---:|---:|---:|---:|---:|---|\n"
         + "\n".join(rows)
         + "\n\n"
         + "\n\n".join(sections)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -15,39 +15,78 @@ class IntegrationCatalogTests(unittest.TestCase):
     def setUp(self) -> None:
         self.catalog = MODULE.load_catalog()
 
+    def entry(self, integration_id: str) -> dict:
+        return next(item for item in self.catalog["integrations"] if item["id"] == integration_id)
+
     def assert_invalid(self, mutate) -> None:
         catalog = copy.deepcopy(self.catalog)
         mutate(catalog)
         with self.assertRaises(MODULE.CatalogError):
             MODULE.validate_catalog(catalog)
 
-    def test_catalog_is_sorted_only_at_render_time_and_has_unique_ids(self) -> None:
+    def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
+        self.assertEqual(self.catalog["schema_version"], 2)
         self.assertEqual(len(self.catalog["integrations"]), 8)
-        self.assertIn("Substack MCP", rendered)
+        self.assertIn("Remote writes", rendered)
+        self.assertIn("Sensitive reads", rendered)
+        self.assertIn("Typed safety signals", rendered)
+        self.assertIn("Required confirmation gates", rendered)
         self.assertIn("immediate public publish action", rendered)
 
-    def test_issue_19_entries_have_expected_high_risk_gates(self) -> None:
-        entries = {item["id"]: item for item in self.catalog["integrations"]}
-        self.assertTrue(entries["tolaria"]["capabilities"]["destructive"])
-        self.assertIn("overwrite-capable", entries["tolaria"]["risk_tags"])
-        self.assertTrue(entries["obsidian"]["capabilities"]["publish"])
-        self.assertIn("arbitrary-eval", entries["obsidian"]["risk_tags"])
-        self.assertEqual(entries["beads-gemini"]["supported_agents"], ["gemini_cli"])
-        self.assertIn("destructive", entries["beads-gemini"]["confirmation"]["required_for"])
-        self.assertFalse(entries["granola-mcp"]["capabilities"]["write"])
-        self.assertEqual(entries["granola-mcp"]["data_boundary"]["writes"], [])
+    def test_issue_19_entries_have_typed_high_risk_gates(self) -> None:
+        tol = self.entry("tolaria")
+        self.assertEqual(tol["name"], "Tolaria MCP")
+        self.assertNotIn("codex", tol["supported_agents"])
+        self.assertTrue(tol["capabilities"]["sensitive_read"])
+        self.assertTrue(tol["capabilities"]["overwrite"])
+        self.assertFalse(tol["capabilities"]["remote_write"])
+        self.assertIn("AutoGit", " ".join(tol["capabilities"]["details"]))
+
+        obsidian = self.entry("obsidian")
+        for capability in ("sensitive_read", "remote_write", "publish", "overwrite", "delete", "arbitrary_execution", "destructive"):
+            self.assertTrue(obsidian["capabilities"][capability])
+        self.assertIn("An exact command allowlist enforced by the calling harness", obsidian["installation"]["prerequisites"])
+        self.assertIn("No enforcement wrapper ships here", " ".join(obsidian["capabilities"]["details"]))
+
+        beads = self.entry("beads-gemini")
+        self.assertEqual(beads["supported_agents"], ["gemini_cli"])
+        self.assertTrue(beads["capabilities"]["remote_write"])
+        self.assertTrue(beads["capabilities"]["overwrite"])
+        self.assertIn("write_remote", beads["confirmation"]["required_for"])
+        self.assertIn("--force", " ".join(beads["capabilities"]["details"]))
+        self.assertIn("--discard-remote", " ".join(beads["capabilities"]["details"]))
+
+        granola = self.entry("granola-mcp")
+        self.assertTrue(granola["capabilities"]["sensitive_read"])
+        self.assertTrue(granola["capabilities"]["oauth"])
+        self.assertFalse(granola["capabilities"]["write"])
+        details = " ".join(granola["capabilities"]["details"])
+        for boundary in ("indefinitely", "United States", "HIPAA", "FERPA", "consent", "30 days"):
+            self.assertIn(boundary, details)
+
+    def test_verified_entries_have_auditable_evidence(self) -> None:
+        for item in self.catalog["integrations"]:
+            self.assertGreaterEqual(len(item["evidence"]), 1)
+            self.assertTrue(all(url.startswith("https://") for url in item["evidence"]))
+        self.assertGreaterEqual(len(self.entry("tolaria")["evidence"]), 3)
+        self.assertGreaterEqual(len(self.entry("granola-mcp")["evidence"]), 3)
 
     def test_generated_reference_matches_catalog(self) -> None:
         expected = MODULE.render_reference(self.catalog)
         self.assertEqual((ROOT / "references" / "integrations.md").read_text(), expected)
 
-    def test_agent_skills_discloses_replacement_and_removal(self) -> None:
-        item = next(item for item in self.catalog["integrations"] if item["id"] == "agent-skills")
+    def test_empty_catalog_and_old_schema_are_rejected(self) -> None:
+        self.assert_invalid(lambda catalog: catalog.update({"integrations": []}))
+        self.assert_invalid(lambda catalog: catalog.update({"schema_version": 1}))
+
+    def test_agent_skills_discloses_replacement_removal_and_uninstall_loss(self) -> None:
+        item = self.entry("agent-skills")
         self.assertTrue(item["capabilities"]["destructive"])
+        self.assertTrue(item["capabilities"]["overwrite"])
+        self.assertTrue(item["capabilities"]["delete"])
         self.assertIn("destructive", item["confirmation"]["required_for"])
-        self.assertIn("replacement", item["risk_tags"])
-        self.assertIn("removal", item["risk_tags"])
+        self.assertTrue(item["uninstall"]["removes_user_data"])
 
     def test_duplicate_ids_are_rejected(self) -> None:
         self.assert_invalid(
@@ -58,9 +97,7 @@ class IntegrationCatalogTests(unittest.TestCase):
 
     def test_duplicate_normalized_names_and_source_urls_are_rejected(self) -> None:
         self.assert_invalid(
-            lambda catalog: catalog["integrations"][1].update(
-                {"name": "Ａgent Ｓkills"}
-            )
+            lambda catalog: catalog["integrations"][1].update({"name": "Ａgent Ｓkills"})
         )
         self.assert_invalid(
             lambda catalog: catalog["integrations"][1].update(
@@ -76,33 +113,13 @@ class IntegrationCatalogTests(unittest.TestCase):
 
     def test_unknown_fields_and_invalid_urls_are_rejected(self) -> None:
         self.assert_invalid(lambda catalog: catalog["integrations"][0].update({"surprise": True}))
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update({"source_url": "http://example.com"})
-        )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update({"source_url": "https://"})
-        )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update(
-                {"source_url": "https://example.com/ok)\n| injected |"}
-            )
-        )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update(
-                {"source_url": "https://example.com:not-a-port/source"}
-            )
-        )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update(
-                {"source_url": "https://[::1"}
-            )
-        )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update(
-                {"source_url": "https://example.com／evil"}
-            )
-        )
         for source_url in (
+            "http://example.com",
+            "https://",
+            "https://example.com/ok)\n| injected |",
+            "https://example.com:not-a-port/source",
+            "https://[::1",
+            "https://example.com／evil",
             "https://example.com/path|forged",
             "https://example.com/[forged]",
             "https://example.com/path?utm=1",
@@ -113,25 +130,47 @@ class IntegrationCatalogTests(unittest.TestCase):
                     {"source_url": value}
                 )
             )
+        self.assert_invalid(
+            lambda catalog: catalog["integrations"][0].update({"evidence": []})
+        )
+        self.assert_invalid(
+            lambda catalog: catalog["integrations"][0].update(
+                {"evidence": ["https://example.com/ok|forged"]}
+            )
+        )
 
     def test_unhashable_enum_values_fail_as_catalog_errors(self) -> None:
+        self.assert_invalid(lambda catalog: catalog["integrations"][0].update({"kind": []}))
+        self.assert_invalid(lambda catalog: catalog["integrations"][0].update({"maturity": {}}))
         self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update({"kind": []})
+            lambda catalog: catalog["integrations"][0]["installation"].update({"scope": []})
         )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update({"maturity": {}})
-        )
+
+    def test_auto_install_and_boundary_parity_are_rejected(self) -> None:
         self.assert_invalid(
             lambda catalog: catalog["integrations"][0]["installation"].update(
-                {"scope": []}
+                {"automatic": True}
+            )
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "granola-mcp"
+            )["data_boundary"].update({"reads": []})
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "beads-gemini"
+            )["capabilities"].update({"write": False})
+        )
+        self.assert_invalid(
+            lambda catalog: catalog["integrations"][0]["capabilities"].update(
+                {"destructive": 1}
             )
         )
 
     def test_markdown_table_and_control_line_injection_is_rejected(self) -> None:
         self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update(
-                {"name": "Injected | Integration"}
-            )
+            lambda catalog: catalog["integrations"][0].update({"name": "Injected | Integration"})
         )
         catalog = copy.deepcopy(self.catalog)
         catalog["integrations"][0]["summary"] = "Uses *emphasis* and [links]"
@@ -156,44 +195,93 @@ class IntegrationCatalogTests(unittest.TestCase):
                 )
             )
 
-    def test_auto_install_and_missing_risk_boundaries_are_rejected(self) -> None:
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][0]["installation"].update({"automatic": True})
+    def test_capability_confirmation_and_risk_tags_are_required(self) -> None:
+        cases = (
+            ("granola-mcp", "sensitive_read", "read_sensitive", "sensitive-read"),
+            ("granola-mcp", "oauth", "oauth", "oauth"),
+            ("beads-gemini", "remote_write", "write_remote", "remote-write"),
+            ("tolaria", "overwrite", "overwrite", "overwrite-capable"),
+            ("obsidian", "delete", "delete", "delete-capable"),
+            ("obsidian", "arbitrary_execution", "arbitrary_execution", "arbitrary-execution"),
         )
-        self.assert_invalid(
-            lambda catalog: catalog["integrations"][3]["confirmation"].update(
-                {"required_for": ["credential_setup", "external_install", "write"]}
+        for integration_id, capability, gate, tag in cases:
+            self.assert_invalid(
+                lambda catalog, item_id=integration_id, field=capability: next(
+                    item for item in catalog["integrations"] if item["id"] == item_id
+                )["capabilities"].update({field: False})
             )
-        )
+            self.assert_invalid(
+                lambda catalog, item_id=integration_id, required=gate: next(
+                    item for item in catalog["integrations"] if item["id"] == item_id
+                )["confirmation"].update(
+                    {
+                        "required_for": [
+                            value
+                            for value in next(
+                                item for item in catalog["integrations"] if item["id"] == item_id
+                            )["confirmation"]["required_for"]
+                            if value != required
+                        ]
+                    }
+                )
+            )
+            self.assert_invalid(
+                lambda catalog, item_id=integration_id, risk_tag=tag: next(
+                    item for item in catalog["integrations"] if item["id"] == item_id
+                ).update(
+                    {
+                        "risk_tags": [
+                            value
+                            for value in next(
+                                item for item in catalog["integrations"] if item["id"] == item_id
+                            )["risk_tags"]
+                            if value != risk_tag
+                        ]
+                    }
+                )
+            )
 
-    def test_capability_and_data_boundary_contradictions_are_rejected(self) -> None:
+    def test_capability_relationships_are_enforced(self) -> None:
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "substack-mcp"
+            )["capabilities"].update({"remote_write": False})
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "obsidian"
+            )["capabilities"].update({"destructive": False})
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "granola-mcp"
+            )["data_boundary"].update({"credentials": []})
+        )
         self.assert_invalid(
             lambda catalog: catalog["integrations"][2]["data_boundary"].update(
                 {"writes": ["Deletes all project files"]}
             )
         )
+
+    def test_uninstall_data_loss_is_typed(self) -> None:
         self.assert_invalid(
-            lambda catalog: catalog["integrations"][3]["capabilities"].update(
-                {"write": False}
-            )
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "granola-mcp"
+            )["uninstall"].update({"instructions": "Delete all project files"})
         )
         self.assert_invalid(
-            lambda catalog: catalog["integrations"][3]["data_boundary"].update(
-                {"reads": []}
-            )
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "granola-mcp"
+            )["uninstall"].update({"removes_user_data": True})
         )
 
     def test_future_verification_dates_are_rejected(self) -> None:
         self.assert_invalid(
-            lambda catalog: catalog["integrations"][0].update(
-                {"last_verified": "9999-12-31"}
-            )
+            lambda catalog: catalog["integrations"][0].update({"last_verified": "9999-12-31"})
         )
 
     def test_maturity_is_not_upgraded_by_rendering(self) -> None:
-        item = next(
-            item for item in self.catalog["integrations"] if item["id"] == "ai-tools-for-creators"
-        )
+        item = self.entry("ai-tools-for-creators")
         self.assertEqual(item["maturity"], "listed")
         self.assertIn("listed", MODULE.render_reference(self.catalog))
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -42,12 +42,16 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assertTrue(tol["capabilities"]["overwrite"])
         self.assertFalse(tol["capabilities"]["remote_write"])
         self.assertIn("AutoGit", " ".join(tol["capabilities"]["details"]))
+        self.assertIn("open_note", " ".join(tol["data_boundary"]["writes"]))
+        self.assertIn("content-mutation surface", " ".join(tol["capabilities"]["details"]))
 
         obsidian = self.entry("obsidian")
         for capability in ("sensitive_read", "remote_write", "publish", "overwrite", "delete", "arbitrary_execution", "destructive"):
             self.assertTrue(obsidian["capabilities"][capability])
-        self.assertIn("An exact command allowlist enforced by the calling harness", obsidian["installation"]["prerequisites"])
+        self.assertIn("An exact command-and-argument policy enforced by the calling harness", obsidian["installation"]["prerequisites"])
         self.assertIn("No enforcement wrapper ships here", " ".join(obsidian["capabilities"]["details"]))
+        self.assertIn("current-working-directory vault", " ".join(obsidian["data_boundary"]["reads"]))
+        self.assertIn("explicit vault= plus path=", " ".join(obsidian["capabilities"]["details"]))
 
         beads = self.entry("beads-gemini")
         self.assertEqual(beads["supported_agents"], ["gemini_cli"])
@@ -56,6 +60,8 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assertIn("write_remote", beads["confirmation"]["required_for"])
         self.assertIn("--force", " ".join(beads["capabilities"]["details"]))
         self.assertIn("--discard-remote", " ".join(beads["capabilities"]["details"]))
+        self.assertNotIn("discards remote state", " ".join(beads["capabilities"]["details"]))
+        self.assertTrue(any(url.endswith("/docs/recovery/init-safety.md") for url in beads["evidence"]))
 
         granola = self.entry("granola-mcp")
         self.assertTrue(granola["capabilities"]["sensitive_read"])
@@ -273,6 +279,46 @@ class IntegrationCatalogTests(unittest.TestCase):
             lambda catalog: next(
                 item for item in catalog["integrations"] if item["id"] == "granola-mcp"
             )["uninstall"].update({"removes_user_data": True})
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "granola-mcp"
+            )["uninstall"].update(
+                {"instructions": "Erase every meeting note and its history."}
+            )
+        )
+
+    def test_hostile_free_text_cannot_waive_typed_safety(self) -> None:
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "granola-mcp"
+            )["confirmation"].update(
+                {"notes": "No confirmation is needed before broad transcript retrieval."}
+            )
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "tolaria"
+            )["capabilities"].update(
+                {
+                    "details": next(
+                        item for item in catalog["integrations"] if item["id"] == "tolaria"
+                    )["capabilities"]["details"]
+                    + ["Sync changed notes to a cloud repository."]
+                }
+            )
+        )
+        self.assert_invalid(
+            lambda catalog: next(
+                item for item in catalog["integrations"] if item["id"] == "tolaria"
+            )["capabilities"].update(
+                {
+                    "details": next(
+                        item for item in catalog["integrations"] if item["id"] == "tolaria"
+                    )["capabilities"]["details"]
+                    + ["Run any JavaScript supplied by the model."]
+                }
+            )
         )
 
     def test_future_verification_dates_are_rejected(self) -> None:

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -23,9 +23,20 @@ class IntegrationCatalogTests(unittest.TestCase):
 
     def test_catalog_is_sorted_only_at_render_time_and_has_unique_ids(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
-        self.assertEqual(len(self.catalog["integrations"]), 4)
+        self.assertEqual(len(self.catalog["integrations"]), 8)
         self.assertIn("Substack MCP", rendered)
         self.assertIn("immediate public publish action", rendered)
+
+    def test_issue_19_entries_have_expected_high_risk_gates(self) -> None:
+        entries = {item["id"]: item for item in self.catalog["integrations"]}
+        self.assertTrue(entries["tolaria"]["capabilities"]["destructive"])
+        self.assertIn("overwrite-capable", entries["tolaria"]["risk_tags"])
+        self.assertTrue(entries["obsidian"]["capabilities"]["publish"])
+        self.assertIn("arbitrary-eval", entries["obsidian"]["risk_tags"])
+        self.assertEqual(entries["beads-gemini"]["supported_agents"], ["gemini_cli"])
+        self.assertIn("destructive", entries["beads-gemini"]["confirmation"]["required_for"])
+        self.assertFalse(entries["granola-mcp"]["capabilities"]["write"])
+        self.assertEqual(entries["granola-mcp"]["data_boundary"]["writes"], [])
 
     def test_generated_reference_matches_catalog(self) -> None:
         expected = MODULE.render_reference(self.catalog)


### PR DESCRIPTION
## What changed

Adds four opt-in integrations behind catalog schema v2:

- **Tolaria MCP**: narrowed to the bundled stdio MCP only, with sensitive-vault-read, transient UI-effect, MCP-client-config, and full-note-overwrite gates. Embedded agents, direct provider models, stored provider keys, and AutoGit are separate trust boundaries.
- **Obsidian CLI**: documents CWD-vault → active-vault resolution and active-file defaults, plus the full command surface. No wrapper is implied: the calling harness must constrain commands, arguments, and flags, require explicit `vault=` + `path=` for bounded file operations, and deny open-world actions by default.
- **Beads for Gemini CLI**: distinguishes the user-global setup default from `--project`, and types remote push/sync, force overwrite, divergent `--discard-remote` initialization, later history replacement, delete, purge, and reset boundaries.
- **Granola MCP**: types OAuth and sensitive transcript reads, with retention, US residency, consent, compliance, plan, model-improvement, and voice-memo/MCP limits.

The catalog now has separate typed fields and confirmation/risk-tag invariants for sensitive reads, remote writes, publish, overwrite, deletion, arbitrary execution, OAuth, and destructive actions. Every entry carries evidence links and a structured uninstall data-loss declaration. Generated docs expose these fields in the summary table and detail sections.

Setup still installs, authenticates, or activates nothing.

## Trust model

`verified` means the dated metadata was checked against the linked evidence; it is not a live account test or certification of upstream truth. CI validates internal consistency, hostile mutations, safe rendering, evidence presence, and documentation drift.

## Validation

- `bash scripts/validate-all.sh`
- 34 Python tests
- hostile capability/confirmation/risk-tag and free-text contradiction mutations
- empty-catalog, evidence, uninstall-data-loss, URL, Markdown, Unicode, type, and cross-field checks
- generated-reference drift, links, hooks, shell, and JSON checks

Closes #19