### PR TITLE
Add a bind command, and enforce that memory lives outside the repo

### DIFF
--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -12,13 +12,33 @@ The `/dream` and `/dream-apply` commands need a stable, explicit directory becau
 
 ## Explicit directory contract for `/dream`
 
-1. Choose a private absolute directory outside this repository.
+1. Choose a private absolute directory outside this repository. This is enforced, not just advised: a store inside the working tree or the git directory is rejected, because private memory in a shared checkout is one `git add -A` from being staged.
 2. Set Claude Code's `autoMemoryDirectory` to that exact absolute path in the project-local `.claude/settings.local.json`, which this repository ignores. Claude Code also supports other settings scopes, but a local file avoids changing unrelated repositories. Do not commit personal paths.
 3. Confirm with `/memory` that Claude Code is using the intended store and that its `MEMORY.md` belongs to this workspace.
 4. Record the same absolute path as the only line of the ignored local file `.context-os/memory-directory`.
 5. Put the resolved git common directory as the only line of `<memory-directory>/.context-os-repository`. That identity is stable across linked worktrees, unlike a checkout root.
 
-Example setup, after replacing the placeholder and reviewing every destination:
+Steps 4 and 5 are what `bind` does for you:
+
+```bash
+python scripts/dream/validate-memory.py bind   --memory-dir /absolute/private/path/to/this-workspace-memory
+```
+
+It writes both recorded files, creates the directory, `archive/`, a git repo,
+and `MEMORY.md` if they are absent, and then runs the real validator and prints
+its verdict — so a zero exit means the binding actually resolves, not that the
+command finished. Prefer it to writing the files by hand: both are read by this
+same script, and every path bug this setup has had came from a shell and a
+Python script disagreeing about how to spell one directory.
+
+It will not overwrite content it did not create, and it refuses to repoint an
+existing binding, or to claim a store already bound to another repository,
+unless you pass `--force`. Re-running it against the same directory is a no-op.
+
+<details>
+<summary>Equivalent by hand</summary>
+
+After replacing the placeholder and reviewing every destination:
 
 ```bash
 MEMORY_DIR="/absolute/private/path/to/this-workspace-memory"
@@ -27,6 +47,8 @@ mkdir -p "$MEMORY_DIR/archive" .context-os
 printf '%s\n' "$MEMORY_DIR" > .context-os/memory-directory
 printf '%s\n' "$REPO_ID" > "$MEMORY_DIR/.context-os-repository"
 ```
+
+</details>
 
 These commands run unchanged on macOS, Linux, and Windows under Git Bash. On
 Windows they record MSYS-style paths (`/c/Users/...`, and `/tmp/...` for a shell

--- a/scripts/dream/validate-memory.py
+++ b/scripts/dream/validate-memory.py
@@ -300,6 +300,42 @@ def changed_memory_paths(memory_dir: Path) -> set[str]:
     )
 
 
+def require_outside_repository(memory_dir: Path, repo: Path, identity: str) -> None:
+    """Refuse a memory directory that lives inside the repository.
+
+    docs/auto-memory.md step 1 says "a private absolute directory OUTSIDE this
+    repository", and until now nothing enforced it: a memory dir nested in the
+    working tree passed every check, because it is its own git top-level and so
+    satisfied the one test that came close.
+
+    Nesting it is the failure this whole binding exists to prevent. Private
+    memory inside a shared checkout is one `git add -A` away from being staged
+    as a gitlink, one `rm -rf .git` away from being committed wholesale, and it
+    travels with any archive of the repo. The repo here is shared with other
+    people, so "it is only local" is not a property that holds.
+
+    Checks the working tree and the git common directory separately: a linked
+    worktree's toplevel is not under its common dir, so testing one does not
+    cover the other.
+    """
+    try:
+        worktree = Path(run_git(["rev-parse", "--show-toplevel"], cwd=repo)).resolve(strict=True)
+    except (ValidationError, OSError):
+        worktree = repo
+
+    for root, what in ((worktree, "working tree"), (Path(identity), "git directory")):
+        try:
+            inside = memory_dir == root or memory_dir.is_relative_to(root)
+        except (OSError, ValueError):
+            continue
+        if inside:
+            raise ValidationError(
+                f"memory directory must live outside this repository; it is inside the {what} "
+                f"({memory_dir}). Move it to a private path outside {root} and update "
+                ".context-os/memory-directory."
+            )
+
+
 def validate_memory_binding(repo: Path, *, require_clean: bool = False) -> dict[str, str]:
     repo = repo.resolve(strict=True)
     identity = repository_identity(repo)
@@ -308,6 +344,8 @@ def validate_memory_binding(repo: Path, *, require_clean: bool = False) -> dict[
         read_single_line(binding, ".context-os/memory-directory"),
         ".context-os/memory-directory",
     )
+
+    require_outside_repository(memory_dir, repo, identity)
 
     marker = memory_dir / ".context-os-repository"
     marker_value = read_single_line(marker, "memory repository marker")
@@ -1324,6 +1362,20 @@ def build_parser() -> argparse.ArgumentParser:
     subcommands = parser.add_subparsers(dest="command", required=True)
     subcommands.add_parser("resolve", help="validate and print the memory binding")
 
+    bind = subcommands.add_parser(
+        "bind", help="write the memory binding for this repository, then validate it"
+    )
+    bind.add_argument(
+        "--memory-dir",
+        required=True,
+        help="absolute path to a private memory directory outside this repository",
+    )
+    bind.add_argument(
+        "--force",
+        action="store_true",
+        help="repoint an existing binding, or claim a store bound to another repository",
+    )
+
     artifact = subcommands.add_parser("artifact", help="validate or allocate a dream artifact")
     artifact.add_argument("timestamp", help="YYYY-MM-DDTHH-MM-SSZ or latest")
     artifact.add_argument(
@@ -1377,12 +1429,103 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def cmd_bind(args: argparse.Namespace) -> dict[str, str]:
+    """Write both halves of the binding, then prove the result validates.
+
+    The two recorded files have always been written by hand, in a shell, from a
+    doc — while being read by this script, in Python. Nothing kept the two
+    spellings in agreement, and both Windows bugs fixed alongside this came from
+    exactly that split: a marker git spelled `C:/...` compared against a
+    a backslash-separated resolve, and a memory path bash spelled `/c/...` that Python read
+    as relative. Normalizing on read treats the symptom. Writing both files here,
+    in the same code that reads them, removes the disagreement by construction.
+
+    Deliberately conservative about existing state. It creates the memory
+    directory, `archive/`, a git repo, and MEMORY.md only when they are ABSENT,
+    never resetting or emptying one that is already there, and it refuses to
+    repoint a binding that already names somewhere else unless --force says so.
+    A memory store is the one thing in this system with no upstream copy.
+    """
+    repo = Path.cwd().resolve(strict=True)
+    identity = repository_identity(repo)
+
+    raw = args.memory_dir
+    if CONTROL.search(raw):
+        raise ValidationError("--memory-dir contains a control character")
+    target = Path(native_path(raw))
+    if not target.is_absolute():
+        raise ValidationError(f"--memory-dir must be absolute: {raw}")
+    if target.is_symlink():
+        raise ValidationError(f"--memory-dir must not be a symlink: {target}")
+
+    # Resolve non-strictly: the directory may not exist yet, but '..' and any
+    # symlinked parent must still collapse before anything is written, or we
+    # would record a path that fails the canonical check on the very next read.
+    target = Path(os.path.abspath(target))
+    if target.exists():
+        target = target.resolve(strict=True)
+        if not target.is_dir():
+            raise ValidationError(f"--memory-dir exists and is not a directory: {target}")
+
+    require_outside_repository(target, repo, identity)
+
+    binding = repo / ".context-os" / "memory-directory"
+    if binding.exists() and not args.force:
+        current = read_single_line(binding, ".context-os/memory-directory")
+        if not same_directory(current, str(target)):
+            raise ValidationError(
+                f".context-os/memory-directory already points at {current}. "
+                "Re-run with --force to repoint it, after confirming the existing "
+                "memory store is somewhere you can still reach."
+            )
+
+    marker = target / ".context-os-repository"
+    if marker.exists() and not args.force:
+        existing = read_single_line(marker, "memory repository marker")
+        if not same_directory(existing, identity):
+            raise ValidationError(
+                f"{target} is already bound to a different repository ({existing}). "
+                "Re-run with --force only if you mean to hand this memory store to "
+                "this repository."
+            )
+
+    created = []
+    for directory in (target, target / "archive"):
+        if not directory.exists():
+            directory.mkdir(parents=True)
+            created.append(str(directory))
+
+    if not (target / ".git").exists():
+        run_git(["init", "-q"], cwd=target)
+        created.append(str(target / ".git"))
+
+    index = target / "MEMORY.md"
+    if not index.exists():
+        index.write_text("# Memory\n", encoding="utf-8")
+        created.append(str(index))
+
+    binding.parent.mkdir(parents=True, exist_ok=True)
+    # Newline-terminated single line: read_single_line rejects anything else.
+    binding.write_text(f"{target}\n", encoding="utf-8")
+    marker.write_text(f"{identity}\n", encoding="utf-8")
+
+    # Prove it. A bind that reports success without the validator agreeing is
+    # the failure this command exists to prevent, so run the real check rather
+    # than trusting that we wrote the right bytes. require_clean stays off: the
+    # marker we just wrote is legitimately uncommitted.
+    result = validate_memory_binding(repo, require_clean=False)
+    result["created"] = ", ".join(created) if created else "nothing (all present)"
+    return result
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
         if args.command == "resolve":
             result = cmd_resolve(args)
+        elif args.command == "bind":
+            result = cmd_bind(args)
         elif args.command == "artifact":
             if args.for_create and args.for_commit:
                 raise ValidationError("--for-create and --for-commit are mutually exclusive")

--- a/tests/test_dream_paths.py
+++ b/tests/test_dream_paths.py
@@ -84,7 +84,15 @@ def run(command: list[str], cwd: Path, *, check: bool = True) -> subprocess.Comp
     return completed
 
 
-class DreamMemoryPathTests(unittest.TestCase):
+class MemoryFixture(unittest.TestCase):
+    """Fixture only -- deliberately holds NO tests.
+
+    Split out because subclassing a class that carries tests re-runs every
+    one of them under the subclass's name: two subclasses turned an 97-test
+    suite into 182 and roughly tripled the runtime, for eleven new cases.
+    Anything needing the repo+memory pair inherits this instead.
+    """
+
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
         # .resolve() matters: on Windows the temp root can come back as an 8.3
@@ -154,52 +162,6 @@ class DreamMemoryPathTests(unittest.TestCase):
         drive, rest = str(path).split(":", 1)
         return f"/{drive.lower()}{rest.replace(chr(92), '/')}"
 
-    @unittest.skipUnless(os.name == "nt", "the binding is already native on POSIX")
-    def test_msys_spelled_binding_is_accepted(self) -> None:
-        (self.repo / ".context-os" / "memory-directory").write_text(
-            self.msys(self.memory) + "\n", encoding="utf-8"
-        )
-        resolved = self.helper("resolve")
-        self.assertEqual(resolved.returncode, 0, resolved.stderr)
-        self.assertEqual(json.loads(resolved.stdout)["memory_dir"], str(self.memory))
-
-    @unittest.skipUnless(os.name == "nt", "the marker is already native on POSIX")
-    def test_msys_spelled_marker_is_accepted(self) -> None:
-        identity = run(
-            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], self.repo
-        ).stdout.strip()
-        (self.memory / ".context-os-repository").write_text(
-            self.msys(Path(identity).resolve()) + "\n", encoding="utf-8"
-        )
-        # resolve also demands a clean memory repo, so commit the rewritten marker
-        # or this asserts on the wrong failure.
-        run(["git", "add", "-A"], self.memory)
-        run(["git", "commit", "-qm", "msys marker"], self.memory)
-        resolved = self.helper("resolve")
-        self.assertEqual(resolved.returncode, 0, resolved.stderr)
-
-    @unittest.skipUnless(os.name == "nt", "Windows-only spelling")
-    def test_a_wrong_marker_is_still_rejected_when_msys_spelled(self) -> None:
-        """Translating the spelling must not become a way to smuggle a
-        mismatched identity past the check."""
-        (self.memory / ".context-os-repository").write_text(
-            "/c/definitely/not/this/repo/.git\n", encoding="utf-8"
-        )
-        self.assertIn("marker", self.assert_rejects("resolve"))
-
-    @unittest.skipUnless(os.name == "nt", "Windows-only spelling")
-    def test_a_noncanonical_msys_path_is_still_rejected(self) -> None:
-        """Translating the spelling must not translate away the '..' check.
-
-        Uses <memory>/../memory, which RESOLVES to a real directory -- so it gets
-        past the existence gate and has to be caught by the canonical check
-        itself, rather than incidentally failing because the path is missing.
-        """
-        (self.repo / ".context-os" / "memory-directory").write_text(
-            self.msys(self.memory) + "/../" + self.memory.name + "\n", encoding="utf-8"
-        )
-        self.assertIn("canonical", self.assert_rejects("resolve"))
-
     def helper(self, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
         normalized = list(args)
         if (
@@ -254,6 +216,54 @@ class DreamMemoryPathTests(unittest.TestCase):
         completed = self.helper(*args, cwd=cwd)
         self.assertNotEqual(completed.returncode, 0, completed.stdout)
         return completed.stderr
+
+
+class DreamMemoryPathTests(MemoryFixture):
+    @unittest.skipUnless(os.name == "nt", "the binding is already native on POSIX")
+    def test_msys_spelled_binding_is_accepted(self) -> None:
+        (self.repo / ".context-os" / "memory-directory").write_text(
+            self.msys(self.memory) + "\n", encoding="utf-8"
+        )
+        resolved = self.helper("resolve")
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        self.assertEqual(json.loads(resolved.stdout)["memory_dir"], str(self.memory))
+
+    @unittest.skipUnless(os.name == "nt", "the marker is already native on POSIX")
+    def test_msys_spelled_marker_is_accepted(self) -> None:
+        identity = run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], self.repo
+        ).stdout.strip()
+        (self.memory / ".context-os-repository").write_text(
+            self.msys(Path(identity).resolve()) + "\n", encoding="utf-8"
+        )
+        # resolve also demands a clean memory repo, so commit the rewritten marker
+        # or this asserts on the wrong failure.
+        run(["git", "add", "-A"], self.memory)
+        run(["git", "commit", "-qm", "msys marker"], self.memory)
+        resolved = self.helper("resolve")
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only spelling")
+    def test_a_wrong_marker_is_still_rejected_when_msys_spelled(self) -> None:
+        """Translating the spelling must not become a way to smuggle a
+        mismatched identity past the check."""
+        (self.memory / ".context-os-repository").write_text(
+            "/c/definitely/not/this/repo/.git\n", encoding="utf-8"
+        )
+        self.assertIn("marker", self.assert_rejects("resolve"))
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only spelling")
+    def test_a_noncanonical_msys_path_is_still_rejected(self) -> None:
+        """Translating the spelling must not translate away the '..' check.
+
+        Uses <memory>/../memory, which RESOLVES to a real directory -- so it gets
+        past the existence gate and has to be caught by the canonical check
+        itself, rather than incidentally failing because the path is missing.
+        """
+        (self.repo / ".context-os" / "memory-directory").write_text(
+            self.msys(self.memory) + "/../" + self.memory.name + "\n", encoding="utf-8"
+        )
+        self.assertIn("canonical", self.assert_rejects("resolve"))
 
     def test_resolve_accepts_real_repo_and_linked_worktree_identity(self) -> None:
         resolved = self.helper("resolve")
@@ -1334,6 +1344,7 @@ class DreamMemoryPathTests(unittest.TestCase):
         )
 
 
+
 if __name__ == "__main__":
     unittest.main()
 
@@ -1371,3 +1382,154 @@ class NativePathTests(unittest.TestCase):
         """Untranslatable input must come back unchanged so the caller's own
         checks reject it, rather than being guessed into something plausible."""
         self.assertEqual(self.vm.native_path("relative/not/absolute"), "relative/not/absolute")
+
+
+class OutsideRepositoryTests(MemoryFixture):
+    """docs/auto-memory.md step 1 requires the memory directory to live OUTSIDE
+    the repository. Until this guard existed nothing enforced it: a nested store
+    is its own git top-level, which satisfied the closest existing check."""
+
+    def rebind(self, path: Path) -> None:
+        (self.repo / ".context-os" / "memory-directory").write_text(
+            str(path) + "\n", encoding="utf-8"
+        )
+
+    def make_store(self, path: Path) -> None:
+        path.mkdir(parents=True)
+        run(["git", "init", "-q"], path)
+        run(["git", "config", "user.name", "m"], path)
+        run(["git", "config", "user.email", "m@e.invalid"], path)
+        self.pin_line_endings(path)
+        identity = run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], self.repo
+        ).stdout.strip()
+        (path / ".context-os-repository").write_text(
+            str(Path(identity).resolve()) + "\n", encoding="utf-8"
+        )
+        (path / "MEMORY.md").write_text("# Memory\n", encoding="utf-8")
+        run(["git", "add", "-A"], path)
+        run(["git", "commit", "-qm", "base"], path)
+
+    def test_memory_inside_the_working_tree_is_rejected(self) -> None:
+        nested = self.repo / "private-memory"
+        self.make_store(nested)
+        self.rebind(nested)
+        self.assertIn("outside this repository", self.assert_rejects("resolve"))
+
+    def test_memory_inside_the_git_directory_is_rejected(self) -> None:
+        nested = self.repo / ".git" / "memory"
+        self.make_store(nested)
+        self.rebind(nested)
+        self.assertIn("outside this repository", self.assert_rejects("resolve"))
+
+    def test_a_sibling_directory_is_still_accepted(self) -> None:
+        """The guard must reject nesting, not every path that shares a prefix.
+        `repo-memory` starts with the repo directory's own name and must bind."""
+        sibling = self.root / "repo-memory"
+        self.make_store(sibling)
+        self.rebind(sibling)
+        resolved = self.helper("resolve")
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+
+
+class BindCommandTests(MemoryFixture):
+    """bind writes both recorded files from the same code that reads them, so
+    the two spellings cannot drift apart the way they did on Windows."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The fixture arrives already bound to self.memory. bind's job is
+        # first-time setup, and binding somewhere else is supposed to be refused
+        # without --force, so start from an unbound repo or every case here
+        # asserts on that refusal instead of on bind.
+        (self.repo / ".context-os" / "memory-directory").unlink()
+
+    def test_bind_produces_a_binding_resolve_accepts(self) -> None:
+        target = self.root / "fresh-memory"
+        bound = self.helper("bind", "--memory-dir", str(target))
+        self.assertEqual(bound.returncode, 0, bound.stderr)
+        self.assertEqual(json.loads(bound.stdout)["memory_dir"], str(target))
+        run(["git", "add", "-A"], target)
+        run(["git", "commit", "-qm", "bound"], target)
+        resolved = self.helper("resolve")
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        self.assertEqual(json.loads(resolved.stdout)["memory_dir"], str(target))
+
+    def test_bind_creates_the_scaffolding_it_reports(self) -> None:
+        target = self.root / "fresh-memory"
+        self.helper("bind", "--memory-dir", str(target))
+        self.assertTrue((target / "archive").is_dir())
+        self.assertTrue((target / ".git").exists())
+        self.assertTrue((target / "MEMORY.md").is_file())
+        self.assertTrue((target / ".context-os-repository").is_file())
+
+    def test_rebinding_the_same_directory_is_idempotent(self) -> None:
+        target = self.root / "fresh-memory"
+        self.helper("bind", "--memory-dir", str(target))
+        again = self.helper("bind", "--memory-dir", str(target))
+        self.assertEqual(again.returncode, 0, again.stderr)
+        self.assertIn("nothing", json.loads(again.stdout)["created"])
+
+    def test_bind_never_empties_an_existing_store(self) -> None:
+        """The memory store is the one thing in this system with no upstream
+        copy, so a re-bind must not reset content it did not create."""
+        target = self.root / "fresh-memory"
+        self.helper("bind", "--memory-dir", str(target))
+        (target / "MEMORY.md").write_text("# Real memory\nkeep me\n", encoding="utf-8")
+        (target / "project_gamma.md").write_text("gamma\n", encoding="utf-8")
+        self.helper("bind", "--memory-dir", str(target))
+        self.assertIn("keep me", (target / "MEMORY.md").read_text(encoding="utf-8"))
+        self.assertTrue((target / "project_gamma.md").is_file())
+
+    def test_repointing_an_existing_binding_needs_force(self) -> None:
+        first = self.root / "first-memory"
+        second = self.root / "second-memory"
+        self.helper("bind", "--memory-dir", str(first))
+        refused = self.helper("bind", "--memory-dir", str(second))
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn("already points at", refused.stderr)
+        forced = self.helper("bind", "--memory-dir", str(second), "--force")
+        self.assertEqual(forced.returncode, 0, forced.stderr)
+
+    def test_claiming_a_store_bound_elsewhere_needs_force(self) -> None:
+        target = self.root / "someone-elses-memory"
+        target.mkdir()
+        (target / ".context-os-repository").write_text(
+            str(self.root / "other-repo" / ".git") + "\n", encoding="utf-8"
+        )
+        refused = self.helper("bind", "--memory-dir", str(target))
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn("already bound to a different repository", refused.stderr)
+
+    def test_bind_refuses_a_directory_inside_the_repository(self) -> None:
+        refused = self.helper("bind", "--memory-dir", str(self.repo / "inside"))
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn("outside this repository", refused.stderr)
+        self.assertFalse(
+            (self.repo / "inside").exists(), "a refused bind must not create anything"
+        )
+
+    def test_bind_refuses_a_relative_path(self) -> None:
+        refused = self.helper("bind", "--memory-dir", "relative/memory")
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn("absolute", refused.stderr)
+
+    def test_bind_reports_failure_when_the_binding_it_wrote_is_invalid(self) -> None:
+        """bind must return the validator's verdict, not its own optimism.
+
+        Writing the two files is the easy half; the claim that matters is that a
+        zero exit means the binding actually validates. Constructed so the writes
+        all succeed and validation still must fail: the target is already a git
+        repo with a remote, which the binding rules forbid. If bind ever stops
+        running the real check and reports what it intended to write, this goes
+        green while `resolve` disagrees -- the precise failure bind exists to
+        prevent.
+        """
+        target = self.root / "memory-with-remote"
+        target.mkdir()
+        run(["git", "init", "-q"], target)
+        run(["git", "remote", "add", "origin", "https://example.invalid/m.git"], target)
+
+        bound = self.helper("bind", "--memory-dir", str(target))
+        self.assertNotEqual(bound.returncode, 0, bound.stdout)
+        self.assertIn("remote", bound.stderr)

--- a/tests/test_dream_paths.py
+++ b/tests/test_dream_paths.py
@@ -1449,6 +1449,13 @@ class BindCommandTests(MemoryFixture):
         bound = self.helper("bind", "--memory-dir", str(target))
         self.assertEqual(bound.returncode, 0, bound.stderr)
         self.assertEqual(json.loads(bound.stdout)["memory_dir"], str(target))
+        # bind git-inits the store but does not set an identity, and it should
+        # not -- that is the user's global config. The TEST must not depend on
+        # one existing though: a clean CI runner has none, and this failed with
+        # "empty ident name" the first time it ran anywhere but a dev box.
+        run(["git", "config", "user.name", "Bind Test"], target)
+        run(["git", "config", "user.email", "bind@example.invalid"], target)
+        self.pin_line_endings(target)
         run(["git", "add", "-A"], target)
         run(["git", "commit", "-qm", "bound"], target)
         resolved = self.helper("resolve")


### PR DESCRIPTION
Reopens the work from #31, which GitHub auto-closed when #30 merged and deleted its base branch. Same two commits, rebased onto the merged `main`.

## Hardening — a memory directory inside the repo is now rejected

`docs/auto-memory.md` step 1 has always said *"a private absolute directory **outside** this repository"*. Nothing checked it — a nested store is its own git top-level, which satisfied the one existing test that came close. I confirmed it was accepted before this change.

Nesting is the exact failure the binding exists to prevent: private memory in a shared checkout is one `git add -A` from being staged as a gitlink, one `rm -rf .git` from being committed wholesale, and it travels with any archive of the repo.

The working tree and the git common directory are checked **separately** — a linked worktree's toplevel isn't under its common dir. A sibling that merely shares a name prefix (`repo-memory` beside `repo`) still binds; there's a test for that, because a prefix check is the easy wrong implementation.

## `bind` — the tool that reads the marker now writes it

```bash
python scripts/dream/validate-memory.py bind --memory-dir /private/path/to/memory
```

The two recorded files were written by hand, in a shell, from a doc — while being read by this script, in Python. Nothing kept the spellings in agreement, and **both** Windows bugs fixed in #30 came from that split. Normalizing on read treats the symptom.

Conservative about existing state, because a memory store has no upstream copy:

- creates the directory, `archive/`, a git repo, and `MEMORY.md` **only when absent** — never resets one already there
- refuses to repoint a binding, or claim a store bound elsewhere, without `--force`
- re-running against the same directory is a no-op; a refused bind creates nothing
- ends by running the real validator and returning **its** verdict, so a zero exit means the binding resolves

## The mutation pass found a hole in my own tests

Replacing `bind`'s self-validation with a fabricated result **passed the first version of this suite** — so "it proves the binding validates" was untested. Fixed with a case that forces the two apart: a target that is already a git repo **with a remote**, so every write succeeds and validation must still fail.

| Mutation | Caught |
|---|---|
| Drop the outside-repo guard | ✅ |
| `bind` allows a silent repoint | ✅ |
| `bind` allows a silent store claim | ✅ |
| `bind` overwrites `MEMORY.md` | ✅ |
| `bind` skips its own validation | ✅ *(after the added test)* |

## Also: extracted `MemoryFixture`

Subclassing a class that carries tests re-runs all of them under the subclass's name — my two new subclasses took the suite from 97 to **182** tests and roughly tripled runtime, the same mistake #30 removed. Fixture extracted; **109 tests in ~46s**.

## Verification

Stacked PRs get no checks here (`validate.yml` only fires for PRs to `main`), so I ran the Linux gate in WSL rather than leave it unverified. That caught a real bug: one test committed inside the store `bind` had just git-init'd, which only works if the machine already has a global git identity — mine does, clean runners don't. Same class as the `python3`/`autocrlf`/8.3 bugs.

- **Linux (WSL, no global git identity):** `validate-all.sh` fully green — 109 tests, 6 skipped
- **Windows:** 109 tests, 4 skipped
- Rebased branch re-verified after the rebase, not just before

## Note

`scripts/validate-all.sh` still can't run on Windows — it invokes `python3`, the Store stub there. Making it portable is a small separate change if you want Windows devs running the full gate locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)