### PR TITLE
Add short lifecycle skill aliases

### DIFF
--- a/.agents/skills/context-setup/SKILL.md
+++ b/.agents/skills/context-setup/SKILL.md
@@ -106,4 +106,4 @@ Present:
 
 Wait for approval, then apply only the approved changes. Run `bash scripts/validate-all.sh` and report the result. Offer a commit only after the user reviews the diff.
 
-Finish by suggesting `$context-start` for the next working session and `$context-end` when that session is complete.
+Finish by suggesting `$start` for the next working session and `$end` when that session is complete.

--- a/.agents/skills/context-update/SKILL.md
+++ b/.agents/skills/context-update/SKILL.md
@@ -28,7 +28,7 @@ If `workspace.yaml` exists, use its state and sessions directories. Otherwise us
    - let `old_date` be the prior real date and `newest_history_date` be the newest date already in the log; archive only when `old_date != today && old_date != newest_history_date`;
    - when that invariant passes, prepend a separate line containing `old_date` under `# current.md update log` in `<state_dir>/current-log.md`; and
    - never log a placeholder. A second checkpoint or close on the same day therefore leaves both the current date and history unchanged.
-5. If a durable decision was made, mention that `$context-end` can add it to the decision log; do not expand a quick checkpoint into a full close workflow.
+5. If a durable decision was made, mention that `$end` can add it to the decision log; do not expand a quick checkpoint into a full close workflow.
 6. Confirm in one line what was checkpointed and which files changed.
 
 Do not invent progress or touch files solely to refresh their timestamps.

--- a/.agents/skills/end/SKILL.md
+++ b/.agents/skills/end/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: end
+description: Close this context workspace through the canonical reviewed handoff workflow. Use only when the user explicitly invokes end.
+---
+
+# End a workspace session
+
+Read and follow `../context-end/SKILL.md` as the canonical workflow. This is a
+short invocation alias; do not duplicate or modify the workflow here.

--- a/.agents/skills/end/agents/openai.yaml
+++ b/.agents/skills/end/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "End"
+  short_description: "Close a session with an approved handoff"
+  default_prompt: "Use $end to close this session and prepare a reviewed handoff."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: setup
+description: Initialize or refresh this context workspace through the canonical guided review. Use only when the user explicitly invokes setup.
+---
+
+# Set up workspace context
+
+Read and follow `../context-setup/SKILL.md` as the canonical workflow. This is a
+short invocation alias; do not duplicate or modify the workflow here.

--- a/.agents/skills/setup/agents/openai.yaml
+++ b/.agents/skills/setup/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Setup"
+  short_description: "Build or import durable workspace context"
+  default_prompt: "Use $setup to initialize this workspace through a guided review."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/start/SKILL.md
+++ b/.agents/skills/start/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: start
+description: Load this context workspace and produce the canonical session briefing. Use only when the user explicitly invokes start.
+---
+
+# Start a workspace session
+
+Read and follow `../context-start/SKILL.md` as the canonical workflow. This is a
+short invocation alias; do not duplicate or modify the workflow here.

--- a/.agents/skills/start/agents/openai.yaml
+++ b/.agents/skills/start/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Start"
+  short_description: "Load state and brief the next work session"
+  default_prompt: "Use $start to load this workspace and brief me on what matters now."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/update/SKILL.md
+++ b/.agents/skills/update/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: update
+description: Save a concise checkpoint through the canonical workspace update workflow. Use only when the user explicitly invokes update.
+---
+
+# Update a workspace session
+
+Read and follow `../context-update/SKILL.md` as the canonical workflow. This is a
+short invocation alias; do not duplicate or modify the workflow here.

--- a/.agents/skills/update/agents/openai.yaml
+++ b/.agents/skills/update/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Update"
+  short_description: "Checkpoint progress with minimal state churn"
+  default_prompt: "Use $update to checkpoint the progress from this session."
+policy:
+  allow_implicit_invocation: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,14 @@ This repository is the durable source of truth for personal, project, and sessio
 
 ## Session lifecycle
 
-- First-time onboarding: use `$context-setup`.
-- Begin work: use `$context-start`.
-- Save a mid-session checkpoint: use `$context-update`.
-- Close a session: use `$context-end`.
+- First-time onboarding: use `$setup`.
+- Begin work: use `$start`.
+- Save a mid-session checkpoint: use `$update`.
+- Close a session: use `$end`.
 
 These skills are deliberately explicit-invocation workflows. Do not start, checkpoint, or close a session merely because their descriptions seem relevant.
+The namespaced `$context-setup`, `$context-start`, `$context-update`, and
+`$context-end` forms remain supported compatibility names.
 
 ## Context routing
 
@@ -36,7 +38,7 @@ These skills are deliberately explicit-invocation workflows. Do not start, check
 Hermes Agent reads this repository's instructions automatically:
 
 - Project rules: Hermes loads `AGENTS.md` from the working directory into every session in this repository. This file is the portable entry point; `CLAUDE.md` remains Claude Code-specific.
-- Session loop: the four lifecycle skills (`context-setup`, `context-start`, `context-update`, `context-end`) under `.agents/skills/` are agentskills.io-compatible SKILL.md files. Install them with `hermes skills install <path>` (or import via `hermes import-agent claude-code`, which picks up skill directories), then invoke them as `/context-start`, `/context-update`, and `/context-end`.
+- Session loop: the lifecycle skills under `.agents/skills/` are agentskills.io-compatible SKILL.md files. Install the short `setup`, `start`, `update`, and `end` aliases with `hermes skills install <path>` (or import via `hermes import-agent claude-code`, which picks up skill directories), then invoke them as `/start`, `/update`, and `/end`. The `context-*` directories remain the canonical workflow cores and compatibility names.
 - Memory: Hermes has its own persistent memory (`MEMORY.md`) plus a background Curator. See `docs/memory-across-agents.md` for how this repository's state layer relates to native Hermes memory, and when to run `/dream` equivalents.
 - Hooks: the checked-in `.claude/hooks/` guards do not run under Hermes. Hermes' equivalent is its plugin/hooks system (`hermes config get plugins`, docs: Features → Hooks); the safety contract in `docs/safety-contract.md` still applies as instructions even without enforcement.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then start your agent from the repository root:
 | Starting point | Next action |
 |---|---|
 | New workspace in Claude Code | Run `/setup` |
-| New workspace in Codex | Run `$context-setup` |
+| New workspace in Codex | Run `$setup` |
 | Existing context in another assistant | Follow the [migration guide](docs/migration-guide.md), then use the selected material during setup |
 | claude.ai only | Use [SETUP-PROMPTS.md](SETUP-PROMPTS.md) and copy the approved output into the repository |
 
@@ -58,9 +58,9 @@ The setup interview fills the identity, first project, workflows, and weekly sta
 
 ![A start session in Claude Code: state files load and a session briefing comes back, using sample data from the included example musician project](docs/assets/start-demo.gif)
 
-`/start` in Claude Code and `$context-start` in Codex read your state, priorities, decisions, blockers, and recent handoff. The result is a working briefing grounded in files, not a request to reconstruct everything from chat.
+`/start` in Claude Code and `$start` in Codex read your state, priorities, decisions, blockers, and recent handoff. The result is a working briefing grounded in files, not a request to reconstruct everything from chat.
 
-At the end, `/end` or `$context-end` proposes a handoff for review before it updates `sessions/` and `state/`.
+At the end, `/end` or `$end` proposes a handoff for review before it updates `sessions/` and `state/`. The namespaced `$context-end` form remains supported.
 
 <sub>The GIF is scripted with sample data. [`docs/start-demo.tape`](docs/start-demo.tape) regenerates it, and [`docs/demo/start-session.sh`](docs/demo/start-session.sh) contains the transcript. Neither reads your state or calls a model.</sub>
 
@@ -70,10 +70,13 @@ Start small. Use the core loop for a week, add one active project, then turn a r
 
 | Moment | Claude Code | Codex | Shared result |
 |---|---|---|---|
-| First run or major refresh | `/setup` | `$context-setup` | Identity, projects, workflows, and weekly state |
-| Start work | `/start` | `$context-start` | Briefing from current state and recent sessions |
-| Save a checkpoint | `/update` | `$context-update` | Short session update with minimal state churn |
-| Finish work | `/end` | `$context-end` | Reviewed handoff, state updates, decisions, and git safety report |
+| First run or major refresh | `/setup` | `$setup` | Identity, projects, workflows, and weekly state |
+| Start work | `/start` | `$start` | Briefing from current state and recent sessions |
+| Save a checkpoint | `/update` | `$update` | Short session update with minimal state churn |
+| Finish work | `/end` | `$end` | Reviewed handoff, state updates, decisions, and git safety report |
+
+The namespaced `$context-setup`, `$context-start`, `$context-update`, and
+`$context-end` invocations remain available for compatibility.
 
 Claude Code also ships host-specific commands for capture, daily checks, recovery, context search, and auto-memory curation. The [host boundary](docs/codex-onboarding.md#host-specific-boundaries) names what is portable and what is not.
 
@@ -106,7 +109,7 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 | Capability | Shared | Claude Code adapter | Codex adapter |
 |---|---:|---:|---:|
 | Identity, project, state, and session files | Yes | Reads the repository | Reads the repository |
-| Lifecycle workflow core | Yes | `/setup`, `/start`, `/update`, `/end` | `$context-setup`, `$context-start`, `$context-update`, `$context-end` |
+| Lifecycle workflow core | Yes | `/setup`, `/start`, `/update`, `/end` | `$setup`, `$start`, `$update`, `$end` |
 | Reusable provider-neutral skills | Yes | Thin slash commands when needed | Repository skills under `.agents/skills/` |
 | Checked-in hooks and settings | No | Included | No equivalent claimed |
 | Claude auto-memory and `/dream` | No | Included | Use repository state and sessions for shared continuity |

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -13,17 +13,17 @@ bash scripts/setup.sh --agent codex
 Then launch Codex from the repository root and invoke the onboarding skill explicitly:
 
 ```text
-$context-setup
+$setup
 ```
 
 Codex discovers the root [`AGENTS.md`](../AGENTS.md) and repository skills automatically. The lifecycle is:
 
 | Moment | Codex skill | Shared result |
 |---|---|---|
-| First run or major refresh | `$context-setup` | Identity, projects, reusable workflows, and weekly state |
-| Start work | `$context-start` | Briefing from repository state and recent sessions |
-| Mid-session | `$context-update` | Append-only checkpoint and minimal state change |
-| Finish work | `$context-end` | Reviewed session log, state updates, decisions, and git safety report |
+| First run or major refresh | `$setup` | Identity, projects, reusable workflows, and weekly state |
+| Start work | `$start` | Briefing from repository state and recent sessions |
+| Mid-session | `$update` | Append-only checkpoint and minimal state change |
+| Finish work | `$end` | Reviewed session log, state updates, decisions, and git safety report |
 
 The four lifecycle skills disable implicit invocation. This prevents an agent from opening, checkpointing, or closing a session merely because a prompt resembles the workflow.
 
@@ -44,7 +44,7 @@ Commit these files only when they are appropriate for the repository's visibilit
 |---|---:|---:|---|
 | Repository state and session logs | Yes | No | Read and update through the lifecycle skills |
 | Lifecycle workflow core | Yes | No | `.agents/skills/context-*` |
-| Slash commands | No | Yes | Invoke `$context-*` skills instead |
+| Slash commands | No | Yes | Invoke `$setup`, `$start`, `$update`, or `$end` instead |
 | Checked-in hooks and settings | No | Yes | No equivalence is claimed |
 | Claude auto-memory and `/dream` | No | Yes | Use repository `state/` and `sessions/` for shared continuity |
 | Personal agent configuration | No | No | Keep it outside the repository |

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -6,12 +6,15 @@ This index separates portable workflow cores from host-specific adapters. A comm
 
 | Job | Claude Code | Codex | Effects and prerequisites |
 |---|---|---|---|
-| Initialize context | `/setup` | `$context-setup` | Proposes identity, project, state, routing, and approved workflow files; review before writes |
-| Start a session | `/start` | `$context-start` | Repository reads only; no live external data or authentication by default |
-| Checkpoint | `/update` | `$context-update` | Writes a reviewed session checkpoint and minimal current state |
-| Close a session | `/end` | `$context-end` | Writes a reviewed handoff, state, and decisions; Claude may separately propose host-local memory |
+| Initialize context | `/setup` | `$setup` (`$context-setup` compatibility) | Proposes identity, project, state, routing, and approved workflow files; review before writes |
+| Start a session | `/start` | `$start` (`$context-start` compatibility) | Repository reads only; no live external data or authentication by default |
+| Checkpoint | `/update` | `$update` (`$context-update` compatibility) | Writes a reviewed session checkpoint and minimal current state |
+| Close a session | `/end` | `$end` (`$context-end` compatibility) | Writes a reviewed handoff, state, and decisions; Claude may separately propose host-local memory |
 
-The portable sources are `.agents/skills/context-setup`, `context-start`, `context-update`, and `context-end`. Claude Code files are thin adapters. All four require explicit user invocation.
+The portable workflow cores are `.agents/skills/context-setup`, `context-start`,
+`context-update`, and `context-end`. The matching short skill directories are
+thin compatibility adapters, and Claude Code files are host-specific adapters.
+Both naming forms require explicit user invocation.
 
 ## Portable migration
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ claude
 codex
 ```
 
-Run `/setup` in Claude Code or `$context-setup` in Codex. The guided interview asks one question at a time, proposes a file map, and waits before changing populated files.
+Run `/setup` in Claude Code or `$setup` in Codex. The guided interview asks one question at a time, proposes a file map, and waits before changing populated files.
 
 ### Bring existing context
 
@@ -97,9 +97,9 @@ Commit and push only after the diff matches what you intend to preserve.
 
 | Moment | Claude Code | Codex |
 |---|---|---|
-| Start work | `/start` | `$context-start` |
-| Save progress without closing | `/update` | `$context-update` |
-| End with a reviewed handoff | `/end` | `$context-end` |
+| Start work | `/start` | `$start` |
+| Save progress without closing | `/update` | `$update` |
+| End with a reviewed handoff | `/end` | `$end` |
 
 The lifecycle writes shared continuity to `state/` and `sessions/`. Claude Code has additional host-specific hooks, commands, and auto-memory features. The [Codex onboarding guide](codex-onboarding.md) documents the exact boundary.
 

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -42,7 +42,7 @@ https://github.com/conorbronsdon/agent-context-os
 
 Context OS update:
 
-Codex is now a first-class path, not a fork. The same repository state powers `$context-setup`, `$context-start`, `$context-update`, and `$context-end`, while Claude Code keeps its slash-command adapters.
+Codex is now a first-class path, not a fork. The same repository state powers `$setup`, `$start`, `$update`, and `$end`, while Claude Code keeps its slash-command adapters.
 
 The optional integration catalog now covers portable skill collections and creator tools, plus reviewed paths for Tolaria, Obsidian, Beads, Granola, Google Workspace, Notion, and Substack. Each entry declares data access, side effects, confirmation gates, evidence, health checks, and uninstall behavior.
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,9 +4,9 @@ Maintenance should keep context accurate and permissions narrow without creating
 
 ## Every working session
 
-1. Run `/start` in Claude Code or `$context-start` in Codex.
-2. Use `/update` or `$context-update` only when a long session needs a durable handoff.
-3. Finish with `/end` or `$context-end` and review the proposed session/state diff.
+1. Run `/start` in Claude Code or `$start` in Codex.
+2. Use `/update` or `$update` only when a long session needs a durable handoff.
+3. Finish with `/end` or `$end` and review the proposed session/state diff.
 4. Inspect `git status` and the exact diff. Commit or push only after a separate approval and remote-audience check.
 
 ## Weekly

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -151,4 +151,4 @@ Before committing:
 - [ ] The final diff contains only intended context
 - [ ] `bash scripts/validate-all.sh` passes
 
-When the packet is approved, run `/setup` in Claude Code or `$context-setup` in Codex and provide the packet as the selected import material. The setup workflow will inventory the current workspace, propose a file map, and wait before overwriting populated files.
+When the packet is approved, run `/setup` in Claude Code or `$setup` in Codex and provide the packet as the selected import material. The setup workflow will inventory the current workspace, propose a file map, and wait before overwriting populated files.

--- a/docs/repo-maintenance.md
+++ b/docs/repo-maintenance.md
@@ -4,7 +4,7 @@ Context is useful only when it is current, scoped, and safe to load. Maintenance
 
 ## Every working session
 
-Use `/start` and `/end` in Claude Code, or `$context-start` and `$context-end` in Codex. The close workflow proposes a handoff before updating shared state.
+Use `/start` and `/end` in Claude Code, or `$start` and `$end` in Codex. The close workflow proposes a handoff before updating shared state.
 
 Before committing:
 

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -16,6 +16,7 @@ test -f state/current-log.md || fail "missing current.md history seed"
 
 skills=(context-setup context-start context-update context-end)
 commands=(setup start update end)
+aliases=(setup start update end)
 
 for index in "${!skills[@]}"; do
   skill="${skills[$index]}"
@@ -41,6 +42,20 @@ for index in "${!skills[@]}"; do
   fi
 done
 
+for index in "${!aliases[@]}"; do
+  alias_name="${aliases[$index]}"
+  core_name="${skills[$index]}"
+  alias_file=".agents/skills/$alias_name/SKILL.md"
+  metadata_file=".agents/skills/$alias_name/agents/openai.yaml"
+
+  test -f "$alias_file" || fail "missing $alias_file"
+  test -f "$metadata_file" || fail "missing $metadata_file"
+  grep -qx "name: $alias_name" "$alias_file" || fail "$alias_file name does not match its directory"
+  grep -Fq "../$core_name/SKILL.md" "$alias_file" || fail "$alias_file does not route to $core_name"
+  python3 tests/validate-openai-metadata.py "$metadata_file" "$alias_name" || fail "$metadata_file failed schema validation"
+  [ "$(wc -l < "$alias_file")" -le 15 ] || fail "$alias_file is no longer a thin alias"
+done
+
 for command in "${commands[@]}"; do
   lines=$(wc -l < ".claude/commands/$command.md")
   [ "$lines" -le 40 ] || fail ".claude/commands/$command.md is no longer a thin adapter"
@@ -62,6 +77,10 @@ grep -qx 'allowed-tools: "Read, Glob, Grep"' .claude/commands/find-context.md \
 
 for skill in "${skills[@]}"; do
   grep -Fq "\$$skill" AGENTS.md || fail "AGENTS.md does not route to \$$skill"
+done
+
+for alias_name in "${aliases[@]}"; do
+  grep -Fq "\$$alias_name" AGENTS.md || fail "AGENTS.md does not route to \$$alias_name"
 done
 
 while IFS= read -r portable_skill; do

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -55,7 +55,7 @@ class DocumentationPositioningTests(unittest.TestCase):
             "Each optional change is prompted",
             "Avoid bulk ingestion",
             "Core setup requires no external integration",
-            "$context-setup",
+            "$setup",
             "/setup",
             "private remote",
             "Antigravity",


### PR DESCRIPTION
## Summary

- add explicit-only `$setup`, `$start`, `$update`, and `$end` aliases
- keep the canonical `$context-*` skills as supported compatibility names
- route aliases to canonical workflow cores without copying procedure text
- update onboarding and command documentation to teach the short names first
- add portability controls for routing, metadata, and alias thinness

## Verification

- full `scripts/validate-all.sh`
- 138 unit tests passed; 8 skipped
- portability, hooks, links, integration catalog, and JSON checks passed
- `git diff --check`