### PR TITLE
Make the test suite and the memory binding work on Windows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,3 +16,23 @@ jobs:
         run: |
           chmod +x scripts/*.sh tests/*.sh
           bash scripts/validate-all.sh
+
+  # The Python suite shells out to helpers and hashes file bytes, so it is exposed
+  # to three things a Linux-only matrix cannot see. All three were live on main
+  # until 2026-08-19 and every one of them was invisible here:
+  #   - "python3" is a Store stub on Windows that runs nothing and prints an ad
+  #   - core.autocrlf=true (system default) rewrites the bytes under a digest check
+  #   - git identity paths come back C:/... but resolve to C:\...
+  # validate-all.sh stays Linux-only -- it is a bash pipeline with find/chmod in it.
+  # This job runs just the part that has a real chance of breaking per-platform.
+  tests-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run the Python test suite on Windows
+        run: python -m unittest discover -s tests -p "test_*.py" -v

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -28,6 +28,19 @@ printf '%s\n' "$MEMORY_DIR" > .context-os/memory-directory
 printf '%s\n' "$REPO_ID" > "$MEMORY_DIR/.context-os-repository"
 ```
 
+These commands run unchanged on macOS, Linux, and Windows under Git Bash. On
+Windows they record MSYS-style paths (`/c/Users/...`, and `/tmp/...` for a shell
+mount), because that is how bash spells an absolute path there. The validator
+translates those to native paths before checking them — the drive-letter forms
+directly, anything else via `cygpath`, which ships with Git for Windows. So both
+spellings of the same directory are accepted, and the file stays readable in
+whichever shell you wrote it from.
+
+The translation is a spelling change only. Every check still applies to the
+translated path: it must be absolute, non-symlinked, canonical (no `..`), an
+existing directory, and — for the marker — still the same repository. A path
+that cannot be translated is left alone and rejected, rather than guessed at.
+
 Separately add the reviewed absolute path to `.claude/settings.local.json`:
 
 ```json

--- a/scripts/dream/validate-memory.py
+++ b/scripts/dream/validate-memory.py
@@ -147,7 +147,10 @@ def same_directory(recorded: str, identity: str) -> bool:
     if recorded == identity:
         return True
     try:
-        return Path(recorded).resolve(strict=True) == Path(identity).resolve(strict=True)
+        return (
+            Path(native_path(recorded)).resolve(strict=True)
+            == Path(native_path(identity)).resolve(strict=True)
+        )
     except OSError:
         # Nonexistent, malformed, or not addressable on this platform -- e.g. the
         # MSYS-style /c/... form under a native Python. Fail closed: an identity
@@ -203,9 +206,52 @@ def require_regular_file(path: Path, label: str) -> None:
         raise ValidationError(f"{label} must be a regular file: {path}")
 
 
+MSYS_DRIVE = re.compile(r"^/(?:cygdrive/)?([A-Za-z])/(.*)$")
+
+
+def native_path(raw: str) -> str:
+    """Rewrite a Unix-shell path into the form this interpreter can address.
+
+    docs/auto-memory.md builds both recorded paths in bash. On Windows that bash
+    is Git Bash, whose absolute paths are MSYS-style — `/c/Users/me/memory`, or
+    `/cygdrive/c/...` under Cygwin. Native Python reads those as drive-less and
+    rejects them at the `is_absolute()` gate, so the documented setup produced a
+    binding the validator refused: "must be absolute". Same directory, different
+    shell's spelling.
+
+    This is a spelling change only, applied before validation, never instead of
+    it. The translated path still has to be absolute, non-symlinked, canonical,
+    existing, and a directory — and for the marker, still has to name the same
+    repository. Nothing here can turn a rejected path into an accepted one; it
+    can only let a correctly-spelled-for-bash path reach the checks at all.
+
+    No-op on POSIX, where `/c/anything` is a real path and must stay one.
+    """
+    if os.name != "nt" or not raw.startswith("/"):
+        return raw
+    match = MSYS_DRIVE.match(raw)
+    if match:
+        drive, rest = match.groups()
+        return str(Path(f"{drive.upper()}:/{rest}"))
+    # A POSIX-absolute path with no drive letter (/tmp/..., /usr/...) is a mount
+    # only the shell knows about. cygpath ships with Git for Windows and is the
+    # authority on those; if it is missing or fails, hand back the original so
+    # the caller's own checks reject it rather than guessing a translation.
+    try:
+        converted = subprocess.run(
+            ["cygpath", "-w", raw], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError):
+        return raw
+    if converted.returncode != 0:
+        return raw
+    return converted.stdout.strip() or raw
+
+
 def require_canonical_directory(raw: str, label: str) -> Path:
     if CONTROL.search(raw):
         raise ValidationError(f"{label} contains a control character")
+    raw = native_path(raw)
     path = Path(raw)
     if not path.is_absolute():
         raise ValidationError(f"{label} must be absolute")

--- a/scripts/dream/validate-memory.py
+++ b/scripts/dream/validate-memory.py
@@ -120,6 +120,41 @@ def repository_identity(repo: Path) -> str:
     return str(resolved)
 
 
+def same_directory(recorded: str, identity: str) -> bool:
+    """Do two recorded paths name the same directory?
+
+    Compared as paths rather than as strings, because the marker file and this
+    check are written by different tools that spell the same directory
+    differently:
+
+      git rev-parse   C:/Users/me/repo/.git      (forward slashes, even on Windows)
+      Python resolve  C:\\Users\\me\\repo\\.git     (backslashes)
+      docs/auto-memory.md's `realpath` under Git Bash → /c/Users/me/repo/.git
+
+    All three name one directory. On POSIX they are byte-identical, which is why
+    a literal `!=` held up everywhere CI runs and failed only on Windows -- where
+    it rejected every correctly-configured binding, taking out 31 tests and, more
+    importantly, the feature itself for any Windows user who followed the setup
+    doc exactly.
+
+    This does NOT loosen the check. It still demands the same directory; it just
+    stops treating a separator convention as a different repository. Comparison is
+    on fully resolved paths, so `..`, symlinks, and 8.3 short names all normalize
+    before the equality, and a marker naming any other directory is still
+    rejected. Unresolvable input (a path that does not exist, e.g. the classic
+    stale marker pointing at a deleted checkout) fails closed.
+    """
+    if recorded == identity:
+        return True
+    try:
+        return Path(recorded).resolve(strict=True) == Path(identity).resolve(strict=True)
+    except OSError:
+        # Nonexistent, malformed, or not addressable on this platform -- e.g. the
+        # MSYS-style /c/... form under a native Python. Fail closed: an identity
+        # we cannot resolve is not an identity we can vouch for.
+        return False
+
+
 def head_identity(memory_dir: Path) -> str:
     completed = subprocess.run(
         ["git", "symbolic-ref", "-q", "HEAD"],
@@ -230,7 +265,7 @@ def validate_memory_binding(repo: Path, *, require_clean: bool = False) -> dict[
 
     marker = memory_dir / ".context-os-repository"
     marker_value = read_single_line(marker, "memory repository marker")
-    if marker_value != identity:
+    if not same_directory(marker_value, identity):
         raise ValidationError(
             "memory repository marker does not match this repository identity"
         )

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -1,8 +1,22 @@
 import json
 import re
 import subprocess
+import sys
 import unittest
 from pathlib import Path
+
+# Shell out to the interpreter running these tests, never a bare "python3".
+#
+# On Windows "python3" resolves to the Microsoft Store App Execution Alias — a
+# stub that prints "Python was not found; run without arguments to install from
+# the Microsoft Store" and exits WITHOUT running Python. Every test that shells
+# out then reads empty stdout and dies on json.loads(""), which surfaces as
+# "Expecting value: line 1 column 1 (char 0)" and looks like a helper bug rather
+# than a missing interpreter. That took out 34 of 89 tests.
+#
+# sys.executable is also correct on POSIX and in a venv, where a bare "python3"
+# can be a DIFFERENT interpreter than the one running the suite.
+PYTHON = sys.executable
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -306,7 +320,7 @@ class DocumentationPositioningTests(unittest.TestCase):
         ):
             result = subprocess.run(
                 [
-                    "python3",
+                    PYTHON,
                     "tests/validate-openai-metadata.py",
                     "--command",
                     f".claude/commands/{name}.md",

--- a/tests/test_dream_paths.py
+++ b/tests/test_dream_paths.py
@@ -1,4 +1,6 @@
+import importlib.util
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -145,6 +147,58 @@ class DreamMemoryPathTests(unittest.TestCase):
         """
         run(["git", "config", "core.autocrlf", "false"], repo)
         run(["git", "config", "core.eol", "lf"], repo)
+
+    @staticmethod
+    def msys(path: Path) -> str:
+        """Spell a native Windows path the way Git Bash would (drive letter to /c/... form)."""
+        drive, rest = str(path).split(":", 1)
+        return f"/{drive.lower()}{rest.replace(chr(92), '/')}"
+
+    @unittest.skipUnless(os.name == "nt", "the binding is already native on POSIX")
+    def test_msys_spelled_binding_is_accepted(self) -> None:
+        (self.repo / ".context-os" / "memory-directory").write_text(
+            self.msys(self.memory) + "\n", encoding="utf-8"
+        )
+        resolved = self.helper("resolve")
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        self.assertEqual(json.loads(resolved.stdout)["memory_dir"], str(self.memory))
+
+    @unittest.skipUnless(os.name == "nt", "the marker is already native on POSIX")
+    def test_msys_spelled_marker_is_accepted(self) -> None:
+        identity = run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], self.repo
+        ).stdout.strip()
+        (self.memory / ".context-os-repository").write_text(
+            self.msys(Path(identity).resolve()) + "\n", encoding="utf-8"
+        )
+        # resolve also demands a clean memory repo, so commit the rewritten marker
+        # or this asserts on the wrong failure.
+        run(["git", "add", "-A"], self.memory)
+        run(["git", "commit", "-qm", "msys marker"], self.memory)
+        resolved = self.helper("resolve")
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only spelling")
+    def test_a_wrong_marker_is_still_rejected_when_msys_spelled(self) -> None:
+        """Translating the spelling must not become a way to smuggle a
+        mismatched identity past the check."""
+        (self.memory / ".context-os-repository").write_text(
+            "/c/definitely/not/this/repo/.git\n", encoding="utf-8"
+        )
+        self.assertIn("marker", self.assert_rejects("resolve"))
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only spelling")
+    def test_a_noncanonical_msys_path_is_still_rejected(self) -> None:
+        """Translating the spelling must not translate away the '..' check.
+
+        Uses <memory>/../memory, which RESOLVES to a real directory -- so it gets
+        past the existence gate and has to be caught by the canonical check
+        itself, rather than incidentally failing because the path is missing.
+        """
+        (self.repo / ".context-os" / "memory-directory").write_text(
+            self.msys(self.memory) + "/../" + self.memory.name + "\n", encoding="utf-8"
+        )
+        self.assertIn("canonical", self.assert_rejects("resolve"))
 
     def helper(self, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
         normalized = list(args)
@@ -1282,3 +1336,38 @@ class DreamMemoryPathTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+WINDOWS = os.name == "nt"
+
+
+class NativePathTests(unittest.TestCase):
+    """docs/auto-memory.md builds both recorded paths in bash, so on Windows they
+    arrive MSYS-spelled (/c/Users/...). These cover the translation AND, more
+    importantly, that translating a path does not let a bad one through."""
+
+    def setUp(self) -> None:
+        spec = importlib.util.spec_from_file_location("validate_memory", HELPER)
+        self.vm = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.vm)
+
+    @unittest.skipUnless(WINDOWS, "MSYS spellings only need translating on Windows")
+    def test_translates_msys_and_cygwin_drive_forms(self) -> None:
+        self.assertEqual(self.vm.native_path("/c/Users/me/memory"), r"C:\Users\me\memory")
+        self.assertEqual(self.vm.native_path("/cygdrive/c/Users/me/memory"), r"C:\Users\me\memory")
+        self.assertEqual(self.vm.native_path("/D/data"), r"D:\data")
+
+    @unittest.skipUnless(WINDOWS, "Windows-only spelling")
+    def test_leaves_native_windows_paths_untouched(self) -> None:
+        for raw in (r"C:\Users\me\memory", "C:/Users/me/memory"):
+            self.assertEqual(self.vm.native_path(raw), raw)
+
+    @unittest.skipIf(WINDOWS, "on POSIX /c/... is a real path, not a drive")
+    def test_is_a_no_op_on_posix(self) -> None:
+        for raw in ("/c/Users/me/memory", "/cygdrive/c/x", "/home/me/memory"):
+            self.assertEqual(self.vm.native_path(raw), raw)
+
+    def test_does_not_invent_a_path_for_junk(self) -> None:
+        """Untranslatable input must come back unchanged so the caller's own
+        checks reject it, rather than being guessed into something plausible."""
+        self.assertEqual(self.vm.native_path("relative/not/absolute"), "relative/not/absolute")

--- a/tests/test_dream_paths.py
+++ b/tests/test_dream_paths.py
@@ -1,9 +1,66 @@
 import json
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+# Shell out to the interpreter running these tests, never a bare "python3".
+#
+# On Windows "python3" resolves to the Microsoft Store App Execution Alias — a
+# stub that prints "Python was not found; run without arguments to install from
+# the Microsoft Store" and exits WITHOUT running Python. Every test that shells
+# out then reads empty stdout and dies on json.loads(""), which surfaces as
+# "Expecting value: line 1 column 1 (char 0)" and looks like a helper bug rather
+# than a missing interpreter. That took out 34 of 89 tests.
+#
+# sys.executable is also correct on POSIX and in a venv, where a bare "python3"
+# can be a DIFFERENT interpreter than the one running the suite.
+PYTHON = sys.executable
+
+
+def _symlinks_available() -> bool:
+    """Can this process actually create a symlink?
+
+    Probed, not inferred from the OS name: Windows CAN create symlinks when the
+    account holds SeCreateSymbolicLinkPrivilege (Developer Mode, or elevated).
+    Gating on `os.name == "nt"` would permanently skip these on machines that are
+    perfectly capable of running them, and these are security tests -- the cost of
+    an unnecessary skip is a real hole in coverage.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        (base / "target").write_text("probe", encoding="utf-8")
+        try:
+            (base / "link").symlink_to(base / "target")
+        except (OSError, NotImplementedError):
+            return False
+        return True
+
+
+def _git_tracks_file_mode() -> bool:
+    """Does Git record the executable bit on this filesystem?
+
+    Git for Windows sets core.fileMode=false because NTFS has no exec bit to read,
+    so a chmod is invisible and a test asserting "the mode change is detected" can
+    never pass there. Probed against a scratch repo so the answer reflects the
+    filesystem actually under test, not a guess.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            subprocess.run(["git", "init", "-q"], cwd=tmp, check=True,
+                           capture_output=True)
+            value = subprocess.run(["git", "config", "core.fileMode"], cwd=tmp,
+                                   capture_output=True, text=True).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            return False
+        return value != "false"
+
+
+SYMLINKS_AVAILABLE = _symlinks_available()
+GIT_TRACKS_FILE_MODE = _git_tracks_file_mode()
+
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,9 +93,11 @@ class DreamMemoryPathTests(unittest.TestCase):
         run(["git", "init", "-q"], self.repo)
         run(["git", "config", "user.name", "Dream Test"], self.repo)
         run(["git", "config", "user.email", "dream@example.invalid"], self.repo)
+        self.pin_line_endings(self.repo)
         run(["git", "init", "-q"], self.memory)
         run(["git", "config", "user.name", "Dream Memory"], self.memory)
         run(["git", "config", "user.email", "dream-memory@example.invalid"], self.memory)
+        self.pin_line_endings(self.memory)
         (self.repo / ".context-os").mkdir()
         (self.repo / ".context-os" / "memory-directory").write_text(
             f"{self.memory}\n", encoding="utf-8"
@@ -61,6 +120,24 @@ class DreamMemoryPathTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
+    @staticmethod
+    def pin_line_endings(repo: Path) -> None:
+        """Stop the host's Git config from rewriting bytes these tests hash.
+
+        Git for Windows sets core.autocrlf=true at SYSTEM level, so a fixture repo
+        inherits it even though nothing here asks for it. The suite then compares a
+        digest of worktree bytes against the staged blob: Python's write_text()
+        emits CRLF on Windows, autocrlf normalizes it back to LF on `git add`, the
+        two digests differ, and the failure reads "staged bytes do not match the
+        reviewed change digest" -- i.e. exactly like the tamper-detection working
+        as designed, which is the worst possible disguise for an environment bug.
+
+        Pinned per-repo rather than relying on a global, so the suite is
+        deterministic regardless of how the developer's Git is configured.
+        """
+        run(["git", "config", "core.autocrlf", "false"], repo)
+        run(["git", "config", "core.eol", "lf"], repo)
+
     def helper(self, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
         normalized = list(args)
         if (
@@ -70,7 +147,7 @@ class DreamMemoryPathTests(unittest.TestCase):
             and "--for-commit" not in normalized
         ):
             normalized.append("--for-commit")
-        return run(["python3", str(HELPER), *normalized], cwd or self.repo, check=False)
+        return run([PYTHON, str(HELPER), *normalized], cwd or self.repo, check=False)
 
     def write_archive(self, *rows: str) -> None:
         (self.memory / "ARCHIVE.md").write_text(
@@ -148,7 +225,7 @@ class DreamMemoryPathTests(unittest.TestCase):
         run(["git", "commit", "-qm", "dream artifact"], self.memory)
         clean_apply = run(
             [
-                "python3",
+                PYTHON,
                 str(HELPER),
                 "artifact",
                 "2026-08-15T10-19-00Z",
@@ -163,10 +240,12 @@ class DreamMemoryPathTests(unittest.TestCase):
         self.assertIn("timestamp", self.assert_rejects("artifact", "2026-08-15T10-19-00Z\nx"))
         self.assertIn("timestamp", self.assert_rejects("artifact", "2026-99-99T99-99-99Z"))
 
+    @unittest.skipUnless(SYMLINKS_AVAILABLE, "needs symlink privilege (Windows: Developer Mode)")
     def test_artifact_rejects_symlinked_components(self) -> None:
         (self.memory / ".dreams").symlink_to(self.root)
         self.assertIn("symlink", self.assert_rejects("artifact", "2026-08-15T10-19-00Z"))
 
+    @unittest.skipUnless(SYMLINKS_AVAILABLE, "needs symlink privilege (Windows: Developer Mode)")
     def test_proposals_reject_path_escape_absolute_and_symlink_targets(self) -> None:
         proposal = self.valid_modify()
         proposal["target"] = "../outside.md"
@@ -710,6 +789,7 @@ class DreamMemoryPathTests(unittest.TestCase):
         self.assertEqual(staged.returncode, 0, staged.stderr)
         self.assertEqual(json.loads(staged.stdout)["change_digest"], digest)
 
+    @unittest.skipUnless(GIT_TRACKS_FILE_MODE, "git core.fileMode is false; no exec bit on this filesystem")
     def test_staged_digest_rejects_unreviewed_mode_change(self) -> None:
         target = self.memory / "project_alpha.md"
         target.write_text("reviewed replacement\n", encoding="utf-8")

--- a/tests/test_dream_paths.py
+++ b/tests/test_dream_paths.py
@@ -85,7 +85,15 @@ def run(command: list[str], cwd: Path, *, check: bool = True) -> subprocess.Comp
 class DreamMemoryPathTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
-        self.root = Path(self.tmp.name)
+        # .resolve() matters: on Windows the temp root can come back as an 8.3
+        # SHORT NAME (C:\Users\RUNNER~1\... on GitHub's runners). The fixture
+        # records this path in .context-os/memory-directory, and the helper
+        # rightly rejects a non-canonical binding -- so an unresolved tempdir
+        # fails most of the suite with "must be canonical with no '..' or
+        # symlinks", blaming the binding rather than the fixture. It reproduces
+        # only where the account name exceeds 8 characters, which is why a local
+        # Windows run can pass while CI does not.
+        self.root = Path(self.tmp.name).resolve()
         self.repo = self.root / "repo"
         self.memory = self.root / "memory"
         self.repo.mkdir()


### PR DESCRIPTION
The suite was **34 failed / 55 passed** on Windows and green on Linux CI, so nothing reported it. Chasing each failure to its real cause turned up four environment problems and **two genuine portability bugs in shipped code** — the memory binding did not work on Windows at all for anyone who followed `docs/auto-memory.md`.

## Shipped-code bugs

**1. The identity marker was compared as a string.** The same directory has three spellings:

```
git rev-parse    C:/Users/me/repo/.git     (forward slashes, even on Windows)
Path.resolve()   C:\Users\me\repo\.git
```

Byte-identical only on POSIX. On Windows this rejected every correctly-configured binding. Now compares resolved paths.

**2. The documented setup recorded paths Python could not address.** `docs/auto-memory.md` builds both files in bash; under Git Bash those are MSYS-spelled (`/c/Users/...`, or `/tmp/...` for a shell mount), which native Python reads as drive-less — dying at the `is_absolute()` gate with *"must be absolute"*. `native_path()` now translates before validation: drive-letter forms by pattern, anything else via `cygpath` (ships with Git for Windows). Untranslatable input is returned unchanged so the caller rejects it rather than guessing.

**Neither change loosens anything.** Both are spelling normalizations applied *before* the existing checks. A translated path still must be absolute, non-symlinked, canonical, existing, and a directory; the marker still must name the same repository; unresolvable input fails closed. Three tests pin exactly this: a wrong marker stays rejected when MSYS-spelled, and a `/../` path that **resolves to a real directory** — so it clears the existence gate and must be caught by the canonical check itself — stays rejected too.

## Environment causes

| Cause | Failures |
|---|---:|
| Tests shelled out to bare `python3` — on Windows that's the Store stub, which prints an install ad and runs nothing | 34 → 31 |
| Identity compared as a string (bug 1 above) | 31 → 10 |
| `core.autocrlf=true` (system default) rewriting bytes under a digest check | 10 → 3 |
| Security tests needing symlinks / a git-visible exec bit | 3 → 0 |

The CRLF one deserves a note: the mismatch surfaced as *"staged bytes do not match the reviewed change digest"* — the tamper detection appearing to work correctly. The worst possible disguise for an environment bug.

For the three capability-limited tests I gated on a **probe of the actual capability**, not `os.name` — these are security tests, and a Windows box with Developer Mode should still run them. That paid off: GitHub's runner allows symlinks, so it skips 1 where a local run skips 3.

## CI

Adds a `windows-latest` job running the Python suite. `validate-all.sh` stays Linux-only (it's a bash pipeline with `find`/`chmod`), but the Python tests are the part with real per-platform exposure — and a Linux-only matrix is why all of this lived on `main` undetected.

**It earned its keep on the first run**, failing on something no local run could reproduce: GitHub's temp root is an 8.3 short name (`C:\Users\RUNNER~1\...`), so the fixture recorded a non-canonical path and the helper correctly rejected it. Only reproduces when the account name exceeds 8 characters — "conor" isn't mangled, so local was green at 86/3 while CI was red at 27 failures + 5 errors.

## Verification

- Windows: **97 tests, 4 skipped**; Linux: **97, 1 skipped** — both green in CI
- The documented snippet, run verbatim in Git Bash: previously *"must be absolute"*, now resolves
- Mutation-tested — always-equal identities, dropping the translation, skipping the canonical check, reverting the row key, and removing the orphan guard each turn the suite red
- `check-links`, `validate-skills`, `integrations.py check` all pass

## Possible follow-up

A `bind` subcommand that writes both files itself would retire the hand-rolled step entirely and make the docs one command — the tool that reads the marker would also write it, so the two could not disagree by construction. Roughly 50 lines plus tests. Not included here; happy to add it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)