### PR TITLE
See through bind mounts when enforcing memory containment

### DIFF
--- a/scripts/dream/validate-memory.py
+++ b/scripts/dream/validate-memory.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 import sys
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -423,6 +423,167 @@ def changed_memory_paths(memory_dir: Path) -> set[str]:
     )
 
 
+MOUNTINFO = Path("/proc/self/mountinfo")
+
+# mountinfo octal-escapes exactly these four characters in the root and
+# mount-point fields, which is what makes a plain whitespace split safe.
+_MOUNTINFO_ESCAPES = {"040": " ", "011": "\t", "012": "\n", "134": "\\"}
+
+
+def _unescape_mountinfo(field: str) -> str:
+    """Decode one field, in a single left-to-right pass.
+
+    The pass matters. A directory literally named `\\040` is emitted as
+    `\\134040`; decoding once yields a backslash followed by "040", which is
+    right. A decoder that applies replacements repeatedly (or str.replace in a
+    loop) turns that same input into a space and silently names a different
+    directory.
+    """
+    out = []
+    i = 0
+    while i < len(field):
+        if field[i] == "\\" and field[i + 1:i + 4] in _MOUNTINFO_ESCAPES:
+            out.append(_MOUNTINFO_ESCAPES[field[i + 1:i + 4]])
+            i += 4
+        else:
+            out.append(field[i])
+            i += 1
+    return "".join(out)
+
+
+def read_mountinfo(source: Path = MOUNTINFO) -> list[tuple[str, str, str]]:
+    """Parse /proc/self/mountinfo into (device, root, mount_point) triples.
+
+    Split first, decode the two path fields individually afterwards -- never the
+    other way round. Unescaping the whole line before splitting would turn a
+    `\\040` inside a directory name into a field separator and a `\\012` into a
+    record boundary, which is a parsing bypass rather than a cosmetic bug.
+
+    Read with surrogateescape, not errors="replace": Linux pathnames are byte
+    strings, so a non-UTF-8 directory name is legal. Replacing those bytes with
+    U+FFFD would make two different paths compare equal, and collapsing several
+    distinct names onto one string is exactly the shape of a bypass.
+
+    Returns [] when the file is absent or unreadable (Windows, macOS, a
+    container with a restricted /proc). Callers treat that as "cannot tell",
+    never as "nothing is mounted".
+    """
+    try:
+        text = source.read_text(encoding="utf-8", errors="surrogateescape")
+    except OSError:
+        return []
+    entries = []
+    for line in text.splitlines():
+        fields = line.split(" ")
+        if len(fields) < 5:
+            continue
+        entries.append(
+            (fields[2], _unescape_mountinfo(fields[3]), _unescape_mountinfo(fields[4]))
+        )
+    return entries
+
+
+def _is_at_or_under(path: PurePosixPath, root: PurePosixPath) -> bool:
+    """Component-wise containment. `/repo` must not swallow `/repository`."""
+    return path == root or root in path.parents
+
+
+def filesystem_location(path: Path, entries: list[tuple[str, str, str]]):
+    """Map a visible path to the (device, path-within-that-filesystem) it names.
+
+    This is what sees through a bind mount. `resolve()` cannot: a bind alias is
+    not a symlink, so a store sitting inside the repository can be published at
+    an outside path and pass a purely lexical containment check. Reproduced.
+
+    The mount whose mount point is the longest component-prefix wins; among
+    equal-length matches the last listed wins, which is how a stacked mount
+    behaves on current kernels. NOTE that line order is an implementation
+    property, not the documented rule -- the documented way to identify the
+    visible mount among several at one point is the parent-ID graph. Adversarial
+    stacking can therefore mis-select. That is an accepted limit: someone able
+    to stack mounts can also unshare a namespace, which defeats any check based
+    on a recorded pathname. This guards against accidents, not attackers.
+
+    `root` is the source's path within its own filesystem -- `/` for an ordinary
+    mount, the source directory for a bind. Chained binds need no iteration: the
+    kernel already reports the ORIGINAL filesystem path for a bind of a bind
+    (verified by mounting one, not assumed).
+
+    Returns None when nothing matches.
+    """
+    target = PurePosixPath(path.as_posix())
+    best = None
+    best_depth = -1
+    for device, root, mount_point in entries:
+        mp = PurePosixPath(mount_point)
+        if not _is_at_or_under(target, mp):
+            continue
+        depth = len(mp.parts)
+        if depth >= best_depth:            # >= so a later equal-depth mount wins
+            best_depth = depth
+            best = (device, root, mp)
+    if best is None:
+        return None
+    device, root, mp = best
+    relative = target.relative_to(mp)
+    if str(relative) == ".":
+        return device, PurePosixPath(root)
+    return device, PurePosixPath(root) / relative
+
+
+def repository_regions(roots, entries):
+    """Every (device, filesystem-path) region reachable at or beneath the repo.
+
+    A repository is not one region. If a separate filesystem is mounted inside
+    it -- `/repo/vendor` on another device, common in containers and dev setups
+    -- then a store on THAT device, aliased to an outside path, is visibly under
+    the repository while sharing no device with the worktree root. Comparing
+    against the worktree's own region alone accepts it.
+
+    So collect the region for each root plus the region of every mount whose
+    mount point falls at or beneath a root. O(mounts), not O(files).
+    """
+    regions = []
+    for root in roots:
+        root_posix = PurePosixPath(Path(root).as_posix())
+        here = filesystem_location(Path(root), entries)
+        if here is not None:
+            regions.append(here)
+        for device, mroot, mount_point in entries:
+            if _is_at_or_under(PurePosixPath(mount_point), root_posix):
+                regions.append((device, PurePosixPath(mroot)))
+    return regions
+
+
+def shares_underlying_location(inner: Path, outer: Path, entries=None) -> bool:
+    """Is `inner` physically at or under `outer`, seeing through bind mounts?
+
+    False when it cannot be determined -- no mountinfo, or the path is not
+    covered by any mount entry. Deliberate: this runs ALONGSIDE the lexical
+    containment check, never instead of it, so an inconclusive answer leaves the
+    existing guarantee exactly where it was. Failing closed would reject every
+    store on every platform without /proc, and rejecting a working setup is the
+    failure users actually hit. Rejection happens only on positive evidence.
+
+    Known limits, none of which this pretends to cover: a mount namespace the
+    helper cannot see, an overlayfs backing directory reached through its upper
+    layer (different device identity from the overlay path), and a mount created
+    after the check. statx(STATX_MNT_ID)/statmount would narrow the first and
+    last, but neither is exposed by the Python standard library.
+    """
+    entries = read_mountinfo() if entries is None else entries
+    if not entries:
+        return False
+    here = filesystem_location(inner, entries)
+    if here is None:
+        return False
+    device, fs_path = here
+    for region_device, region_path in repository_regions([outer], entries):
+        if device == region_device and _is_at_or_under(fs_path, region_path):
+            return True
+    return False
+
+
 def require_outside_repository(memory_dir: Path, repo: Path, identity: str) -> None:
     """Refuse a memory directory that lives inside the repository.
 
@@ -450,7 +611,15 @@ def require_outside_repository(memory_dir: Path, repo: Path, identity: str) -> N
         try:
             inside = memory_dir == root or memory_dir.is_relative_to(root)
         except (OSError, ValueError):
-            continue
+            inside = False
+        # A bind mount publishes one directory at a second path. The alias is not
+        # a symlink, so resolve() cannot see through it and the check above reads
+        # "outside" for a store sitting in the repository. Reproduced, then fixed
+        # by asking the kernel where each path actually lives.
+        if not inside:
+            inside = shares_underlying_location(memory_dir, root)
+            if inside:
+                what = f"{what} (reached through a bind mount)"
         if inside:
             raise ValidationError(
                 f"memory directory must live outside this repository; it is inside the {what} "

--- a/tests/test_dream_paths.py
+++ b/tests/test_dream_paths.py
@@ -1714,5 +1714,156 @@ class RecordedPathHardeningTests(unittest.TestCase):
         self.assertIsNotNone(self.vm.find_cygpath())
 
 
+class MountContainmentTests(unittest.TestCase):
+    """A bind mount publishes one directory at a second path. The alias is not a
+    symlink, so resolve() cannot see through it and a store sitting inside the
+    repository passes a purely lexical containment check.
+
+    Reproduced on Linux with `unshare --user --map-root-user --mount`, then
+    fixed. These pin the algorithm with synthetic mountinfo so they run
+    everywhere, including Windows, where /proc does not exist -- the real
+    bind-mount integration case needs user namespaces and is exercised by hand.
+    """
+
+    def setUp(self) -> None:
+        spec = importlib.util.spec_from_file_location("validate_memory", HELPER)
+        self.vm = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.vm)
+
+    # Field order: device, root, mount_point
+    ORDINARY = ("8:48", "/", "/")
+    BIND_ALIAS = ("8:48", "/tmp/x/repo/private-memory", "/tmp/x/alias")
+
+    def test_unescapes_only_the_four_characters_mountinfo_escapes(self) -> None:
+        u = self.vm._unescape_mountinfo
+        self.assertEqual(u(r"/tmp/od\040d"), "/tmp/od d")
+        self.assertEqual(u(r"/tmp/ta\011b"), "/tmp/ta\tb")
+        self.assertEqual(u(r"/tmp/nl\012x"), "/tmp/nl\nx")
+        self.assertEqual(u(r"/tmp/bs\134x"), "/tmp/bs\\x")
+        # A backslash that is not one of those four sequences is literal, not an
+        # escape -- mangling it would misname a legitimate directory.
+        self.assertEqual(u(r"/tmp/keep\999"), r"/tmp/keep\999")
+
+    def test_missing_mountinfo_reads_as_unknown_not_as_nothing_mounted(self) -> None:
+        self.assertEqual(self.vm.read_mountinfo(Path("/definitely/not/here")), [])
+
+    def test_a_bind_alias_resolves_to_its_source_location(self) -> None:
+        entries = [self.ORDINARY, self.BIND_ALIAS]
+        device, fs_path = self.vm.filesystem_location(Path("/tmp/x/alias"), entries)
+        self.assertEqual(device, "8:48")
+        self.assertEqual(str(fs_path), "/tmp/x/repo/private-memory")
+
+    def test_a_path_under_a_bind_alias_maps_through_the_alias(self) -> None:
+        entries = [self.ORDINARY, self.BIND_ALIAS]
+        _, fs_path = self.vm.filesystem_location(Path("/tmp/x/alias/notes"), entries)
+        self.assertEqual(str(fs_path), "/tmp/x/repo/private-memory/notes")
+
+    def test_the_longest_matching_mount_point_wins(self) -> None:
+        entries = [self.ORDINARY, ("8:48", "/src", "/tmp/x"), self.BIND_ALIAS]
+        _, fs_path = self.vm.filesystem_location(Path("/tmp/x/alias"), entries)
+        self.assertEqual(str(fs_path), "/tmp/x/repo/private-memory",
+                         "a shorter mount point shadowed the more specific one")
+
+    def test_the_last_of_two_equal_mount_points_wins(self) -> None:
+        """Over-mounting the same directory twice leaves both in mountinfo; the
+        LAST is the one you see through. Verified by mounting twice and reading
+        the file back."""
+        entries = [self.ORDINARY,
+                   ("8:48", "/first", "/tmp/over"),
+                   ("8:48", "/second", "/tmp/over")]
+        _, fs_path = self.vm.filesystem_location(Path("/tmp/over"), entries)
+        self.assertEqual(str(fs_path), "/second")
+
+    def test_a_bind_alias_of_a_nested_store_is_detected(self) -> None:
+        entries = [self.ORDINARY, self.BIND_ALIAS]
+        self.assertTrue(self.vm.shares_underlying_location(
+            Path("/tmp/x/alias"), Path("/tmp/x/repo"), entries))
+
+    def test_an_outside_store_is_not_flagged(self) -> None:
+        """The failure that actually hurts users is rejecting a working setup."""
+        entries = [self.ORDINARY, ("8:48", "/tmp/x/outside-src", "/tmp/x/outside-alias")]
+        self.assertFalse(self.vm.shares_underlying_location(
+            Path("/tmp/x/outside-alias"), Path("/tmp/x/repo"), entries))
+
+    def test_a_different_device_is_never_nested(self) -> None:
+        entries = [self.ORDINARY, ("0:42", "/", "/tmp/x/tmpfs")]
+        self.assertFalse(self.vm.shares_underlying_location(
+            Path("/tmp/x/tmpfs/memory"), Path("/tmp/x/repo"), entries))
+
+    def test_nested_paths_on_different_devices_are_not_contained(self) -> None:
+        """Path nesting alone is not containment. Without the device check this
+        returns True for two directories that merely happen to share a prefix
+        inside their own filesystems -- e.g. /data on two separate disks."""
+        entries = [("8:48", "/", "/"),
+                   ("0:99", "/repo/x", "/mnt/other")]
+        self.assertFalse(
+            self.vm.shares_underlying_location(
+                Path("/mnt/other"), Path("/repo"), entries),
+            "a path on a different device was reported as nested",
+        )
+
+    def test_require_outside_repository_actually_consults_the_mount_check(self) -> None:
+        """The guard has to be WIRED IN, not merely present. Nothing else here
+        would notice if require_outside_repository stopped calling it: the
+        lexical check still passes every existing case on its own."""
+        entries = [("8:48", "/", "/"),
+                   ("8:48", "/srv/repo/private-memory", "/srv/alias")]
+        original = self.vm.read_mountinfo
+        self.vm.read_mountinfo = lambda *a, **k: entries
+        try:
+            with self.assertRaises(self.vm.ValidationError) as ctx:
+                self.vm.require_outside_repository(
+                    Path("/srv/alias"), Path("/srv/repo"), "/srv/repo/.git"
+                )
+        finally:
+            self.vm.read_mountinfo = original
+        self.assertIn("bind mount", str(ctx.exception))
+
+    def test_a_literal_backslash_sequence_is_not_decoded_twice(self) -> None:
+        r"""A directory literally named \040 is emitted as \134040. One pass
+        yields a backslash then "040". A decoder that re-applies replacements
+        turns it into a space and silently names a different directory."""
+        self.assertEqual(self.vm._unescape_mountinfo(r"/tmp/\134040"), r"/tmp/\040")
+
+    def test_containment_is_component_wise_not_string_prefix(self) -> None:
+        """/repo must not swallow /repository."""
+        entries = [("8:48", "/", "/"), ("8:48", "/", "/repository")]
+        self.assertFalse(self.vm.shares_underlying_location(
+            Path("/repository/memory"), Path("/repo"), entries))
+
+    def test_a_store_on_a_filesystem_mounted_INSIDE_the_repo_is_caught(self) -> None:
+        """A repository is not one region. With another filesystem mounted at
+        /repo/vendor, a store on THAT device aliased outside is visibly under the
+        repository while sharing no device with the worktree root -- so comparing
+        against the worktree's own region alone accepts it."""
+        entries = [
+            ("8:48", "/", "/"),                        # root filesystem
+            ("0:99", "/", "/repo/vendor"),             # another fs mounted INSIDE the repo
+            ("0:99", "/private-memory", "/outside"),   # bind alias of a dir on that fs
+        ]
+        self.assertTrue(
+            self.vm.shares_underlying_location(Path("/outside"), Path("/repo"), entries),
+            "a store on a filesystem mounted inside the repo escaped containment",
+        )
+
+    def test_a_sibling_filesystem_outside_the_repo_is_still_accepted(self) -> None:
+        """The mirror of the case above: another filesystem NOT under the repo
+        must not be dragged in by the same logic."""
+        entries = [
+            ("8:48", "/", "/"),
+            ("0:99", "/", "/mnt/data"),                # mounted OUTSIDE the repo
+            ("0:99", "/memory", "/outside"),
+        ]
+        self.assertFalse(
+            self.vm.shares_underlying_location(Path("/outside"), Path("/repo"), entries))
+
+    def test_no_mountinfo_answers_unknown_rather_than_contained(self) -> None:
+        """This check runs ALONGSIDE the lexical one, never instead of it, so an
+        inconclusive answer must leave the existing guarantee where it was.
+        Failing closed would reject every store on any platform without /proc."""
+        self.assertFalse(self.vm.shares_underlying_location(
+            Path("/tmp/x/alias"), Path("/tmp/x/repo"), []))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#33 documented this as unfixed. It's fixable.

## The bypass, reproduced first

A bind mount publishes one directory at a second path. The alias is not a symlink, so `resolve()` can't see through it and a store sitting inside the repository passes a lexical containment check.

Reproduced on Linux via `unshare --user --map-root-user --mount` — no root needed:

```
store at   <repo>/private-memory          <- inside the repo
bound to   <tmp>/alias                    <- outside
recording  <tmp>/alias                    -> ACCEPTED
same inode on both paths: 2096:608679
```

## The fix

Ask the kernel where each path actually lives. `/proc/self/mountinfo` gives, per mount, the source's path *within its own filesystem* — `/` for an ordinary mount, the source directory for a bind — so a visible path maps to a `(device, filesystem-path)` pair that survives aliasing. Containment becomes a comparison on those pairs rather than on spelling.

**Four things checked against a real kernel rather than assumed:**

| Question | Answer |
|---|---|
| `root` for a plain mount vs a subdir bind | `/` vs the source path |
| Does a bind *of a bind* need iterating? | **No** — the kernel already reports the original fs path |
| Two mounts on one point — which wins? | The **later** one is what you see through |
| Escaping in `root`/`mount_point`? | Octal: `\040 \011 \012 \134` |

## A repository is not one region

The strongest finding from a Codex design review, and one I'd missed. With another filesystem mounted **inside** the repo (`/repo/vendor` on a different device — ordinary in containers), a store on *that* device aliased outside is visibly under the repository while sharing no device with the worktree root. Comparing against the worktree's own region alone accepts it.

Every mount at or beneath the worktree and the git directory is now part of the comparison. `O(mounts)`, not `O(files)`.

## Parsing is deliberate

- **Split first, decode the two path fields after.** Unescaping a whole line before splitting turns a `\040` inside a directory name into a field separator — a parsing bypass, not a cosmetic bug.
- **Single-pass decode**, so a directory literally named `\040` (emitted as `\134040`) stays literal. A decoder that re-applies replacements turns it into a space and names a different directory.
- **`surrogateescape`, not `errors="replace"`.** A non-UTF-8 directory name is legal on Linux; mapping those bytes to U+FFFD would make distinct paths compare equal.

## Fails open, on purpose

When mountinfo is unavailable (Windows, macOS, restricted `/proc`) this returns "cannot tell". It runs **alongside** the lexical check, never instead of it, so an inconclusive answer leaves the previous guarantee untouched, and rejection requires positive evidence. Failing closed would reject every store on any platform without `/proc` — and rejecting a working setup is the failure users actually hit.

## Verification

Against a real kernel with real bind mounts:

**Still accepted (4/4)** — sibling directory, separate tmpfs mount, bind of an *outside* store to another outside path, sibling sharing the repo's name prefix.
**Now rejected (4/4)** — direct nesting, bind alias, **chained** bind alias, alias of a store inside `.git`.

Mutation-tested — each of these turns the suite red: skipping the check entirely, first-match instead of last, dropping the device comparison, disabling unescaping, treating missing mountinfo as contained, counting only the worktree region.

- Linux: `validate-all.sh` green
- Windows: 138 tests, 8 skipped — and direct execution matches discovery

## Known limits, documented rather than papered over

A mount namespace the helper cannot see; an overlayfs backing directory reached through its upper layer (different device identity from the overlay path); a mount created after the check. `statx(STATX_MNT_ID)`/`statmount` would narrow the first and last — neither is exposed by the Python standard library (checked on 3.12).

This is a misconfiguration guardrail, not a boundary against someone who can unshare a namespace. Anyone who can do that can also edit the marker or the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)