### PR TITLE
Add provider-neutral cross-runtime lifecycle kernel

### DIFF
--- a/.agents/skills/context-end/SKILL.md
+++ b/.agents/skills/context-end/SKILL.md
@@ -7,73 +7,52 @@ description: Close a workspace session by reviewing a proposed summary, recordin
 
 Leave durable, reviewable state for the next session.
 
-## Configuration
-
-If `workspace.yaml` exists, use its state and sessions directories. Otherwise use `state/` and `sessions/`.
-
 ## Procedure
 
 ### 1. Draft before writing
 
-Determine today's local date and time. Extract:
+Determine today's local date and time. Extract completed work, durable decisions
+and rationale, meaningful rejected alternatives, priority or thread changes,
+blockers, open work, and next actions. Present the draft and obtain confirmation
+before creating a proposal.
 
-- work completed,
-- decisions and their rationale,
-- meaningful rejected alternatives,
-- priority or thread changes,
-- blockers,
-- open work, and
-- next actions.
+### 2. Build the deterministic proposal
 
-Present the draft and wait for confirmation before editing context files.
+Create a reviewed JSON payload under `.context-os/inputs/` with:
 
-### 2. Record the approved session
+- `what_happened`: approved factual strings;
+- `decisions`: durable objects containing `decision`, `rationale`, and optional
+  `rejected_alternatives`;
+- `next_time`: approved open-work strings; and
+- optional complete desired Markdown for `current_markdown`,
+  `blockers_markdown`, or `weekly_priorities_markdown`, only when that state
+  materially changed.
 
-Create `<sessions_dir>/<YYYY-MM-DD>.md` with this shape when it does not exist:
+Run `python3 -m contextos propose end --input <payload.json>`. The kernel owns
+session append behavior, decision rows, dates, exact paths, the single
+`Last Updated` line, and same-day history. Present every returned diff and its
+proposal digest. The digest binds the exact content but does not authenticate a
+human approver; rely on the host permission boundary for explicit confirmation.
 
-```markdown
-# Session — <YYYY-MM-DD>
+### 3. Apply only the approved proposal
 
-## What happened
-- <approved facts>
+After explicit approval of that exact diff, run:
 
-## Decisions
-- <approved decisions>
-
-## Next time
-- <approved open work>
+```text
+python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
 ```
 
-If the file exists, append `## Session <HH:MM>` and the three subsections instead of overwriting it.
+The kernel must refuse altered proposals, changed targets, path escapes, or a
+concurrent apply. Never bypass those checks or edit lifecycle state directly.
 
-### 3. Update state
+### 4. Check repository state
 
-- Update `<state_dir>/current.md` with approved active threads, completions, and a brief recent-context note.
-- Keep exactly one `**Last Updated:**` line in `current.md` and set it to today's date. Let `old_date` be the prior real date and `newest_history_date` be the newest date already in the log; archive only when `old_date != today && old_date != newest_history_date`. When that invariant passes, prepend a separate line containing `old_date` under `# current.md update log` in `<state_dir>/current-log.md`. Never log a placeholder; a second checkpoint or close on the same day leaves both the current date and history unchanged.
-- Update `<state_dir>/blockers.md` only for a new, changed, or resolved dependency.
-- Update `<state_dir>/weekly-priorities.md` only when meaningful progress changed the weekly view.
-- Preserve unrelated content in every file.
+If this is a git repository, inspect recent commits for parallel work touching
+the same files, show uncommitted files, and show the count of unpushed commits
+when an upstream exists. Flag conflicts and wait for direction. Never commit,
+push, discard, or reconcile without explicit approval. Outside git, skip this.
 
-### 4. Record durable decisions
+### 5. Confirm the handoff
 
-For each approved decision future sessions need, append one row to `<state_dir>/decisions.md`:
-
-```markdown
-| <date> | <decision> | <context or rationale> | <rejected alternatives> |
-```
-
-Skip trivial choices. Leave rejected alternatives blank when there was no real branch point.
-
-### 5. Check repository state
-
-If this is a git repository:
-
-1. inspect recent commits for parallel work touching the same files,
-2. show uncommitted files, and
-3. show the count of unpushed commits when an upstream exists.
-
-Flag conflicts and wait for direction. Never commit, push, discard, or reconcile work without explicit approval. Outside git, skip this step.
-
-### 6. Confirm the handoff
-
-Report what was logged, which state files changed, and the top next action. Mention any conflict or repository work still awaiting a decision.
+Report the receipt path, what was logged, changed state files, and the top next
+action. Mention any conflict or repository work still awaiting a decision.

--- a/.agents/skills/context-setup/SKILL.md
+++ b/.agents/skills/context-setup/SKILL.md
@@ -5,105 +5,62 @@ description: Build, import, or refresh this workspace's identity, project, reusa
 
 # Set up workspace context
 
-Build useful context from the user's own words or selected migration material without silently overwriting existing files.
+Build useful context without silently overwriting user data.
 
 ## Guardrails
 
-- Ask questions one at a time.
-- Inspect existing files before proposing changes. Treat non-placeholder content as user data.
+- Ask questions one at a time and inspect existing files before proposing changes.
 - Preserve the user's wording; do not embellish credentials, goals, or biography.
-- Show the proposed file map and summarize replacements before writing.
-- Require approval before overwriting populated files, creating broad batches of files, committing, or pushing.
-- Never request or store passwords, access tokens, recovery codes, or other credentials.
-- Never ingest a raw account export or complete conversation archive into tracked context.
+- Require approval before replacing populated files, broad writes, commits, or pushes.
+- Never request or store credentials or ingest a raw account export into tracked context.
 
 ## Procedure
 
-### 1. Confirm storage and audience before collecting context
+### 1. Confirm storage and audience
 
-Explain that identity, project, state, session, and imported context can be
-sensitive. Tracked files are visible to every repository collaborator and
-configured agent, and deleting them later does not erase them from git history.
-Recommend a local-only workspace or private remote by default; a public remote
-requires deliberately sanitized content. Keep raw exports and migration staging
-outside tracked files.
+Explain that tracked identity, project, state, session, and imported context is
+visible to repository collaborators and configured agents. Deleting it later
+does not erase git history. Recommend local-only or private storage by default;
+a public remote requires deliberately sanitized content. Stop before collecting
+personal information unless the user explicitly confirms the audience.
 
-Ask the user to confirm that the current storage location, repository audience,
-and intended agent access are appropriate. If they do not explicitly confirm,
-stop before reading migration material or asking for personal information.
+### 2. Choose and inspect the starting point
 
-### 2. Choose the starting point
+Ask whether to start from answers, selected existing material, or both. For
+existing material, follow `docs/migration-guide.md` and accept only a reviewed,
+narrow packet. Read the existing identity, project index, current state, weekly
+priorities, and routing files. Classify each as missing, placeholder, or populated.
 
-Ask whether the user wants to start from their answers, selected existing material, or both.
+### 3. Gather reviewed context
 
-For existing material, read `docs/migration-guide.md`. Ask for one reviewed migration packet or a narrow set of source files. Inventory the selected input, mark claims that need verification, identify sensitive items that should stay out of the workspace, and propose destinations. Do not read beyond the scope the user selected.
+One question at a time, gather identity, current focus, relevant background,
+three-month goals, working preferences, optional useful personal context,
+verifiable proof points, and approved public links. Then gather one recurring
+project: purpose, audience, current focus, non-goals, prior decisions, and
+repeated workflows. Finally gather weekly outcomes, non-goals, success criteria,
+and blockers. Draft the smallest coherent file map and routing additions.
 
-### 3. Inspect the workspace
+Portable repeated workflows belong under `.agents/skills/`; facts stay in their
+identity, project, or state source and are referenced rather than copied.
 
-Read:
+### 4. Propose and apply deterministically
 
-- `identity/who-i-am.md`
-- `identity/professional-background.md`
-- `projects/README.md`
-- `state/current.md`
-- `state/weekly-priorities.md`
-- `ROUTING.md`
+Encode the reviewed file map as JSON under `.context-os/inputs/`, with `files`
+mapping repository-relative paths to complete desired content. Add a path to
+`replace_populated` only after explicit approval to replace that populated file.
+Use `{{TODAY}}` where the deterministic local date belongs.
 
-Classify each as missing, placeholder-only, or populated. Tell the user what can be filled safely, what would be merged, and what would be updated.
+Run `python3 -m contextos propose setup --input <payload.json>`. Present every
+returned diff and its proposal digest. The digest binds the exact content but
+does not authenticate a human approver; rely on the host permission boundary.
+After explicit approval of that exact proposal, run:
 
-### 4. Gather identity context
+```text
+python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+```
 
-Ask for, one question at a time:
+The kernel must refuse path escapes, writes outside context paths, unapproved
+populated replacements, changed targets, or concurrent applies.
 
-1. name and a one-sentence description,
-2. current role or main focus,
-3. relevant background,
-4. three-month goals,
-5. working preferences,
-6. optional personal context that genuinely helps,
-7. a short self-description,
-8. verifiable credentials or proof points, and
-9. public links they want recorded.
-
-Use approved migration items as candidate answers, then ask only for missing details or verification. Draft updates to the two identity files, preserve the user's language, and use today's date for `**Last Updated:**`.
-
-### 5. Gather the first project
-
-Ask for one recurring project, then gather:
-
-1. purpose and desired outcome,
-2. audience or collaborators,
-3. current focus and explicit non-goals,
-4. decisions already made,
-5. repeated tasks, and
-6. the one or two repeated tasks most worth standardizing.
-
-Draft `projects/<project-slug>/context.md` and `projects/<project-slug>/strategy.md`. For each approved repeated workflow, draft a portable skill at `.agents/skills/<project-slug>-<workflow-slug>/SKILL.md`; keep project facts in the project files and reference them from the skill rather than copying them. Add a concise route to `ROUTING.md`.
-
-Offer to repeat this phase for another project.
-
-### 6. Gather weekly state
-
-Ask for:
-
-1. the top three outcomes for this week,
-2. explicit non-goals,
-3. what a good week looks like, and
-4. blockers or items waiting on someone else.
-
-Draft `state/current.md` and `state/weekly-priorities.md` with current dates.
-
-### 7. Review and apply
-
-Present:
-
-- every file to create or edit,
-- populated content that would be replaced,
-- imported claims that remain unverified,
-- selected source material that will stay outside tracked files,
-- the proposed routing additions, and
-- any reusable workflow skills.
-
-Wait for approval, then apply only the approved changes. Run `bash scripts/validate-all.sh` and report the result. Offer a commit only after the user reviews the diff.
-
-Finish by suggesting `$start` for the next working session and `$end` when that session is complete.
+Run `bash scripts/validate-all.sh`, report the receipt and result, and offer a
+commit only after final diff review. Suggest `$start` next and `$end` to close.

--- a/.agents/skills/context-start/SKILL.md
+++ b/.agents/skills/context-start/SKILL.md
@@ -7,32 +7,30 @@ description: Load this workspace's current state, recent decisions, blockers, pr
 
 Resume from durable repository state instead of reconstructing context from chat history.
 
-## Configuration
-
-If `workspace.yaml` exists at the project root, use its configured state directory, sessions directory, task file, and staleness thresholds. Otherwise use:
-
-- state directory: `state/`
-- sessions directory: `sessions/`
-- task file: `TODO.md`
-- stale after: `current.md` 3 days, `weekly-priorities.md` 5 days, `blockers.md` 7 days
-
 ## Procedure
 
-1. Determine today's local date and day of week.
-2. Read `ROUTING.md`, then load in order:
-   - `<state_dir>/current.md`
-   - the latest five entries in `<state_dir>/decisions.md`
-   - `<state_dir>/blockers.md`
-   - `<state_dir>/weekly-priorities.md`
-   - today's session file, or the most recent session file when today's does not exist
-3. If this is a git repository, inspect commits since the most recent session date and read any changed state or context files relevant to today's work. Outside git, skip this check.
-4. Use only explicitly configured, connected, read-only live sources when they materially improve the briefing. Keep queries narrow, follow the source's documented data boundary, and fall back to repository files if the source is unavailable. Never activate or authenticate an integration as part of this workflow.
-5. Report only actionable health findings:
-   - state files past their configured thresholds,
-   - non-placeholder files in a configured inbox,
-   - unchecked dated tasks whose date has passed, and
-   - unresolved blockers or deadlines.
-6. Give a short briefing with the date, state freshness, relevant changes, top two or three priorities, time-sensitive threads, blockers, and any scoped live-data highlights.
-7. If today's session already exists, acknowledge it and resume from its latest entry. End by asking what to focus on.
+1. Run `python3 -m contextos start` from the repository root. Treat its JSON as
+   the deterministic inventory of configured paths, freshness, latest session,
+   and repository revision. If the kernel is unavailable, stop and recommend
+   `python3 -m contextos doctor`; do not silently substitute another lifecycle
+   implementation.
+2. Determine today's local date and day of week. Read `ROUTING.md`, then load:
+   - the configured `current.md`;
+   - the latest five entries in the configured `decisions.md`;
+   - the configured `blockers.md` and `weekly-priorities.md`; and
+   - today's session file, or the most recent session when today's does not exist.
+3. If this is a git repository, inspect commits since the most recent session
+   date and read changed state or context files relevant to today's work.
+4. Use only explicitly configured, connected, read-only live sources when they
+   materially improve the briefing. Keep queries narrow and fall back to
+   repository files. Never activate or authenticate an integration here.
+5. Report only actionable health findings, including kernel-reported staleness,
+   non-placeholder inbox files, overdue dated tasks, unresolved blockers, and
+   deadlines.
+6. Give a short briefing with date, state freshness, relevant changes, top two
+   or three priorities, time-sensitive threads, blockers, and any scoped
+   live-data highlights.
+7. If today's session exists, acknowledge it and resume from its latest entry.
+   End by asking what to focus on.
 
-Keep this read-only. Do not update timestamps merely because the files were read.
+Keep this read-only. Do not update timestamps merely because files were read.

--- a/.agents/skills/context-update/SKILL.md
+++ b/.agents/skills/context-update/SKILL.md
@@ -5,30 +5,36 @@ description: Save a brief mid-session checkpoint to this workspace and update cu
 
 # Checkpoint a workspace session
 
-Save continuity with minimal churn.
-
-## Configuration
-
-If `workspace.yaml` exists, use its state and sessions directories. Otherwise use `state/` and `sessions/`.
+Save continuity with minimal churn through the deterministic lifecycle kernel.
 
 ## Procedure
 
-1. Identify what was just completed, any decisions made, and whether a priority or open thread changed.
-2. Determine today's local date and time.
-3. Append to `<sessions_dir>/<YYYY-MM-DD>.md`:
+1. Identify what was completed, any decisions, and whether a priority or open
+   thread changed. Do not invent progress.
+2. Create a reviewed JSON payload under `.context-os/inputs/` with `progress`
+   as one to three factual strings. Include `current_markdown` only when a
+   priority shifted, a thread opened or closed, or a tracked task completed.
+   When present, it is the complete desired `current.md` before the kernel
+   advances its date and history. Preserve unrelated content and ordering.
+3. Run:
 
-   ```markdown
-   ## Update: <HH:MM>
-   - <one to three factual progress bullets>
+   ```text
+   python3 -m contextos propose update --input <payload.json>
    ```
 
-   Create the file with a date header when it does not exist. Never overwrite earlier entries.
-4. Update `<state_dir>/current.md` only when a priority shifted, a thread opened or closed, or a tracked task completed. Preserve unrelated content and its ordering. When changing it:
-   - keep exactly one `**Last Updated:**` line and set it to today's date;
-   - let `old_date` be the prior real date and `newest_history_date` be the newest date already in the log; archive only when `old_date != today && old_date != newest_history_date`;
-   - when that invariant passes, prepend a separate line containing `old_date` under `# current.md update log` in `<state_dir>/current-log.md`; and
-   - never log a placeholder. A second checkpoint or close on the same day therefore leaves both the current date and history unchanged.
-5. If a durable decision was made, mention that `$end` can add it to the decision log; do not expand a quick checkpoint into a full close workflow.
-6. Confirm in one line what was checkpointed and which files changed.
+   The kernel owns session append behavior, dates, the single `Last Updated`
+   line, and same-day history. Present every returned diff and the exact
+   proposal digest. The digest binds the exact content but does not authenticate
+   a human approver; rely on the host permission boundary for confirmation.
+4. Wait for explicit approval of that exact proposal. Then run:
 
-Do not invent progress or touch files solely to refresh their timestamps.
+   ```text
+   python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+   ```
+
+   If any target changed after proposal creation, create and review a new
+   proposal. Never bypass stale-write, path-containment, or locking checks.
+5. If a durable decision was made, mention that `$end` can add it to the
+   decision log; do not expand a checkpoint into a full close workflow.
+6. Report the receipt path and changed files. Do not edit lifecycle state
+   directly, commit, push, or touch files only to refresh timestamps.

--- a/.claude/commands/end.md
+++ b/.claude/commands/end.md
@@ -1,7 +1,7 @@
 ---
 name: end
 description: "End a session — log what happened, update state and the decision log, propose memory updates, and check for uncommitted or unpushed work"
-allowed-tools: "Read, Write, Edit, Glob, Bash"
+allowed-tools: "Read, Glob"
 disable-model-invocation: true
 ---
 

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,7 +1,7 @@
 ---
 name: setup
 description: "Guided onboarding or import for durable workspace context"
-allowed-tools: "Read, Write, Edit, Bash, Glob"
+allowed-tools: "Read, Glob"
 disable-model-invocation: true
 ---
 

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,7 +1,7 @@
 ---
 name: update
 description: "Mid-session checkpoint — append progress to today's session log and update state files if a priority shifted, without ending the session"
-allowed-tools: "Read, Write, Edit, Bash"
+allowed-tools: "Read"
 disable-model-invocation: true
 ---
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,31 @@
+{
+  "description": "Context OS lifecycle advisories. Deterministic mutation checks also run inside proposal/apply.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" codex session-start",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex session-start\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^apply_patch$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" codex pre-write",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex pre-write\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Context OS
 
-This repository is the durable source of truth for personal, project, and session context. Keep provider-neutral state in the repository and keep host-specific behavior in its adapter directory.
+This repository is the durable source of truth for personal, project, and
+session context. Keep provider-neutral state here and host-specific behavior in
+its adapter directory.
 
 ## Session lifecycle
 
@@ -9,39 +11,59 @@ This repository is the durable source of truth for personal, project, and sessio
 - Save a mid-session checkpoint: use `$update`.
 - Close a session: use `$end`.
 
-These skills are deliberately explicit-invocation workflows. Do not start, checkpoint, or close a session merely because their descriptions seem relevant.
-The namespaced `$context-setup`, `$context-start`, `$context-update`, and
-`$context-end` forms remain supported compatibility names.
+These workflows require explicit invocation. The `$context-setup`,
+`$context-start`, `$context-update`, and `$context-end` compatibility names
+remain supported.
+
+## Lifecycle kernel
+
+- `python3 -m contextos start` is the read-only continuity inventory.
+- Setup, update, and end use `propose` then exact-digest `apply`; never edit
+  lifecycle state directly.
+- Present every proposal diff. Apply only after explicit approval of that exact
+  proposal and report its receipt.
+- Run `python3 -m contextos doctor` when discovery, runtime setup, a lock, or
+  copied skills may be stale.
 
 ## Context routing
 
 - Read `ROUTING.md` before loading task-specific context.
-- Treat `TODO.md` as the task backlog and `state/current.md` as the curated top-of-mind view.
-- Keep each fact in one canonical file; link to it elsewhere instead of duplicating it.
-- Load only the files needed for the current task. Identity and session data may be sensitive.
+- Treat `TODO.md` as the backlog and `state/current.md` as top-of-mind context.
+- Keep each fact in one canonical file and link to it elsewhere.
+- Load only what the current task needs. Identity and session data may be sensitive.
 
 ## Safety
 
-- Follow `docs/safety-contract.md` before any external write, publish, destructive action, credential change, or permission expansion.
-- Show proposed context-file changes before broad or destructive rewrites.
+- Follow `docs/safety-contract.md` before any external write, publish,
+  destructive action, credential change, or permission expansion.
+- Show proposed context changes before broad or destructive rewrites.
 - Never commit or push without explicit approval.
-- Treat optional integrations as disabled until the user chooses and configures one. Check `references/integrations.md` for its data and side-effect boundaries.
+- Optional integrations stay disabled until chosen and configured. Review
+  `references/integrations.md` for data and side-effect boundaries.
 
 ## Portability boundary
 
-- `.agents/skills/` contains the portable workflow cores.
-- `.claude/` contains Claude Code commands, hooks, settings, and memory adapters. Do not assume those features run in Codex or Hermes.
-- Do not commit personal Codex configuration or credentials. Keep machine-level configuration outside this repository.
+- `.agents/skills/` contains portable workflow cores.
+- `.claude/` contains Claude Code commands, hooks, settings, and memory adapters.
+- `.codex/hooks.json` maps Codex events to the same read-only policy checks.
+- `adapters/hermes/` documents optional Hermes hooks and skill installation.
+- Runtime manifests under `runtimes/` declare support instead of implying parity.
+- Kernel proposal/apply is the enforcement boundary on every host; hooks are
+  defense in depth and host-local memory is never shared automatically.
 
 ## Hermes Agent
 
-Hermes Agent reads this repository's instructions automatically:
-
-- Project rules: Hermes loads `AGENTS.md` from the working directory into every session in this repository. This file is the portable entry point; `CLAUDE.md` remains Claude Code-specific.
-- Session loop: the lifecycle skills under `.agents/skills/` are agentskills.io-compatible SKILL.md files. Install the short `setup`, `start`, `update`, and `end` aliases with `hermes skills install <path>` (or import via `hermes import-agent claude-code`, which picks up skill directories), then invoke them as `/start`, `/update`, and `/end`. The `context-*` directories remain the canonical workflow cores and compatibility names.
-- Memory: Hermes has its own persistent memory (`MEMORY.md`) plus a background Curator. See `docs/memory-across-agents.md` for how this repository's state layer relates to native Hermes memory, and when to run `/dream` equivalents.
-- Hooks: the checked-in `.claude/hooks/` guards do not run under Hermes. Hermes' equivalent is its plugin/hooks system (`hermes config get plugins`, docs: Features → Hooks); the safety contract in `docs/safety-contract.md` still applies as instructions even without enforcement.
+- Hermes loads `AGENTS.md` as project context.
+- Expose `.agents/skills/` as an external skill directory, or install the four
+  short aliases and all four `context-*` cores together. Copied skills must be
+  refreshed after source changes.
+- Invoke `/setup`, `/start`, `/update`, and `/end` explicitly.
+- Keep Hermes `MEMORY.md` and `USER.md` separate from repository state. See
+  `docs/memory-across-agents.md`.
+- `.claude/hooks/` does not run under Hermes. The optional Hermes adapter maps
+  supported events to portable checks; kernel enforcement does not depend on it.
 
 ## Validation
 
-Run `bash scripts/validate-all.sh` after changing instructions, skills, commands, hooks, scripts, or generated references.
+Run `bash scripts/validate-all.sh` after changing instructions, skills,
+commands, hooks, scripts, manifests, or generated references.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ A Git-backed context and workflow layer for agents like Claude Code, Codex, and 
 
 Chat history, project instructions, and copied prompts drift apart. Context OS puts the durable parts in plain Markdown: who you are, what you are working on, decisions already made, and the workflows you want an agent to follow.
 
-Claude Code and Codex read the same repository state. Git shows what changed. A reviewed start, checkpoint, and close loop keeps the context current without treating an assistant's private memory as the source of truth.
+Claude Code, Codex, and Hermes read the same repository state. A deterministic
+lifecycle kernel turns reviewed setup, checkpoint, and close requests into
+hash-checked proposals and receipts, without treating native memory as the
+source of truth.
 
 | What you need | How Context OS handles it |
 |---|---|
 | Bring useful context forward | A source-neutral [migration workflow](docs/migration-guide.md) turns selected chats, project instructions, memory exports, and documents into reviewable files. |
-| Work across coding agents | Provider-neutral state and skills live outside host adapters. Claude Code and Codex share the same lifecycle core. |
+| Work across coding agents | Provider-neutral state, skills, and lifecycle transitions live outside host adapters. Claude Code, Codex, and Hermes share the same kernel. |
 | Add the tools that fit | A generated [integration catalog](references/integrations.md) documents install scope, data access, side effects, and confirmation gates. Nothing is enabled automatically. |
 | Keep context useful | Session handoffs, staleness checks, decision logs, and reviewable memory proposals make maintenance part of the normal workflow. |
 
@@ -41,6 +44,7 @@ git remote add origin <YOUR_PRIVATE_REPO_URL>
 # Pick a host, or omit --agent to auto-detect one:
 bash scripts/setup.sh --agent claude
 # bash scripts/setup.sh --agent codex
+# bash scripts/setup.sh --agent hermes
 ```
 
 Then start your agent from the repository root:
@@ -49,6 +53,7 @@ Then start your agent from the repository root:
 |---|---|
 | New workspace in Claude Code | Run `/setup` |
 | New workspace in Codex | Run `$setup` |
+| New workspace in Hermes | Run `/setup` after exposing the repository skills |
 | Existing context in another assistant | Follow the [migration guide](docs/migration-guide.md), then use the selected material during setup |
 | claude.ai only | Use [SETUP-PROMPTS.md](SETUP-PROMPTS.md) and copy the approved output into the repository |
 
@@ -58,7 +63,9 @@ The setup interview fills the identity, first project, workflows, and weekly sta
 
 ![A start session in Claude Code: state files load and a session briefing comes back, using sample data from the included example musician project](docs/assets/start-demo.gif)
 
-`/start` in Claude Code and `$start` in Codex read your state, priorities, decisions, blockers, and recent handoff. The result is a working briefing grounded in files, not a request to reconstruct everything from chat.
+`/start` in Claude Code or Hermes and `$start` in Codex read your state,
+priorities, decisions, blockers, and recent handoff. The result is grounded in
+files rather than reconstructed from chat.
 
 At the end, `/end` or `$end` proposes a handoff for review before it updates `sessions/` and `state/`. The namespaced `$context-end` form remains supported.
 
@@ -68,12 +75,12 @@ At the end, `/end` or `$end` proposes a handoff for review before it updates `se
 
 Start small. Use the core loop for a week, add one active project, then turn a repeated task into a skill when the repetition is clear.
 
-| Moment | Claude Code | Codex | Shared result |
-|---|---|---|---|
-| First run or major refresh | `/setup` | `$setup` | Identity, projects, workflows, and weekly state |
-| Start work | `/start` | `$start` | Briefing from current state and recent sessions |
-| Save a checkpoint | `/update` | `$update` | Short session update with minimal state churn |
-| Finish work | `/end` | `$end` | Reviewed handoff, state updates, decisions, and git safety report |
+| Moment | Claude Code | Codex | Hermes | Shared result |
+|---|---|---|---|---|
+| First run or major refresh | `/setup` | `$setup` | `/setup` | Reviewed context proposal |
+| Start work | `/start` | `$start` | `/start` | Read-only continuity inventory and briefing |
+| Save a checkpoint | `/update` | `$update` | `/update` | Hash-checked update and receipt |
+| Finish work | `/end` | `$end` | `/end` | Hash-checked handoff, decisions, and receipt |
 
 The namespaced `$context-setup`, `$context-start`, `$context-update`, and
 `$context-end` invocations remain available for compatibility.
@@ -97,8 +104,8 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 | Host | Support level |
 |---|---|
 | Claude Code | Full experience: shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation |
-| Codex | First-class shared lifecycle and repository skills; no claim of Claude hook or auto-memory parity |
-| Hermes Agent | Reads `AGENTS.md` automatically; installs the portable lifecycle skills as slash commands (`hermes skills install`); native memory mapping in [memory across agents](docs/memory-across-agents.md); no Claude hook or auto-memory parity |
+| Codex | First-class lifecycle, repository skills, trusted project hooks, and the shared deterministic kernel; native memory remains outside the contract |
+| Hermes Agent | `AGENTS.md`, portable skills, the shared kernel, and optional hook adapter; copied skills and native memory remain explicit host boundaries |
 | Gemini CLI / Antigravity CLI | Migration tooling plus portable-skill discovery for continuing enterprise/API-key Gemini CLI; no complete workspace adapter, and no Antigravity discovery or permission parity is claimed |
 | Cursor / OpenClaw | Read `AGENTS.md` from the repository root; portable skills usable where their Agent Skills support allows |
 | claude.ai | Manual consumer of selected knowledge files; no repository writes, hooks, or slash-command parity |
@@ -106,14 +113,13 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 
 ## One source, explicit host adapters
 
-| Capability | Shared | Claude Code adapter | Codex adapter |
-|---|---:|---:|---:|
-| Identity, project, state, and session files | Yes | Reads the repository | Reads the repository |
-| Lifecycle workflow core | Yes | `/setup`, `/start`, `/update`, `/end` | `$setup`, `$start`, `$update`, `$end` |
-| Reusable provider-neutral skills | Yes | Thin slash commands when needed | Repository skills under `.agents/skills/` |
-| Checked-in hooks and settings | No | Included | No equivalent claimed |
-| Claude auto-memory and `/dream` | No | Included | Use repository state and sessions for shared continuity |
-| Browser project knowledge | Selected files only | Manual upload to claude.ai | Product-specific import or attachment flows remain separate |
+| Capability | Shared | Claude Code | Codex | Hermes |
+|---|---:|---:|---:|---:|
+| Identity, project, state, and session files | Yes | Reads | Reads | Reads |
+| Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls |
+| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. |
+| Project hooks | Event contract only | `.claude/` | `.codex/` | Optional adapter |
+| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` |
 
 The shared layer is intentionally plain files. Provider-specific tool names, hooks, permissions, and memory features stay in their adapter directories.
 
@@ -128,7 +134,7 @@ The current catalog includes portable skill collections and creator tools, plus 
 ## Repository layout
 
 ```text
-AGENTS.md                  Codex repository instructions
+AGENTS.md                  Portable repository instructions
 CLAUDE.md                  Claude Code root context and adapter index
 ROUTING.md                 Task-to-context routing table
 TODO.md                    Full backlog
@@ -137,9 +143,13 @@ projects/                  Project context and project-specific workflows
 state/                     Current focus, priorities, blockers, and decisions
 sessions/                  Reviewed session handoffs
 .agents/skills/            Provider-neutral workflow cores
+contextos/                 Deterministic lifecycle kernel
 .claude/commands/          Claude Code slash-command adapters
 .claude/skills/            Claude Code-only skills
 .claude/hooks/             Claude Code-only safety and session hooks
+.codex/hooks.json          Codex lifecycle advisory adapter
+adapters/hermes/           Hermes installation and optional hook adapter
+runtimes/                  Machine-readable capability manifests
 integrations/              Machine-checked opt-in integration catalog
 references/                Generated catalog and integration setup notes
 scripts/                   Setup, validation, migration, and maintenance tools

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,0 +1,21 @@
+# Hermes adapter
+
+Run `python3 -m contextos install --runtime hermes` from the repository root.
+Expose `.agents/skills/` as an external Hermes skill directory, or install the
+four short aliases together with their four `context-*` cores. Hermes copies
+installed skills, so `python3 -m contextos doctor --runtime hermes` should be
+part of updates and copied skills should be refreshed after a source change.
+
+The optional [`hooks.example.yaml`](hooks.example.yaml) maps Hermes lifecycle
+and pre-write events to the same read-only policy checks used by the other
+runtimes. Merge it into user configuration only after reviewing its commands.
+Kernel proposal/apply enforcement does not depend on these hooks.
+
+The YAML example is POSIX-oriented. On Windows, use an equivalent command such
+as `powershell.exe -NoProfile -NonInteractive -Command "$root = git rev-parse
+--show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') hermes
+pre-write"` for the pre-tool event (and replace `pre-write` with
+`session-start` for the session event). Hermes hook policy remains advisory.
+
+Hermes `MEMORY.md` and `USER.md` remain host-local. Never point the kernel at
+them or mirror them into repository state automatically.

--- a/adapters/hermes/hooks.example.yaml
+++ b/adapters/hermes/hooks.example.yaml
@@ -1,0 +1,8 @@
+# Merge only after reviewing the exact commands and Hermes hook trust boundary.
+hooks:
+  - event: on_session_start
+    command: "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" hermes session-start"
+  - event: pre_tool_call
+    command: "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" hermes pre-write"
+    when:
+      tools: [patch, write_file, terminal]

--- a/contextos/__init__.py
+++ b/contextos/__init__.py
@@ -1,0 +1,3 @@
+"""Deterministic lifecycle kernel for Context OS."""
+
+__version__ = "0.1.0"

--- a/contextos/__main__.py
+++ b/contextos/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import __version__
+from .kernel import (
+    ContextOSError,
+    apply_proposal,
+    create_proposal,
+    discover_root,
+    doctor,
+    hook_report,
+    install_runtime,
+    parse_now,
+    read_json,
+    start_report,
+)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(prog="context-os", description="Deterministic Context OS lifecycle kernel")
+    result.add_argument("--root", type=Path, help="Context OS repository root")
+    result.add_argument("--version", action="version", version=__version__)
+    commands = result.add_subparsers(dest="command", required=True)
+
+    start = commands.add_parser("start", help="Read workspace continuity as structured data")
+    start.add_argument("--now", help="ISO-8601 timestamp for deterministic runs")
+
+    propose = commands.add_parser("propose", help="Create a reviewable lifecycle proposal")
+    propose.add_argument("workflow", choices=("setup", "update", "end"))
+    propose.add_argument("--input", type=Path, required=True, help="Reviewed JSON payload")
+    propose.add_argument("--now", help="ISO-8601 timestamp for deterministic runs")
+
+    apply = commands.add_parser("apply", help="Apply one exact host-confirmed proposal")
+    apply.add_argument("proposal", type=Path)
+    apply.add_argument("--confirm", required=True, help="Exact proposal digest printed by propose")
+    apply.add_argument("--runtime", choices=("claude", "codex", "hermes", "generic"), required=True)
+
+    install = commands.add_parser("install", help="Record the selected runtime and print host setup steps")
+    install.add_argument("--runtime", choices=("claude", "codex", "hermes"), required=True)
+
+    diagnose = commands.add_parser("doctor", help="Check kernel, state, manifests, locks, and runtime")
+    diagnose.add_argument("--runtime", choices=("claude", "codex", "hermes"))
+
+    hook = commands.add_parser("hook", help="Run a normalized read-only lifecycle hook check")
+    hook.add_argument("event", choices=("session-start", "pre-write"))
+    hook.add_argument("--runtime", choices=("claude", "codex", "hermes"), required=True)
+    return result
+
+
+def emit(value: object) -> None:
+    print(json.dumps(value, indent=2, ensure_ascii=False))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        root = discover_root(args.root)
+        if args.command == "start":
+            emit(start_report(root, parse_now(args.now)))
+        elif args.command == "propose":
+            path, document = create_proposal(root, args.workflow, read_json(args.input), parse_now(args.now))
+            emit({
+                "proposal": path.relative_to(root).as_posix(),
+                "proposal_id": document["proposal_id"],
+                "proposal_digest": document["proposal_digest"],
+                "changes": [{"path": item["path"], "diff": item["diff"]} for item in document["changes"]],
+            })
+        elif args.command == "apply":
+            proposal = args.proposal if args.proposal.is_absolute() else root / args.proposal
+            receipt_path, receipt = apply_proposal(root, proposal, args.confirm, args.runtime)
+            emit({"receipt": receipt_path.relative_to(root).as_posix(), **receipt})
+        elif args.command == "install":
+            path, manifest = install_runtime(root, args.runtime)
+            emit({"runtime_file": path.relative_to(root).as_posix(), **manifest})
+        elif args.command == "doctor":
+            report = doctor(root, args.runtime)
+            emit(report)
+            return 1 if report["status"] == "fail" else 0
+        elif args.command == "hook":
+            raw = sys.stdin.read().strip()
+            payload = json.loads(raw) if raw else {}
+            if not isinstance(payload, dict):
+                raise ContextOSError("hook input must be a JSON object")
+            report = hook_report(root, args.event, payload)
+            messages = [item["message"] for item in report["findings"]]
+            if args.runtime in {"claude", "codex"}:
+                if messages:
+                    emit({"systemMessage": "\n".join(messages)})
+            else:
+                emit({"action": "allow", "message": "\n".join(messages)})
+        return 0
+    except (ContextOSError, json.JSONDecodeError, OSError, UnicodeError) as exc:
+        print(f"context-os: {exc}", file=sys.stderr)
+        return 2

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1,0 +1,733 @@
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+SCHEMA_VERSION = 1
+PLACEHOLDER_DATE = "[DATE]"
+LAST_UPDATED_RE = re.compile(r"^\*\*Last Updated:\*\*\s*(.+?)\s*$", re.MULTILINE)
+REAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+SETUP_ROOTS = {"identity", "projects", "state"}
+SETUP_FILES = {"ROUTING.md", "TODO.md", "CLAUDE.md", "AGENTS.md"}
+RUNTIME_NAMES = {"claude", "codex", "hermes"}
+CAPABILITY_VALUES = {"native", "adapter", "advisory", "unsupported"}
+CAPABILITY_KEYS = {
+    "agent_skills", "explicit_invocation", "project_hooks",
+    "blocking_pre_tool_hook", "mcp", "native_memory", "proposal_apply",
+}
+
+
+class ContextOSError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Workspace:
+    root: Path
+    state_dir: Path
+    sessions_dir: Path
+    task_file: Path
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_text(value: str) -> str:
+    return sha256_bytes(value.encode("utf-8"))
+
+
+def file_digest(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    # Repository lifecycle files are text. Normalize checkout line endings so
+    # proposal digests are stable across Windows, macOS, and Linux.
+    return sha256_text(path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n"))
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc).astimezone()
+
+
+def parse_now(raw: str | None) -> datetime:
+    if not raw:
+        return utc_now()
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ContextOSError(f"invalid --now timestamp: {raw}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.astimezone()
+    return parsed
+
+
+def discover_root(start: Path | None = None) -> Path:
+    candidate = (start or Path.cwd()).resolve()
+    for path in (candidate, *candidate.parents):
+        if (path / "AGENTS.md").is_file() and (
+            (path / "state").is_dir() or (path / "workspace.yaml").is_file()
+        ):
+            return path
+    raise ContextOSError("could not find a Context OS root (AGENTS.md plus state/ or workspace.yaml)")
+
+
+def _simple_workspace_yaml(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or line.startswith("-") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key, value = key.strip(), value.strip().strip("'\"")
+        if key in {"state_dir", "sessions_dir", "task_file"} and value:
+            values[key] = value
+    return values
+
+
+def load_workspace(root: Path) -> Workspace:
+    config = _simple_workspace_yaml(root / "workspace.yaml")
+    state_dir = safe_repo_path(root, config.get("state_dir", "state"))
+    sessions_dir = safe_repo_path(root, config.get("sessions_dir", "sessions"))
+    task_file = safe_repo_path(root, config.get("task_file", "TODO.md"))
+    return Workspace(root=root, state_dir=state_dir, sessions_dir=sessions_dir, task_file=task_file)
+
+
+def safe_repo_path(root: Path, raw: str) -> Path:
+    relative = Path(raw)
+    if relative.is_absolute():
+        raise ContextOSError(f"absolute repository path is not allowed: {raw}")
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ContextOSError(f"path escapes repository root: {raw}") from exc
+    return resolved
+
+
+def relative_path(root: Path, path: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def ensure_text(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise ContextOSError(f"{field} must be a string")
+    return value
+
+
+def ensure_string_list(value: Any, field: str, required: bool = False) -> list[str]:
+    if value is None and not required:
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ContextOSError(f"{field} must be a list of non-empty strings")
+    return [item.strip() for item in value]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContextOSError(f"cannot read JSON from {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ContextOSError(f"expected a JSON object in {path}")
+    return value
+
+
+def _replace_last_updated(content: str, today: str) -> tuple[str, str | None]:
+    matches = LAST_UPDATED_RE.findall(content)
+    if len(matches) != 1:
+        raise ContextOSError("state/current.md must contain exactly one **Last Updated:** line")
+    old = matches[0].strip()
+    updated = LAST_UPDATED_RE.sub(f"**Last Updated:** {today}", content, count=1)
+    return updated, old if REAL_DATE_RE.fullmatch(old) else None
+
+
+def _newest_history_date(content: str) -> str | None:
+    dates = [line.strip() for line in content.splitlines() if REAL_DATE_RE.fullmatch(line.strip())]
+    return max(dates) if dates else None
+
+
+def _advance_current(
+    workspace: Workspace, desired: str, today: str, pending: dict[Path, str]
+) -> None:
+    current = workspace.state_dir / "current.md"
+    history = workspace.state_dir / "current-log.md"
+    updated, old_date = _replace_last_updated(desired.rstrip() + "\n", today)
+    pending[current] = updated
+    history_text = history.read_text(encoding="utf-8") if history.exists() else "# current.md update log\n\n"
+    newest = _newest_history_date(history_text)
+    if old_date and old_date != today and old_date != newest:
+        marker = "# current.md update log"
+        if marker not in history_text:
+            raise ContextOSError("state/current-log.md is missing its required heading")
+        before, after = history_text.split(marker, 1)
+        pending[history] = f"{before}{marker}\n\n{old_date}\n\n{after.lstrip()}"
+
+
+def _session_append(path: Path, block: str, date: str) -> str:
+    if path.exists():
+        existing = path.read_text(encoding="utf-8").rstrip()
+        return f"{existing}\n\n{block.rstrip()}\n"
+    return f"# Session — {date}\n\n{block.rstrip()}\n"
+
+
+def _bullets(values: list[str], empty: str = "- None recorded") -> str:
+    return "\n".join(f"- {value}" for value in values) if values else empty
+
+
+def _escape_table(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def render_update(workspace: Workspace, payload: dict[str, Any], now: datetime) -> dict[Path, str]:
+    progress = ensure_string_list(payload.get("progress"), "progress", required=True)
+    today, clock = now.strftime("%Y-%m-%d"), now.strftime("%H:%M")
+    session = workspace.sessions_dir / f"{today}.md"
+    pending = {session: _session_append(session, f"## Update: {clock}\n{_bullets(progress)}", today)}
+    if "current_markdown" in payload:
+        _advance_current(workspace, ensure_text(payload["current_markdown"], "current_markdown"), today, pending)
+    return pending
+
+
+def render_end(workspace: Workspace, payload: dict[str, Any], now: datetime) -> dict[Path, str]:
+    happened = ensure_string_list(payload.get("what_happened"), "what_happened", required=True)
+    decisions = payload.get("decisions", [])
+    if not isinstance(decisions, list):
+        raise ContextOSError("decisions must be a list")
+    next_time = ensure_string_list(payload.get("next_time"), "next_time")
+    today, clock = now.strftime("%Y-%m-%d"), now.strftime("%H:%M")
+    session = workspace.sessions_dir / f"{today}.md"
+    decision_bullets = []
+    for index, decision in enumerate(decisions):
+        if not isinstance(decision, dict):
+            raise ContextOSError(f"decisions[{index}] must be an object")
+        decision_bullets.append(ensure_text(decision.get("decision"), f"decisions[{index}].decision"))
+    sections = (
+        f"## What happened\n{_bullets(happened)}\n\n"
+        f"## Decisions\n{_bullets(decision_bullets)}\n\n"
+        f"## Next time\n{_bullets(next_time)}"
+    )
+    if session.exists():
+        sections = f"## Session {clock}\n\n{sections}"
+    pending: dict[Path, str] = {session: _session_append(session, sections, today)}
+    if "current_markdown" in payload:
+        _advance_current(workspace, ensure_text(payload["current_markdown"], "current_markdown"), today, pending)
+    for field, filename in (("blockers_markdown", "blockers.md"), ("weekly_priorities_markdown", "weekly-priorities.md")):
+        if field in payload:
+            pending[workspace.state_dir / filename] = ensure_text(payload[field], field).rstrip() + "\n"
+    if decisions:
+        decision_path = workspace.state_dir / "decisions.md"
+        if not decision_path.exists():
+            raise ContextOSError(f"decision log does not exist: {relative_path(workspace.root, decision_path)}")
+        text = decision_path.read_text(encoding="utf-8").rstrip()
+        for index, decision in enumerate(decisions):
+            rationale = ensure_text(decision.get("rationale", ""), f"decisions[{index}].rationale")
+            rejected = ensure_text(decision.get("rejected_alternatives", ""), f"decisions[{index}].rejected_alternatives")
+            text += (
+                f"\n| {today} | {_escape_table(decision_bullets[index])} | "
+                f"{_escape_table(rationale)} | {_escape_table(rejected)} |"
+            )
+        pending[decision_path] = text + "\n"
+    return pending
+
+
+def _is_populated(content: str) -> bool:
+    stripped = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
+    for raw_line in stripped.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or re.fullmatch(r"\|?[\s:|-]+\|?", line):
+            continue
+        value = re.sub(r"^(?:[-*+]\s+|\d+[.)]\s+)", "", line)
+        if re.fullmatch(r"(?:\*\*[^*]+:\*\*\s*)?\[[^\]\n]+\][.,;:]?", value):
+            continue
+        return True
+    return False
+
+
+def render_setup(workspace: Workspace, payload: dict[str, Any], now: datetime) -> dict[Path, str]:
+    files = payload.get("files")
+    replace = set(ensure_string_list(payload.get("replace_populated"), "replace_populated"))
+    if not isinstance(files, dict) or not files:
+        raise ContextOSError("files must be a non-empty object mapping paths to content")
+    pending: dict[Path, str] = {}
+    for raw_path, raw_content in files.items():
+        if not isinstance(raw_path, str):
+            raise ContextOSError("setup file paths must be strings")
+        path = safe_repo_path(workspace.root, raw_path)
+        relative = relative_path(workspace.root, path)
+        top = Path(relative).parts[0]
+        skill_path = len(Path(relative).parts) >= 3 and Path(relative).parts[:2] == (".agents", "skills")
+        if top not in SETUP_ROOTS and relative not in SETUP_FILES and not skill_path:
+            raise ContextOSError(f"setup cannot write outside approved context paths: {relative}")
+        content = ensure_text(raw_content, f"files[{raw_path}]").replace("{{TODAY}}", now.strftime("%Y-%m-%d"))
+        if path.exists() and _is_populated(path.read_text(encoding="utf-8")) and relative not in replace:
+            raise ContextOSError(f"populated file requires replace_populated approval: {relative}")
+        pending[path] = content.rstrip() + "\n"
+    return pending
+
+
+def build_changes(
+    root: Path, pending: dict[Path, str], replacement_approvals: set[str] | None = None
+) -> list[dict[str, Any]]:
+    changes = []
+    for path in sorted(pending, key=lambda item: relative_path(root, item)):
+        after = pending[path]
+        before = path.read_text(encoding="utf-8") if path.exists() else ""
+        if before == after:
+            continue
+        rel = relative_path(root, path)
+        diff = "".join(
+            difflib.unified_diff(
+                before.splitlines(keepends=True), after.splitlines(keepends=True),
+                fromfile=f"a/{rel}", tofile=f"b/{rel}",
+            )
+        )
+        change = {
+            "path": rel,
+            "before_sha256": file_digest(path),
+            "after_sha256": sha256_text(after),
+            "after_text": after,
+            "diff": diff,
+        }
+        if replacement_approvals is not None:
+            change["replacement_approved"] = rel in replacement_approvals
+        changes.append(change)
+    return changes
+
+
+def proposal_id(workflow: str, now: datetime, changes: list[dict[str, Any]]) -> str:
+    seed = canonical_json({"workflow": workflow, "now": now.isoformat(), "changes": changes})
+    return f"{now.strftime('%Y%m%dT%H%M%S')}-{workflow}-{sha256_text(seed)[:10]}"
+
+
+def create_proposal(root: Path, workflow: str, payload: dict[str, Any], now: datetime) -> tuple[Path, dict[str, Any]]:
+    workspace = load_workspace(root)
+    renderers = {"update": render_update, "end": render_end, "setup": render_setup}
+    if workflow not in renderers:
+        raise ContextOSError(f"unsupported proposal workflow: {workflow}")
+    replacement_approvals = (
+        set(ensure_string_list(payload.get("replace_populated"), "replace_populated"))
+        if workflow == "setup" else None
+    )
+    changes = build_changes(
+        root, renderers[workflow](workspace, payload, now), replacement_approvals
+    )
+    if not changes:
+        raise ContextOSError("proposal has no changes")
+    document: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": workflow,
+        "created_at": now.isoformat(),
+        "proposal_id": proposal_id(workflow, now, changes),
+        "changes": changes,
+        "invariants": ["workflow-path-policy", "optimistic-file-hashes", "exact-proposal-integrity"],
+    }
+    if workflow in {"update", "end"} and any(change["path"].endswith("current.md") for change in changes):
+        document["invariants"].extend(["single-last-updated", "same-day-history"])
+    digest = sha256_text(canonical_json(document))
+    document["proposal_digest"] = digest
+    target = root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n")
+    return target, document
+
+
+@contextmanager
+def transaction_lock(root: Path) -> Iterator[None]:
+    lock = root / ".context-os" / "apply.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as exc:
+        raise ContextOSError(f"another apply is active or left a stale lock: {lock}") from exc
+    try:
+        os.write(descriptor, f"pid={os.getpid()}\n".encode())
+        os.close(descriptor)
+        yield
+    finally:
+        lock.unlink(missing_ok=True)
+
+
+def git_head(root: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True, capture_output=True, check=False
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def validate_proposal(document: dict[str, Any]) -> str:
+    digest = document.get("proposal_digest")
+    if not isinstance(digest, str):
+        raise ContextOSError("proposal is missing proposal_digest")
+    unsigned = dict(document)
+    del unsigned["proposal_digest"]
+    expected = sha256_text(canonical_json(unsigned))
+    if digest != expected:
+        raise ContextOSError("proposal digest does not match its contents")
+    return digest
+
+
+def _validate_change_path(workspace: Workspace, workflow: str, created_at: datetime, relative: str) -> None:
+    parts = Path(relative).parts
+    if not parts or parts[0] in {".git", ".context-os"}:
+        raise ContextOSError(f"proposal path is reserved: {relative}")
+    if workflow == "setup":
+        allowed = (
+            relative in SETUP_FILES
+            or parts[0] in {"identity", "projects", "state"}
+            or (len(parts) >= 3 and parts[:2] == (".agents", "skills"))
+        )
+    else:
+        state_paths = {
+            relative_path(workspace.root, workspace.state_dir / name)
+            for name in ("current.md", "current-log.md")
+        }
+        if workflow == "end":
+            state_paths.update(
+                relative_path(workspace.root, workspace.state_dir / name)
+                for name in ("decisions.md", "blockers.md", "weekly-priorities.md")
+            )
+        session_path = relative_path(
+            workspace.root, workspace.sessions_dir / f"{created_at.strftime('%Y-%m-%d')}.md"
+        )
+        allowed = relative in state_paths or relative == session_path
+    if not allowed:
+        raise ContextOSError(f"{workflow} proposal cannot write path: {relative}")
+
+
+def _validate_proposal_shape(root: Path, proposal: Path, document: dict[str, Any]) -> tuple[str, datetime]:
+    required = {
+        "schema_version", "workflow", "created_at", "proposal_id",
+        "changes", "invariants", "proposal_digest",
+    }
+    if set(document) != required or document.get("schema_version") != SCHEMA_VERSION:
+        raise ContextOSError("proposal has an invalid top-level shape")
+    workflow = document.get("workflow")
+    if workflow not in {"setup", "update", "end"}:
+        raise ContextOSError(f"unsupported proposal workflow: {workflow}")
+    proposal_id_value = ensure_text(document.get("proposal_id"), "proposal_id")
+    expected_dir = (root / ".context-os" / "proposals").resolve()
+    try:
+        proposal.resolve().relative_to(expected_dir)
+    except ValueError as exc:
+        raise ContextOSError("proposal must be loaded from .context-os/proposals") from exc
+    if proposal.name != f"{proposal_id_value}.json":
+        raise ContextOSError("proposal filename does not match proposal_id")
+    created_at = parse_now(ensure_text(document.get("created_at"), "created_at"))
+    changes = document.get("changes")
+    if not isinstance(changes, list) or not changes:
+        raise ContextOSError("proposal changes must be a non-empty list")
+    if not isinstance(document.get("invariants"), list):
+        raise ContextOSError("proposal invariants must be a list")
+    workspace = load_workspace(root)
+    seen: set[str] = set()
+    for index, change in enumerate(changes):
+        if not isinstance(change, dict):
+            raise ContextOSError(f"changes[{index}] must be an object")
+        relative = ensure_text(change.get("path"), f"changes[{index}].path")
+        if relative in seen:
+            raise ContextOSError(f"proposal contains duplicate path: {relative}")
+        seen.add(relative)
+        safe_repo_path(root, relative)
+        _validate_change_path(workspace, workflow, created_at, relative)
+        if workflow == "setup" and change.get("replacement_approved") not in {True, False}:
+            raise ContextOSError(f"setup change is missing replacement policy: {relative}")
+    return workflow, created_at
+
+
+def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) -> tuple[Path, dict[str, Any]]:
+    document = read_json(proposal)
+    workflow, _ = _validate_proposal_shape(root, proposal, document)
+    expected_digest = validate_proposal(document)
+    if confirmation != expected_digest:
+        raise ContextOSError("--confirm must exactly match the proposal_digest")
+    runtime_manifest(root, runtime)
+    with transaction_lock(root):
+        for change in document.get("changes", []):
+            path = safe_repo_path(root, ensure_text(change.get("path"), "change.path"))
+            if workflow == "setup" and path.exists() and _is_populated(path.read_text(encoding="utf-8")):
+                if change.get("replacement_approved") is not True:
+                    raise ContextOSError(f"populated file lacks replacement approval: {change['path']}")
+            if file_digest(path) != change.get("before_sha256"):
+                raise ContextOSError(f"refusing stale proposal; file changed: {change['path']}")
+            if sha256_text(ensure_text(change.get("after_text"), "change.after_text")) != change.get("after_sha256"):
+                raise ContextOSError(f"proposal after hash is invalid: {change['path']}")
+        head_before = git_head(root)
+        applied = []
+        backups: dict[Path, bytes | None] = {}
+        staged: dict[Path, Path] = {}
+        staging_root = root / ".context-os" / "staging" / document["proposal_id"]
+        receipt_path = root / ".context-os" / "receipts" / f"{document['proposal_id']}.json"
+        receipt: dict[str, Any]
+        try:
+            for change in document["changes"]:
+                path = safe_repo_path(root, change["path"])
+                backups[path] = path.read_bytes() if path.exists() else None
+                stage = staging_root / change["path"]
+                stage.parent.mkdir(parents=True, exist_ok=True)
+                stage.write_text(change["after_text"], encoding="utf-8", newline="\n")
+                staged[path] = stage
+            for change in document["changes"]:
+                path = safe_repo_path(root, change["path"])
+                if file_digest(path) != change.get("before_sha256"):
+                    raise ContextOSError(f"refusing target changed during apply: {change['path']}")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(staged[path], path)
+                applied.append({
+                    "path": change["path"],
+                    "sha256_before": change["before_sha256"],
+                    "sha256_after": file_digest(path),
+                })
+            receipt = {
+                "schema_version": SCHEMA_VERSION,
+                "proposal_id": document["proposal_id"],
+                "proposal_digest": expected_digest,
+                "approval_evidence": "host-mediated confirmation; kernel does not authenticate the human approver",
+                "applied_at": utc_now().isoformat(),
+                "runtime": runtime,
+                "files_changed": applied,
+                "git_head_before": head_before,
+                "git_head_after": git_head(root),
+                "invariants_checked": document.get("invariants", []),
+            }
+            receipt_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_stage = staging_root / "receipt.json"
+            receipt_stage.parent.mkdir(parents=True, exist_ok=True)
+            receipt_stage.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8", newline="\n")
+            os.replace(receipt_stage, receipt_path)
+        except Exception as exc:
+            rollback_errors = []
+            for applied_change in reversed(applied):
+                applied_path = safe_repo_path(root, applied_change["path"])
+                try:
+                    before = backups[applied_path]
+                    if before is None:
+                        applied_path.unlink(missing_ok=True)
+                    else:
+                        applied_path.write_bytes(before)
+                except OSError as rollback_exc:
+                    rollback_errors.append(f"{applied_change['path']}: {rollback_exc}")
+            if rollback_errors:
+                raise ContextOSError(
+                    f"apply failed and rollback was incomplete ({'; '.join(rollback_errors)}): {exc}"
+                ) from exc
+            if isinstance(exc, ContextOSError):
+                raise
+            raise ContextOSError(f"apply failed; staged writes were rolled back: {exc}") from exc
+        finally:
+            shutil.rmtree(staging_root, ignore_errors=True)
+        return receipt_path, receipt
+
+
+def runtime_manifest(root: Path, runtime: str) -> dict[str, Any]:
+    if runtime not in RUNTIME_NAMES | {"generic"}:
+        raise ContextOSError(f"unsupported runtime: {runtime}")
+    manifest_path = root / "runtimes" / f"{runtime}.json"
+    if not manifest_path.exists():
+        if runtime == "generic":
+            return {"runtime": "generic", "capabilities": {}}
+        raise ContextOSError(f"missing runtime manifest: {manifest_path}")
+    manifest = read_json(manifest_path)
+    required = {"schema_version", "runtime", "instruction_file", "invocation", "capabilities", "install"}
+    invocation = manifest.get("invocation")
+    capabilities = manifest.get("capabilities")
+    install = manifest.get("install")
+    valid = (
+        set(manifest) == required
+        and manifest.get("runtime") == runtime
+        and manifest.get("schema_version") == SCHEMA_VERSION
+        and isinstance(manifest.get("instruction_file"), str)
+        and isinstance(invocation, dict)
+        and set(invocation) == {"setup", "start", "update", "end"}
+        and all(isinstance(value, str) and value for value in invocation.values())
+        and isinstance(capabilities, dict)
+        and set(capabilities) == CAPABILITY_KEYS
+        and set(capabilities.values()) <= CAPABILITY_VALUES
+        and isinstance(install, dict)
+        and set(install) == {"mode", "next_steps"}
+        and isinstance(install.get("mode"), str)
+        and isinstance(install.get("next_steps"), list)
+        and all(isinstance(item, str) and item for item in install["next_steps"])
+    )
+    if not valid:
+        raise ContextOSError(f"invalid runtime manifest: {manifest_path}")
+    return manifest
+
+
+def start_report(root: Path, now: datetime) -> dict[str, Any]:
+    workspace = load_workspace(root)
+    thresholds = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
+    files: dict[str, Any] = {}
+    today = now.date()
+    for filename, threshold in thresholds.items():
+        path = workspace.state_dir / filename
+        age = None
+        updated = None
+        if path.exists():
+            match = LAST_UPDATED_RE.search(path.read_text(encoding="utf-8"))
+            if match and REAL_DATE_RE.fullmatch(match.group(1).strip()):
+                updated = match.group(1).strip()
+                age = (today - datetime.strptime(updated, "%Y-%m-%d").date()).days
+        files[relative_path(root, path)] = {
+            "exists": path.exists(), "last_updated": updated, "age_days": age,
+            "stale_after_days": threshold, "stale": age is not None and age > threshold,
+        }
+    sessions = sorted(workspace.sessions_dir.glob("????-??-??.md"), reverse=True) if workspace.sessions_dir.exists() else []
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": now.isoformat(),
+        "state": files,
+        "latest_session": relative_path(root, sessions[0]) if sessions else None,
+        "task_file": relative_path(root, workspace.task_file),
+        "git_head": git_head(root),
+    }
+
+
+def install_runtime(root: Path, runtime: str) -> tuple[Path, dict[str, Any]]:
+    manifest = runtime_manifest(root, runtime)
+    local = {
+        "schema_version": SCHEMA_VERSION,
+        "runtime": runtime,
+        "installed_at": utc_now().isoformat(),
+        "source_manifest_sha256": sha256_text(canonical_json(manifest)),
+        "next_steps": manifest.get("install", {}).get("next_steps", []),
+    }
+    target = root / ".context-os" / "runtime.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(local, indent=2) + "\n", encoding="utf-8", newline="\n")
+    return target, local
+
+
+def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
+    checks: list[dict[str, str]] = []
+
+    def add(name: str, status: str, detail: str) -> None:
+        checks.append({"name": name, "status": status, "detail": detail})
+
+    git_location = shutil.which("git")
+    add("command:git", "pass" if git_location else "fail", git_location or "not found")
+    add("command:python", "pass", sys.executable)
+    workspace = load_workspace(root)
+    required_paths = [
+        root / "AGENTS.md", workspace.state_dir / "current.md",
+        workspace.state_dir / "current-log.md", workspace.state_dir / "decisions.md",
+    ]
+    for path in required_paths:
+        rel = relative_path(root, path)
+        add(f"file:{rel}", "pass" if path.exists() else "fail", rel)
+    selected = runtime
+    local_runtime = root / ".context-os" / "runtime.json"
+    if selected is None and local_runtime.exists():
+        selected = read_json(local_runtime).get("runtime")
+    hosts = [selected] if selected else sorted(RUNTIME_NAMES)
+    for host in hosts:
+        try:
+            manifest = runtime_manifest(root, host)
+            add(f"manifest:{host}", "pass", f"schema {manifest['schema_version']}")
+        except ContextOSError as exc:
+            add(f"manifest:{host}", "fail", str(exc))
+    lock = root / ".context-os" / "apply.lock"
+    add("transaction-lock", "warn" if lock.exists() else "pass", str(lock) if lock.exists() else "none")
+    cutoff = utc_now().timestamp() - (30 * 24 * 60 * 60)
+    old_artifacts = [
+        path for folder in ("proposals", "receipts")
+        for path in (root / ".context-os" / folder).glob("*.json")
+        if path.stat().st_mtime < cutoff
+    ]
+    add(
+        "local-artifact-retention", "warn" if old_artifacts else "pass",
+        f"{len(old_artifacts)} artifacts older than 30 days" if old_artifacts else "none older than 30 days",
+    )
+    if selected:
+        try:
+            selected_manifest = runtime_manifest(root, selected)
+            expected_source = sha256_text(canonical_json(selected_manifest))
+            if local_runtime.exists():
+                recorded_source = read_json(local_runtime).get("source_manifest_sha256")
+                add(
+                    "runtime-manifest-drift",
+                    "pass" if recorded_source == expected_source else "warn",
+                    "current" if recorded_source == expected_source else "rerun context-os install",
+                )
+        except ContextOSError as exc:
+            add("runtime-manifest-drift", "fail", str(exc))
+        binary = {"claude": "claude", "codex": "codex", "hermes": "hermes"}.get(selected)
+        if binary:
+            location = shutil.which(binary)
+            add(f"runtime:{selected}", "pass" if location else "warn", location or "not installed")
+    status = "fail" if any(item["status"] == "fail" for item in checks) else "warn" if any(item["status"] == "warn" for item in checks) else "pass"
+    return {"schema_version": SCHEMA_VERSION, "status": status, "checks": checks}
+
+
+def _hook_targets(payload: dict[str, Any]) -> set[str]:
+    targets: set[str] = set()
+
+    def visit(value: Any, key: str = "") -> None:
+        if isinstance(value, dict):
+            for child_key, child in value.items():
+                visit(child, child_key)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child, key)
+        elif isinstance(value, str):
+            if key in {"file_path", "path"} and value.strip():
+                targets.add(value.strip().replace("\\", "/"))
+            if key in {"command", "patch"}:
+                for match in re.finditer(r"^\*\*\* (?:Add|Update|Delete) File: (.+?)\s*$", value, re.MULTILINE):
+                    targets.add(match.group(1).strip().replace("\\", "/"))
+
+    visit(payload)
+    return targets
+
+
+def hook_report(root: Path, event: str, payload: dict[str, Any]) -> dict[str, Any]:
+    findings: list[dict[str, str]] = []
+    workspace = load_workspace(root)
+    if event == "session-start":
+        current = workspace.state_dir / "current.md"
+        if current.exists() and PLACEHOLDER_DATE in current.read_text(encoding="utf-8"):
+            findings.append({"severity": "advisory", "message": "Context OS is not initialized; run the explicit setup workflow."})
+        lock = root / ".context-os" / "apply.lock"
+        if lock.exists():
+            findings.append({"severity": "warning", "message": f"A lifecycle apply lock exists at {lock}. Run context-os doctor before writing."})
+    elif event == "pre-write":
+        protected = {
+            relative_path(root, workspace.state_dir / "current.md"): "Use the lifecycle proposal/apply kernel for current.md so date and history invariants are enforced.",
+            relative_path(root, workspace.state_dir / "current-log.md"): "Use the lifecycle proposal/apply kernel for current-log.md so history remains consistent.",
+            relative_path(root, workspace.state_dir / "decisions.md"): "Use the end-session proposal/apply kernel for append-only decision rows.",
+            relative_path(root, workspace.state_dir / "blockers.md"): "Use the lifecycle proposal/apply kernel for blockers.md.",
+            relative_path(root, workspace.state_dir / "weekly-priorities.md"): "Use the lifecycle proposal/apply kernel for weekly-priorities.md.",
+        }
+        normalized_targets = set()
+        for target in _hook_targets(payload):
+            candidate = Path(target)
+            if candidate.is_absolute():
+                try:
+                    normalized_targets.add(relative_path(root, candidate))
+                except ValueError:
+                    continue
+            else:
+                normalized_targets.add(Path(target.removeprefix("./")).as_posix())
+        for path, message in protected.items():
+            if path in normalized_targets:
+                findings.append({"severity": "advisory", "message": message})
+    else:
+        raise ContextOSError(f"unsupported hook event: {event}")
+    return {"schema_version": SCHEMA_VERSION, "event": event, "findings": findings}

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -1,72 +1,73 @@
 # Codex onboarding
 
-Codex can use the same repository state as Claude Code. The portable boundary is the root `AGENTS.md`, reusable workflows in `.agents/skills/`, and the existing `identity/`, `projects/`, `state/`, and `sessions/` files. A fork is not required.
+Codex uses the same repository state and deterministic lifecycle kernel as the
+other supported runtimes. The portable boundary is `AGENTS.md`,
+`.agents/skills/`, `contextos/`, and the repository state directories.
 
 ## Set up
-
-From a fresh clone:
 
 ```bash
 bash scripts/setup.sh --agent codex
 ```
 
-Then launch Codex from the repository root and invoke the onboarding skill explicitly:
+Then launch Codex from the repository root and explicitly invoke `$setup`.
+Use `$start`, `$update`, and `$end` for the daily loop. The namespaced
+`$context-*` forms remain compatibility aliases.
 
-```text
-$setup
+Setup records a gitignored local runtime selection. Inspect it with:
+
+```bash
+python3 -m contextos doctor --runtime codex
 ```
 
-Codex discovers the root [`AGENTS.md`](../AGENTS.md) and repository skills automatically. The lifecycle is:
+## Deterministic writes
 
-| Moment | Codex skill | Shared result |
-|---|---|---|
-| First run or major refresh | `$setup` | Identity, projects, reusable workflows, and weekly state |
-| Start work | `$start` | Briefing from repository state and recent sessions |
-| Mid-session | `$update` | Append-only checkpoint and minimal state change |
-| Finish work | `$end` | Reviewed session log, state updates, decisions, and git safety report |
-
-The four lifecycle skills disable implicit invocation. This prevents an agent from opening, checkpointing, or closing a session merely because a prompt resembles the workflow.
-
-## What is shared
-
-- Identity and professional context in `identity/`
-- Project context in `projects/`
-- Current priorities, decisions, and blockers in `state/`
-- Session handoffs in `sessions/`
-- Provider-neutral workflow instructions in `.agents/skills/`
-- Routing and safety rules in `ROUTING.md` and `docs/safety-contract.md`
-
-Commit these files only when they are appropriate for the repository's visibility. They may contain personal or business-sensitive information.
+The skills do not directly mutate lifecycle state. They create reviewed input,
+run `python3 -m contextos propose`, present exact diffs, and run `apply` only
+after the user approves the displayed digest. The receipt is the portable proof
+of which paths and hashes changed. The kernel never commits or pushes.
 
 ## Host-specific boundaries
 
-| Capability | Portable | Claude Code only in this repository | Codex path |
-|---|---:|---:|---|
-| Repository state and session logs | Yes | No | Read and update through the lifecycle skills |
-| Lifecycle workflow core | Yes | No | `.agents/skills/context-*` |
-| Slash commands | No | Yes | Invoke `$setup`, `$start`, `$update`, or `$end` instead |
-| Checked-in hooks and settings | No | Yes | No equivalence is claimed |
-| Claude auto-memory and `/dream` | No | Yes | Use repository `state/` and `sessions/` for shared continuity |
-| Personal agent configuration | No | No | Keep it outside the repository |
+| Capability | Shared contract | Codex path |
+|---|---|---|
+| State, sessions, and decisions | Yes | Lifecycle kernel and skills |
+| Explicit lifecycle names | Yes | `$setup`, `$start`, `$update`, `$end` |
+| Project instructions | Semantically shared | Hierarchical `AGENTS.md` discovery |
+| Project hooks | Event-specific | Trusted `.codex/hooks.json` adapter |
+| MCP | Configuration-specific | Keep auth and credentials outside tracked files |
+| Native memory | No | Repository state remains the shared SSOT |
 
-Codex supports trusted repository-scoped [`.codex/config.toml` overrides](https://developers.openai.com/codex/config-basic). This template intentionally does not ship one: its portable lifecycle does not need project-level model, sandbox, approval, MCP, or hook overrides, and adding them would expand the template's trust boundary. If a project later adopts shared Codex configuration, review it like infrastructure. Keep credentials, personal preferences, and provider/auth settings at user or managed scope.
+Codex now supports repository hooks. This template includes advisory
+`SessionStart` and `PreToolUse` mappings, but hook trust and event semantics are
+host-specific. Project-local hooks run only after the `.codex` layer is trusted.
+Proposal/apply does not rely on a hook firing.
+
+The template intentionally avoids checked-in model, sandbox, approval, MCP, or
+credential overrides. Review any future `.codex/config.toml` like infrastructure.
 
 ## Optional import
 
-Codex CLI offers `/import` from Claude Code or Cursor for selected supported setup, project files, and up to 50 recent chats from the last 30 days. It is optional migration help, not the runtime path for this repository or an account-wide history importer. Run it before a task in a local interactive CLI; it is unavailable inside a running task, a remote session, or the local app-server daemon. The repository already has native `AGENTS.md` and `.agents/skills/`, so preview the item list and review every resulting change for duplicates or conflicts.
-
-## Official references
-
-- [How Codex discovers `AGENTS.md`](https://developers.openai.com/codex/agent-configuration/agents-md)
-- [Build and use Codex skills](https://developers.openai.com/codex/build-skills)
-- [Import configuration into Codex](https://developers.openai.com/codex/import)
+Codex `/import` can help migrate selected supported configuration and recent
+history, including up to 50 recent chats from the last 30 days where the current
+client supports it. It is not the runtime path for Context OS or an account-wide
+importer. Preview every imported item and resolve duplicates against repository
+SSOTs.
 
 ## Verify
 
-Run:
-
 ```bash
+python3 -m contextos doctor --runtime codex
 bash scripts/validate-all.sh
 ```
 
-CI validates file structure, adapter mapping, explicit invocation policy, local links, shell syntax, hooks, JSON, and unit tests. It cannot prove the behavior of every installed Codex version or external integration, so keep the host boundaries above explicit.
+Local validation proves kernel transitions and adapter contracts. Opt-in runtime
+smoke tests report a visible skip when an installed or authenticated host is not
+available; they never turn a skipped runtime into a parity claim. Validation
+cannot prove the behavior of every installed Codex version.
+
+Official references:
+
+- [Codex `AGENTS.md` discovery](https://learn.chatgpt.com/docs/agent-configuration/agents-md)
+- [Codex skills](https://learn.chatgpt.com/docs/build-skills)
+- [Codex hooks](https://learn.chatgpt.com/docs/hooks)

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -1,59 +1,80 @@
 # Commands and skills
 
-This index separates portable workflow cores from host-specific adapters. A command or skill exists only where listed; a similar name does not imply permission, hook, or runtime parity on another host.
+Context OS guarantees shared state transitions, not identical host features.
+Portable skills gather and review intent; the deterministic kernel owns paths,
+dates, append behavior, optimistic hashes, locking, and receipts.
 
 ## Shared lifecycle
 
-| Job | Claude Code | Codex | Effects and prerequisites |
+| Job | Claude Code | Codex | Hermes | Deterministic operation |
+|---|---|---|---|---|
+| Initialize context | `/setup` | `$setup` | `/setup` | `contextos propose setup` then `apply` |
+| Start a session | `/start` | `$start` | `/start` | read-only `contextos start` |
+| Checkpoint | `/update` | `$update` | `/update` | `contextos propose update` then `apply` |
+| Close a session | `/end` | `$end` | `/end` | `contextos propose end` then `apply` |
+
+The portable cores are `.agents/skills/context-setup`, `context-start`,
+`context-update`, and `context-end`. Short skill directories are thin aliases;
+Claude files are host adapters. All lifecycle names require explicit invocation.
+
+The mutation protocol is always:
+
+1. the agent drafts reviewed JSON input under ignored `.context-os/inputs/`;
+2. `python3 -m contextos propose` emits exact diffs and a proposal digest;
+3. the agent presents those diffs and waits;
+4. `python3 -m contextos apply` receives that exact digest; and
+5. the kernel verifies target hashes, takes an exclusive lock, writes only the
+   proposal paths, and records a receipt.
+
+## Runtime boundary
+
+| Capability | Claude Code | Codex | Hermes |
 |---|---|---|---|
-| Initialize context | `/setup` | `$setup` (`$context-setup` compatibility) | Proposes identity, project, state, routing, and approved workflow files; review before writes |
-| Start a session | `/start` | `$start` (`$context-start` compatibility) | Repository reads only; no live external data or authentication by default |
-| Checkpoint | `/update` | `$update` (`$context-update` compatibility) | Writes a reviewed session checkpoint and minimal current state |
-| Close a session | `/end` | `$end` (`$context-end` compatibility) | Writes a reviewed handoff, state, and decisions; Claude may separately propose host-local memory |
+| Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` |
+| Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills |
+| Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter |
+| Lifecycle enforcement | Kernel | Kernel | Kernel |
+| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` |
 
-The portable workflow cores are `.agents/skills/context-setup`, `context-start`,
-`context-update`, and `context-end`. The matching short skill directories are
-thin compatibility adapters, and Claude Code files are host-specific adapters.
-Both naming forms require explicit user invocation.
+Runtime manifests in `runtimes/` are machine-readable claims. Hooks are defense
+in depth: the kernel repeats mutation invariants during every proposal and apply.
 
-## Portable migration
+## Portable skill index
 
-| Job | Claude Code | Codex/compatible skill host | Effects and prerequisites |
-|---|---|---|---|
-| Map selected Gemini configuration | `/migrate-gemini` | `$migrate-gemini` | Metadata-first inventory in ignored staging; writes only an approved mapping |
-| Recover repeated Gemini workflows | `/mine-gemini-workflows` | `$mine-gemini-workflows` | Selected session directory; content and paths require separate opt-ins |
+| Skill | Job | Effects |
+|---|---|---|
+| `$context-setup` | Canonical setup core | Proposal/apply only |
+| `$context-start` | Canonical read-only start core | No writes |
+| `$context-update` | Canonical checkpoint core | Proposal/apply only |
+| `$context-end` | Canonical close core | Proposal/apply only |
+| `$migrate-gemini` | Map selected Gemini configuration | Reviewed mapping only |
+| `$mine-gemini-workflows` | Recover repeated Gemini workflows | Narrow selected evidence |
 
-These are the portable skills `.agents/skills/migrate-gemini` and `.agents/skills/mine-gemini-workflows`. They do not expose private reasoning or make a bulk-history import safe by default.
+The `$setup`, `$start`, `$update`, and `$end` rows in the shared lifecycle table
+are the short portable aliases. The ten tokens above and in that table are the
+complete shipped portable skill catalog.
 
-## Claude Code context and maintenance
+The two migration skills do not expose private reasoning or make bulk-history
+import safe. Their Claude adapters appear in the command index below.
+
+## Claude-specific command index
 
 | Command | Job | Effects and prerequisites |
 |---|---|---|
-| `/today` | Morning heartbeat from repository state | Writes `state/heartbeat-log.md`; live data is skipped unless separately enabled and requested |
-| `/capture` | Triage reviewed inbox notes | Writes only approved destinations, verifies them, and leaves each source for separate user-controlled cleanup |
-| `/find-context` | Find relevant repository context | Read-only |
-| `/reconcile` | Detect repository and session drift | Read-only report by default; explicit fix mode may edit and commit individually approved repairs |
-| `/recover` | Inspect orphaned worktrees/branches and offer cleanup | Cleanup is destructive and remains approval-gated |
-| `/content-shipped` | Record a confirmed published item | Writes `content/log.md`; it does not publish the item |
-| `/clean-ai-writing` | Apply the included writing workflow | Reads supplied content and returns a proposed revision in chat; no file write grant |
+| `/today` | Morning heartbeat | Reviewed heartbeat write; live data stays opt-in |
+| `/capture` | Triage inbox notes | Approved destinations only; source cleanup remains separate |
+| `/find-context` | Locate relevant context | Read-only |
+| `/reconcile` | Detect repository drift | Read-only report unless fixes are separately approved |
+| `/recover` | Inspect stale worktrees and branches | Read-only until destructive cleanup approval |
+| `/content-shipped` | Log confirmed published content | Local content-log write; does not publish |
+| `/clean-ai-writing` | Apply the writing workflow | Proposed revision only |
+| `/dream` | Curate host-local auto-memory | Proposal artifacts only |
+| `/dream-apply` | Apply reviewed memory proposals | Host-local write with per-item review |
+| `/migrate-gemini` | Claude adapter for selected migration | Routes to the portable skill |
+| `/mine-gemini-workflows` | Claude adapter for workflow recovery | Routes to the portable skill |
 
-## Claude Code auto-memory
+Uploading these files to claude.ai does not activate commands, hooks, tool
+permissions, or skill metadata. See `docs/claude-projects-sync.md`.
 
-| Command | Job | Effects and prerequisites |
-|---|---|---|
-| `/dream` | Run one shipped curator: `rot`, `merge`, `split`, or `lint` | Requires the explicit local memory-directory contract; writes and commits proposal artifacts only |
-| `/dream-apply` | Review a proposal artifact item by item | Applies accepted live-memory changes and commits locally; refuses a memory remote |
-
-Claude Code's ordinary auto-memory is enabled by default and may write automatically; `/dream` and `/dream-apply` add separate artifact/apply gates but do not govern that host behavior. Auto-memory is not shared with Codex. See [`auto-memory.md`](auto-memory.md).
-
-## Claude Code customization
-
-| Command or skill | Job | Effects and prerequisites |
-|---|---|---|
-| `.claude/skills/skill-creator` | Scaffold or revise a Claude-native skill and optional adapter | Claude Code only; shows files and safety metadata for review before installation |
-
-To create a provider-neutral workflow, start under `.agents/skills/` and follow [`first-skill.md`](first-skill.md).
-
-## Claude.ai Projects
-
-Claude.ai does not activate these repository slash commands or skill metadata. Selected files can be uploaded as guidance only. See [`claude-projects-sync.md`](claude-projects-sync.md).
+Run `python3 -m contextos doctor` for runtime and state diagnostics, then
+`bash scripts/validate-all.sh` after repository changes.

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -1,0 +1,80 @@
+# Cross-runtime architecture
+
+Context OS guarantees equivalent lifecycle state transitions across supported
+runtimes. It does not claim identical command syntax, hook timing, permission
+models, tool names, or native memory.
+
+## Layers
+
+1. **Repository state:** `identity/`, `projects/`, `state/`, and `sessions/` are
+   the durable, reviewable source of truth.
+2. **Portable intent:** `.agents/skills/context-*` gathers facts and asks for
+   judgment without owning mutation mechanics.
+3. **Deterministic kernel:** `python3 -m contextos` owns paths, rendering,
+   invariants, proposals, locks, optimistic hashes, applies, and receipts.
+4. **Runtime adapters:** `.claude/`, `.codex/`, and `adapters/hermes/` map host
+   discovery and hooks to the portable layers.
+5. **Conformance:** dependency-light tests assert exact state transitions;
+   opt-in launch tests exercise installed host discovery without hiding skips.
+
+## Commands
+
+```text
+python3 -m contextos start [--now ISO_TIMESTAMP]
+python3 -m contextos propose setup|update|end --input payload.json [--now ISO_TIMESTAMP]
+python3 -m contextos apply proposal.json --confirm SHA256 --runtime claude|codex|hermes
+python3 -m contextos install --runtime claude|codex|hermes
+python3 -m contextos doctor [--runtime claude|codex|hermes]
+```
+
+`--now` exists for deterministic fixtures. Production calls use local time.
+
+## Input contracts
+
+Update requires `progress: [string]` and optionally accepts complete
+`current_markdown`. End requires `what_happened: [string]` and accepts
+`decisions`, `next_time`, and complete desired Markdown for state files that
+materially changed. Setup accepts `files: {path: content}` and requires every
+populated replacement path in `replace_populated`.
+
+The kernel rejects absolute paths, traversal, setup writes outside approved
+context roots, multiple or missing `Last Updated` lines, and no-op proposals.
+
+## Best-effort transaction protocol
+
+Proposal files contain exact after-content, unified diffs, and before/after
+SHA-256 values. Their proposal digest covers the entire unsigned proposal. It
+binds integrity; the host permission prompt supplies the human approval boundary.
+Apply requires that exact digest, re-hashes every target, takes an exclusive
+`O_EXCL` lock, writes using UTF-8/LF, and emits a receipt inside the rollback
+boundary. Individual replacements are atomic; a multi-file batch is not
+crash-atomic. A process kill can leave partial state and a stale lock; `doctor`
+surfaces the lock and never deletes it silently.
+
+Proposals and receipts can contain full state text. They remain local and ignored
+by Git; `doctor` warns when artifacts are older than 30 days so the owner can
+remove them after their audit or recovery value has expired.
+
+The kernel never commits, pushes, calls an integration, or accesses native
+memory. Those actions remain separate approval boundaries.
+
+## Capabilities and degradation
+
+`runtimes/*.json` declares host capabilities as `native`, `adapter`,
+`advisory`, or `unsupported`. Adapters may improve presentation or catch errors
+earlier, but unsupported hooks never weaken kernel enforcement. Hermes copied
+skills can drift, so installation and `doctor` report that boundary explicitly.
+
+## Conformance policy
+
+Every lifecycle mutation needs:
+
+- a successful transition test;
+- an exact-confirmation rejection;
+- a stale-target rejection;
+- a concurrent-lock rejection;
+- path-containment controls; and
+- a must-not-change assertion for unrelated files.
+
+Runtime launch tests are opt-in because CI may not have installed clients or
+authentication. A skip is visible and is not counted as evidence of parity.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,14 @@
 # Getting started with Context OS
 
-Context OS can begin with a blank interview or selected context from another assistant. The result is the same: a small, reviewable repository that Claude Code and Codex can use as shared state.
+Context OS can begin with a blank interview or selected context from another
+assistant. The result is a small, reviewable repository that Claude Code,
+Codex, and Hermes can use as shared state.
 
 ## Before you clone
 
-You need Git, Bash, and Python 3. You also need Claude Code or Codex for the guided lifecycle. claude.ai can help produce files, but it cannot maintain a local checkout directly.
+You need Git, Bash, Python 3, and at least one supported local agent: Claude
+Code, Codex, or Hermes. claude.ai can help produce files but cannot maintain a
+local checkout directly.
 
 Decide where the repository will live. If it will contain personal, client, employer, financial, or unpublished project context, use a private remote. Repository visibility is only one control; do not store credentials, raw account exports, or information you would not want every configured agent to read.
 
@@ -35,6 +39,8 @@ Choose the host you expect to use first:
 bash scripts/setup.sh --agent claude
 # or
 bash scripts/setup.sh --agent codex
+# or
+bash scripts/setup.sh --agent hermes
 ```
 
 You can omit `--agent` to auto-detect an installed host, or use `--agent none` to prepare the repository without launching one.
@@ -59,9 +65,13 @@ Launch the selected host from the repository root:
 claude
 # or
 codex
+# or
+hermes
 ```
 
-Run `/setup` in Claude Code or `$setup` in Codex. The guided interview asks one question at a time, proposes a file map, and waits before changing populated files.
+Run `/setup` in Claude Code or Hermes, or `$setup` in Codex. The guided
+interview asks one question at a time, builds a deterministic proposal, and
+waits before applying the exact reviewed diff.
 
 ### Bring existing context
 
@@ -86,6 +96,7 @@ Remove any unsupported inference, stale claim, duplicate fact, or context that i
 Then run:
 
 ```bash
+python3 -m contextos doctor
 bash scripts/validate-all.sh
 git diff --check
 git status --short
@@ -95,13 +106,16 @@ Commit and push only after the diff matches what you intend to preserve.
 
 ## Run the daily loop
 
-| Moment | Claude Code | Codex |
-|---|---|---|
-| Start work | `/start` | `$start` |
-| Save progress without closing | `/update` | `$update` |
-| End with a reviewed handoff | `/end` | `$end` |
+| Moment | Claude Code | Codex | Hermes |
+|---|---|---|---|
+| Start work | `/start` | `$start` | `/start` |
+| Save progress without closing | `/update` | `$update` | `/update` |
+| End with a reviewed handoff | `/end` | `$end` | `/end` |
 
-The lifecycle writes shared continuity to `state/` and `sessions/`. Claude Code has additional host-specific hooks, commands, and auto-memory features. The [Codex onboarding guide](codex-onboarding.md) documents the exact boundary.
+The lifecycle kernel writes shared continuity to `state/` and `sessions/` only
+after exact-proposal approval, then emits a local receipt. Each host retains
+different hooks, commands, permissions, and native memory. See the
+[cross-runtime architecture](cross-runtime-architecture.md).
 
 ## Add capabilities later
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,9 +4,9 @@ Maintenance should keep context accurate and permissions narrow without creating
 
 ## Every working session
 
-1. Run `/start` in Claude Code or `$start` in Codex.
+1. Run `/start` in Claude Code or Hermes, or `$start` in Codex.
 2. Use `/update` or `$update` only when a long session needs a durable handoff.
-3. Finish with `/end` or `$end` and review the proposed session/state diff.
+3. Finish with `/end` or `$end`, review the kernel proposal, and verify its receipt.
 4. Inspect `git status` and the exact diff. Commit or push only after a separate approval and remote-audience check.
 
 ## Weekly
@@ -26,7 +26,9 @@ Maintenance should keep context accurate and permissions narrow without creating
 
 ## Portable continuity versus Claude memory
 
-`state/` and `sessions/` are the shared, version-controlled continuity layer for Claude Code and Codex. Claude Code auto-memory is a separate, host-local and often confidential store. It is not copied to Codex or Claude.ai.
+`state/` and `sessions/` are the shared, version-controlled continuity layer for
+Claude Code, Codex, and Hermes. Native memory is host-local and often
+confidential. It is never synchronized by the lifecycle kernel.
 
 If you opt into `/dream`, first configure and verify the explicit path in [`auto-memory.md`](auto-memory.md). Run `/dream` on demand, then inspect its committed proposal artifact. `/dream-apply` is a separate live-memory write workflow with per-item review. The shipped curators are `rot`, `merge`, `split`, and `lint`; later curator designs are not current functionality.
 

--- a/docs/memory-across-agents.md
+++ b/docs/memory-across-agents.md
@@ -1,33 +1,50 @@
 # Memory across agents
 
-Context OS is deliberately not a memory product. It is a Git-backed context layer, and its relationship to each host's native memory feature is worth stating plainly so users do not double-book the same fact in two systems.
+Context OS is a Git-backed context layer, not a native-memory synchronizer.
 
-## The short version
-
-| Concern | Where it lives |
+| Concern | Canonical home |
 |---|---|
-| Durable facts you want every agent to see | This repository (`identity/`, `state/`, `projects/`) — versioned, reviewable, portable |
-| Host-local working memory (one agent's private scratch) | That host's native memory feature |
-| Curated long-term memory with provenance and review gates | Repository state plus a reviewed curator workflow |
+| Facts every configured agent should see | Reviewed repository files |
+| One host's private scratch or learned preferences | That host's native memory |
+| Promotion from a session into shared state | Kernel proposal/apply transaction |
+| Evidence of a host-confirmed shared mutation | Gitignored proposal and receipt |
 
 ## Claude Code
 
-Claude Code auto-memory writes machine-local files under `~/.claude/projects/<encoded-cwd>/memory/` automatically. Context OS treats it as a separate layer: `/dream` curates it via proposal artifacts, `/dream-apply` applies accepted changes, and neither governs auto-memory's ordinary automatic writes. See [`auto-memory.md`](auto-memory.md) and [`dream-architecture.md`](dream-architecture.md).
+Claude auto-memory is machine-local and may write during ordinary sessions. Use
+Claude's `/memory` command to inspect the active store; do not derive its path.
+`/dream` and `/dream-apply` are separate review workflows for that host-local
+store. They do not replace lifecycle proposal/apply for repository state.
+
+## Codex
+
+No Codex-native memory behavior is part of the shared contract. `AGENTS.md`,
+`state/`, and `sessions/` provide continuity. Personal Codex configuration and
+credentials remain outside the repository.
 
 ## Hermes Agent
 
-Hermes has two native memory mechanisms that overlap conceptually with parts of this repository:
+Hermes `MEMORY.md` and `USER.md` are bounded, per-profile, machine-local memory.
+Its Curator maintains Hermes-owned stores. Context OS never reads, writes, or
+synchronizes those files automatically.
 
-| Hermes native | Closest Context OS concept | How they differ |
-|---|---|---|
-| `MEMORY.md` + `USER.md` persistent memory (typed entries, injected every session) | `state/current.md`, `identity/who-i-am.md` | Hermes memory is per-profile and machine-local; repository state is versioned, diffable, and travels with the clone. Keep facts that must survive a machine or agent switch in the repository. |
-| Background Curator (usage tracking, staleness detection, archival of skills and memories) | `/dream` rot-detection pass | Both detect drift and propose maintenance. The Curator runs autonomously on Hermes' own stores; `/dream` writes reviewable proposal artifacts before anything mutates. |
+Use Hermes memory for host-local preferences and environment facts. Promote a
+fact that must travel across runtimes only by drafting it into an approved
+repository proposal. Do not run multiple writers against one Hermes home, and
+do not duplicate the same fact in native memory and repository state without a
+declared canonical home.
 
-Practical guidance for Hermes users:
+## Proposal/apply boundary
 
-1. Let Hermes remember session-level preferences natively — do not mirror them into `state/`.
-2. Put identity, project briefs, decisions, and priorities in this repository. They are the durable layer.
-3. If you run `/dream` against a Hermes memory directory, treat the output exactly as designed: proposals only, reviewed item by item before any write-back.
-4. Do not configure the same fact as both a Hermes memory entry and a repository file without picking one canonical home. See the SSOT rule in `AGENTS.md`.
+All three runtimes use the same repository transaction:
 
-The design bet is the same one described in [`positioning.md`](positioning.md): durable context belongs in files you control, and an assistant's private memory is never the source of truth.
+1. reviewed structured input;
+2. exact proposed diffs and digest;
+3. host-mediated explicit confirmation (the kernel does not authenticate the human);
+4. optimistic hash and exclusive-lock checks;
+5. bounded writes; and
+6. a receipt naming the runtime and before/after hashes.
+
+This provides portable provenance without copying private native memory between
+providers. Proposal and receipt files are ignored and may still contain
+sensitive context; treat the local checkout as part of the privacy boundary.

--- a/docs/templates/end-payload.json
+++ b/docs/templates/end-payload.json
@@ -1,0 +1,15 @@
+{
+  "what_happened": [
+    "Replace this with one approved factual outcome."
+  ],
+  "decisions": [
+    {
+      "decision": "Replace or remove this example decision.",
+      "rationale": "Why this choice matters later.",
+      "rejected_alternatives": "Leave blank when there was no real branch point."
+    }
+  ],
+  "next_time": [
+    "Replace this with the highest-value next action."
+  ]
+}

--- a/docs/templates/setup-payload.json
+++ b/docs/templates/setup-payload.json
@@ -1,0 +1,6 @@
+{
+  "files": {
+    "identity/who-i-am.md": "# Your reviewed content\n\n**Last Updated:** {{TODAY}}\n"
+  },
+  "replace_populated": []
+}

--- a/docs/templates/update-payload.json
+++ b/docs/templates/update-payload.json
@@ -1,0 +1,5 @@
+{
+  "progress": [
+    "Replace this with one approved factual progress item."
+  ]
+}

--- a/runtimes/claude.json
+++ b/runtimes/claude.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "runtime": "claude",
+  "instruction_file": "CLAUDE.md",
+  "invocation": {
+    "setup": "/setup",
+    "start": "/start",
+    "update": "/update",
+    "end": "/end"
+  },
+  "capabilities": {
+    "agent_skills": "native",
+    "explicit_invocation": "native",
+    "project_hooks": "native",
+    "blocking_pre_tool_hook": "native",
+    "mcp": "native",
+    "native_memory": "native",
+    "proposal_apply": "adapter"
+  },
+  "install": {
+    "mode": "repository-native",
+    "next_steps": [
+      "Launch Claude Code from the repository root.",
+      "Review project hook trust, then run /setup or /start."
+    ]
+  }
+}

--- a/runtimes/codex.json
+++ b/runtimes/codex.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "runtime": "codex",
+  "instruction_file": "AGENTS.md",
+  "invocation": {
+    "setup": "$setup",
+    "start": "$start",
+    "update": "$update",
+    "end": "$end"
+  },
+  "capabilities": {
+    "agent_skills": "native",
+    "explicit_invocation": "native",
+    "project_hooks": "native",
+    "blocking_pre_tool_hook": "native",
+    "mcp": "native",
+    "native_memory": "unsupported",
+    "proposal_apply": "adapter"
+  },
+  "install": {
+    "mode": "repository-native",
+    "next_steps": [
+      "Launch Codex from the repository root.",
+      "Review the trusted .codex layer and project hooks, then run $setup or $start."
+    ]
+  }
+}

--- a/runtimes/hermes.json
+++ b/runtimes/hermes.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "runtime": "hermes",
+  "instruction_file": "AGENTS.md",
+  "invocation": {
+    "setup": "/setup",
+    "start": "/start",
+    "update": "/update",
+    "end": "/end"
+  },
+  "capabilities": {
+    "agent_skills": "adapter",
+    "explicit_invocation": "advisory",
+    "project_hooks": "adapter",
+    "blocking_pre_tool_hook": "advisory",
+    "mcp": "native",
+    "native_memory": "native",
+    "proposal_apply": "adapter"
+  },
+  "install": {
+    "mode": "skill-copy-or-external-directory",
+    "next_steps": [
+      "Expose this repository's .agents/skills directory to Hermes or install all four short aliases and their context-* cores.",
+      "Start a new Hermes session so the installed skill catalog refreshes.",
+      "Keep Hermes MEMORY.md and USER.md separate from repository state."
+    ]
+  }
+}

--- a/runtimes/schema.json
+++ b/runtimes/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Context OS runtime capability manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "runtime", "instruction_file", "invocation", "capabilities", "install"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "runtime": {"enum": ["claude", "codex", "hermes"]},
+    "instruction_file": {"type": "string"},
+    "invocation": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "required": ["setup", "start", "update", "end"]
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": {"enum": ["native", "adapter", "advisory", "unsupported"]}
+    },
+    "install": {
+      "type": "object",
+      "required": ["mode", "next_steps"],
+      "properties": {
+        "mode": {"type": "string"},
+        "next_steps": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/scripts/context-os-hook.py
+++ b/scripts/context-os-hook.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Stable hook entry point that works when the runtime starts below repo root."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from contextos.kernel import ContextOSError, hook_report  # noqa: E402
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"claude", "codex", "hermes"}:
+        print("usage: context-os-hook.py claude|codex|hermes session-start|pre-write", file=sys.stderr)
+        return 2
+    runtime, event = sys.argv[1:]
+    try:
+        raw = sys.stdin.read().strip()
+        payload = json.loads(raw) if raw else {}
+        if not isinstance(payload, dict):
+            raise ContextOSError("hook input must be an object")
+        report = hook_report(ROOT, event, payload)
+        messages = [item["message"] for item in report["findings"]]
+        if runtime in {"claude", "codex"}:
+            if messages:
+                print(json.dumps({"systemMessage": "\n".join(messages)}))
+        else:
+            print(json.dumps({"action": "allow", "message": "\n".join(messages)}))
+        return 0
+    except (ContextOSError, json.JSONDecodeError) as exc:
+        # These hooks are advisory. Surface malformed input instead of silently
+        # passing, but do not create a second mutation-enforcement path.
+        message = f"Context OS advisory hook could not run: {exc}"
+        if runtime in {"claude", "codex"}:
+            print(json.dumps({"systemMessage": message}))
+        else:
+            print(json.dumps({"action": "allow", "message": message}))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -250,6 +250,16 @@ fi
 
 echo "    Optional add-ons: see references/integrations.md (nothing is installed automatically)"
 
+echo ""
+echo "  Checking the provider-neutral lifecycle kernel..."
+if python3 -m contextos doctor >/dev/null; then
+  echo "    Found: context-os kernel"
+else
+  echo "    Kernel doctor found a required repository problem." >&2
+  python3 -m contextos doctor >&2 || true
+  exit 1
+fi
+
 # ── 7. Initial commit ───────────────────────────────────────────────────────
 
 echo ""
@@ -309,6 +319,7 @@ fi
 
 case "$SELECTED_AGENT" in
   claude)
+    python3 -m contextos install --runtime claude >/dev/null
     echo "  Claude Code auto-memory is enabled by default and may write machine-local memory."
     echo "  Inspect it with /memory; to opt out, set autoMemoryEnabled: false in"
     echo "  .claude/settings.local.json. Setup does not change that host setting."
@@ -324,8 +335,9 @@ case "$SELECTED_AGENT" in
     fi
     ;;
   codex)
+    python3 -m contextos install --runtime codex >/dev/null
     printf '  1. cd %q && codex\n' "$REPO_ROOT"
-    echo '  2. Type: $context-setup'
+    echo '  2. Type: $setup'
     echo "     Codex will interview you and build your context files."
     echo "     See docs/getting-started.md for migration, integrations, and host limits."
     echo ""
@@ -335,11 +347,12 @@ case "$SELECTED_AGENT" in
     fi
     ;;
   hermes)
+    python3 -m contextos install --runtime hermes >/dev/null
     printf '  1. cd %q && hermes\n' "$REPO_ROOT"
-    echo "  2. Hermes reads AGENTS.md automatically; ask it to run the context-setup"
-    echo "     skill (install the .agents/skills/ lifecycle skills first if you have"
-    echo "     not: hermes skills install .agents/skills/context-setup and siblings)."
-    echo "     See AGENTS.md (Hermes Agent section) and docs/memory-across-agents.md."
+    echo "  2. Hermes reads AGENTS.md automatically. Expose .agents/skills/ as an"
+    echo "     external skill directory, then type /setup. If you copy skills instead,"
+    echo "     install the short aliases and context-* cores together."
+    echo "     See adapters/hermes/ and docs/memory-across-agents.md."
     echo ""
     if [ "$HERMES_FOUND" = true ] && prompt_yn "  Launch Hermes now?" "y"; then
       cd "$REPO_ROOT"
@@ -369,7 +382,7 @@ case "$SELECTED_AGENT" in
     ;;
   none)
     printf '  Claude Code: cd %q && claude, then run /setup\n' "$REPO_ROOT"
-    printf '  Codex:       cd %q && codex, then run $context-setup\n' "$REPO_ROOT"
+    printf '  Codex:       cd %q && codex, then run $setup\n' "$REPO_ROOT"
     printf '  Hermes:      cd %q && hermes (reads AGENTS.md; see AGENTS.md Hermes section)\n' "$REPO_ROOT"
     printf '  Cursor:      cd %q and open in Cursor (reads AGENTS.md)\n' "$REPO_ROOT"
     printf '  OpenClaw:    cd %q && openclaw (reads AGENTS.md + .agents/skills/)\n' "$REPO_ROOT"

--- a/scripts/validate-all.sh
+++ b/scripts/validate-all.sh
@@ -23,8 +23,16 @@ from pathlib import Path
 
 paths = [
     Path(".claude/settings.json"),
+    Path(".codex/hooks.json"),
     Path("docs/templates/workflow-parity.json"),
+    Path("docs/templates/setup-payload.json"),
+    Path("docs/templates/update-payload.json"),
+    Path("docs/templates/end-payload.json"),
     Path("integrations/catalog.json"),
+    Path("runtimes/schema.json"),
+    Path("runtimes/claude.json"),
+    Path("runtimes/codex.json"),
+    Path("runtimes/hermes.json"),
 ]
 for path in paths:
     with path.open(encoding="utf-8") as handle:

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -57,7 +57,7 @@ done < <(find . -path './.git' -prune -o -name 'SKILL.md' -print0)
 if [ -d ".claude/commands" ]; then
   while IFS= read -r -d '' cmd; do
     check_frontmatter "$cmd" 20
-    declared_name=$(grep '^name:' "$cmd" | head -1 | sed 's/^name:[[:space:]]*//' || true)
+    declared_name=$(grep '^name:' "$cmd" | head -1 | sed 's/^name:[[:space:]]*//' | tr -d '\r' || true)
     file_name=$(basename "$cmd" .md)
     if [ -n "$declared_name" ] && [ "$declared_name" != "$file_name" ]; then
       ERRORS+=("COMMAND NAME MISMATCH: $cmd declares '$declared_name'")

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -29,7 +29,7 @@ for index in "${!skills[@]}"; do
   test -f "$metadata_file" || fail "missing $metadata_file"
   test -f "$command_file" || fail "missing $command_file"
 
-  grep -qx "name: $skill" "$skill_file" || fail "$skill_file name does not match its directory"
+  tr -d '\r' < "$skill_file" | grep -qx "name: $skill" || fail "$skill_file name does not match its directory"
   python3 tests/validate-openai-metadata.py "$metadata_file" "$skill" || fail "$metadata_file failed schema validation"
   grep -Fq ".agents/skills/$skill/SKILL.md" "$command_file" || fail "$command_file does not route to $skill"
   python3 tests/validate-openai-metadata.py --command "$command_file" "$command" || fail "$command_file failed frontmatter validation"
@@ -50,7 +50,7 @@ for index in "${!aliases[@]}"; do
 
   test -f "$alias_file" || fail "missing $alias_file"
   test -f "$metadata_file" || fail "missing $metadata_file"
-  grep -qx "name: $alias_name" "$alias_file" || fail "$alias_file name does not match its directory"
+  tr -d '\r' < "$alias_file" | grep -qx "name: $alias_name" || fail "$alias_file name does not match its directory"
   grep -Fq "../$core_name/SKILL.md" "$alias_file" || fail "$alias_file does not route to $core_name"
   python3 tests/validate-openai-metadata.py "$metadata_file" "$alias_name" || fail "$metadata_file failed schema validation"
   [ "$(wc -l < "$alias_file")" -le 15 ] || fail "$alias_file is no longer a thin alias"
@@ -70,9 +70,9 @@ for command in "${side_effecting_commands[@]}"; do
     || fail ".claude/commands/$command.md failed strict side-effecting frontmatter validation"
 done
 
-grep -qx 'allowed-tools: "Read"' .claude/commands/clean-ai-writing.md \
+tr -d '\r' < .claude/commands/clean-ai-writing.md | grep -qx 'allowed-tools: "Read"' \
   || fail "clean-ai-writing must remain read-only when it is model-invocable"
-grep -qx 'allowed-tools: "Read, Glob, Grep"' .claude/commands/find-context.md \
+tr -d '\r' < .claude/commands/find-context.md | grep -qx 'allowed-tools: "Read, Glob, Grep"' \
   || fail "find-context must not pre-approve Bash when it is model-invocable"
 
 for skill in "${skills[@]}"; do
@@ -97,20 +97,20 @@ done < <(find .agents/skills projects/example-musician/workflow-examples -name S
 test ! -d projects/example-musician/skills || fail "example project still presents a nested skills directory as discoverable"
 
 [ "$(wc -l < AGENTS.md)" -le 100 ] || fail "AGENTS.md should stay under 100 lines"
-grep -Fq 'hooks and settings' docs/codex-onboarding.md || fail "Codex guide must disclose host-only hooks and settings"
-grep -Fq 'auto-memory' docs/codex-onboarding.md || fail "Codex guide must disclose the auto-memory boundary"
+grep -Fq 'repository hooks' docs/codex-onboarding.md || fail "Codex guide must describe repository hooks"
+grep -Fq 'Native memory' docs/codex-onboarding.md || fail "Codex guide must disclose the native-memory boundary"
 grep -Fq '/import' docs/codex-onboarding.md || fail "Codex guide must explain optional import"
 
-grep -Fq 'trusted repository-scoped' docs/codex-onboarding.md || fail "Codex guide must describe supported project configuration accurately"
+grep -Fq '`.codex` layer is trusted' docs/codex-onboarding.md || fail "Codex guide must describe project trust"
 
 setup_skill=.agents/skills/context-setup/SKILL.md
-storage_line=$(grep -n 'Confirm storage and audience before collecting context' "$setup_skill" | cut -d: -f1)
-source_line=$(grep -n 'Choose the starting point' "$setup_skill" | cut -d: -f1)
+storage_line=$(grep -n 'Confirm storage and audience' "$setup_skill" | cut -d: -f1)
+source_line=$(grep -n 'Choose and inspect the starting point' "$setup_skill" | cut -d: -f1)
 test -n "$storage_line" && test -n "$source_line" && test "$storage_line" -lt "$source_line" \
   || fail "portable setup does not confirm storage before reading or collecting context"
-grep -Fq 'does not erase them from git history' "$setup_skill" \
+grep -Fq 'does not erase git history' "$setup_skill" \
   || fail "portable setup omits git-history retention disclosure"
-grep -Fq 'explicitly confirm' "$setup_skill" \
+grep -Fq 'explicitly confirms the audience' "$setup_skill" \
   || fail "portable setup does not require audience confirmation"
 grep -Fq 'auto-memory is enabled by default' .claude/commands/setup.md \
   || fail "Claude setup adapter omits the host auto-memory default"
@@ -154,42 +154,49 @@ if python3 tests/validate-openai-metadata.py "$control_prompt" context-start >/d
   fail "escaped control character passed metadata validation"
 fi
 
+normalized_start="$portability_tmp/normalized-start.md"
+normalized_setup="$portability_tmp/normalized-setup.md"
+normalized_dream="$portability_tmp/normalized-dream.md"
+tr -d '\r' < .claude/commands/start.md > "$normalized_start"
+tr -d '\r' < .claude/commands/setup.md > "$normalized_setup"
+tr -d '\r' < .claude/commands/dream.md > "$normalized_dream"
+
 body_only_command="$portability_tmp/body-only-start.md"
-sed '/^disable-model-invocation: true$/d' .claude/commands/start.md > "$body_only_command"
+sed '/^disable-model-invocation: true$/d' "$normalized_start" > "$body_only_command"
 printf '\ndisable-model-invocation: true\n' >> "$body_only_command"
 if python3 tests/validate-openai-metadata.py --command "$body_only_command" start >/dev/null 2>&1; then
   fail "body-only invocation gate passed command validation"
 fi
 
 unrestricted_start="$portability_tmp/unrestricted-start.md"
-sed 's/^allowed-tools:.*/allowed-tools: [Read, Bash]/' .claude/commands/start.md > "$unrestricted_start"
+sed 's/^allowed-tools:.*/allowed-tools: [Read, Bash]/' "$normalized_start" > "$unrestricted_start"
 if python3 tests/validate-openai-metadata.py --command "$unrestricted_start" start >/dev/null 2>&1; then
   fail "unrestricted inline Bash grant passed command validation"
 fi
 
 wildcard_start="$portability_tmp/wildcard-start.md"
-sed 's/^allowed-tools:.*/allowed-tools: "Read, Glob, Bash(gws drive files list:*)"/' .claude/commands/start.md > "$wildcard_start"
+sed 's/^allowed-tools:.*/allowed-tools: "Read, Glob, Bash(gws drive files list:*)"/' "$normalized_start" > "$wildcard_start"
 if python3 tests/validate-openai-metadata.py --command "$wildcard_start" start >/dev/null 2>&1; then
   fail "gws trailing-wildcard pre-approval passed command validation"
 fi
 
 for bad_scalar in false null 123; do
   typed_command="$portability_tmp/non-string-description-$bad_scalar.md"
-  sed "s/^description:.*/description: $bad_scalar/" .claude/commands/setup.md > "$typed_command"
+  sed "s/^description:.*/description: $bad_scalar/" "$normalized_setup" > "$typed_command"
   if python3 tests/validate-openai-metadata.py --command "$typed_command" setup >/dev/null 2>&1; then
     fail "$bad_scalar command description passed scalar-type validation"
   fi
 done
 
 boolean_tools="$portability_tmp/boolean-tools-start.md"
-sed 's/^allowed-tools:.*/allowed-tools: false/' .claude/commands/start.md > "$boolean_tools"
+sed 's/^allowed-tools:.*/allowed-tools: false/' "$normalized_start" > "$boolean_tools"
 if python3 tests/validate-openai-metadata.py --command "$boolean_tools" start >/dev/null 2>&1; then
   fail "boolean allowed-tools passed scalar-type validation"
 fi
 
 duplicate_gate="$portability_tmp/duplicate-gate-dream.md"
 sed '/^disable-model-invocation: true$/a disable-model-invocation: false' \
-  .claude/commands/dream.md > "$duplicate_gate"
+  "$normalized_dream" > "$duplicate_gate"
 if python3 tests/validate-openai-metadata.py --command "$duplicate_gate" dream >/dev/null 2>&1; then
   fail "duplicate false invocation gate passed command validation"
 fi
@@ -207,7 +214,7 @@ make_setup_fixture() {
   git -C "$destination" init -q
   git -C "$destination" config user.name "Portability Test"
   git -C "$destination" config user.email "portability@example.invalid"
-  git -C "$destination" add -A
+  git -C "$destination" -c core.autocrlf=false add -A
   git -C "$destination" commit -qm baseline
   git -C "$destination" remote add origin https://example.invalid/context.git
 }
@@ -263,7 +270,7 @@ git -C "$no_remote_fixture" diff --quiet || fail "no-remote default-no path wrot
 
 memory_notice_fixture="$portability_tmp/claude-memory-notice"
 make_setup_fixture "$memory_notice_fixture"
-memory_notice_output=$(printf 'y\n\nn\nn\nn\n' | (cd "$memory_notice_fixture" && PATH="$(dirname "$(command -v python3)"):/usr/bin:/bin" bash scripts/setup.sh --agent claude))
+memory_notice_output=$(printf 'y\n\nn\nn\nn\n' | (cd "$memory_notice_fixture" && PATH="$(dirname "$(command -v python3)"):$(dirname "$(command -v git)"):/usr/bin:/bin" bash scripts/setup.sh --agent claude))
 grep -Fq 'auto-memory is enabled by default' <<<"$memory_notice_output" || fail "local Claude onboarding omitted auto-memory default"
 grep -Fq 'Inspect it with /memory' <<<"$memory_notice_output" || fail "local Claude onboarding omitted /memory inspection"
 grep -Fq 'autoMemoryEnabled: false' <<<"$memory_notice_output" || fail "local Claude onboarding omitted opt-out setting"
@@ -277,10 +284,17 @@ warning_line=$(grep -n 'This workspace can contain identity' scripts/setup.sh | 
 name_line=$(grep -n 'Name to place in CLAUDE.md' scripts/setup.sh | cut -d: -f1)
 test -n "$warning_line" && test -n "$name_line" && test "$warning_line" -lt "$name_line" || fail "privacy warning did not precede personalization"
 
-for skill in context-update context-end; do
-  grep -Fq 'current-log.md' ".agents/skills/$skill/SKILL.md" || fail "$skill lacks current.md history handling"
-  grep -Fq '**Last Updated:**' ".agents/skills/$skill/SKILL.md" || fail "$skill lacks current.md timestamp handling"
-  grep -Fq 'old_date != today && old_date != newest_history_date' ".agents/skills/$skill/SKILL.md" || fail "$skill lacks the same-day history invariant"
+for skill in context-setup context-update context-end; do
+  grep -Fq 'python3 -m contextos propose' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route mutation through the kernel"
+  grep -Fq 'python3 -m contextos apply' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route approval through the kernel"
 done
+
+test -f .codex/hooks.json || fail "missing Codex hook adapter"
+test -f adapters/hermes/hooks.example.yaml || fail "missing Hermes hook adapter"
+test -f contextos/__main__.py || fail "missing deterministic lifecycle kernel"
+python3 -m unittest discover -s tests -p 'test_contextos_kernel.py' >/dev/null \
+  || fail "kernel conformance failed"
+python3 -m unittest discover -s tests -p 'test_runtime_manifests.py' >/dev/null \
+  || fail "kernel or runtime manifest conformance failed"
 
 echo "Portability checks passed"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+from datetime import datetime
+from pathlib import Path
+
+from contextos.kernel import (
+    ContextOSError,
+    apply_proposal,
+    create_proposal,
+    doctor,
+    hook_report,
+    install_runtime,
+    read_json,
+    canonical_json,
+    sha256_text,
+    start_report,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOW = datetime.fromisoformat("2026-08-23T14:30:00-07:00")
+
+
+class KernelTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "state").mkdir()
+        (self.root / "sessions").mkdir()
+        (self.root / "runtimes").mkdir()
+        (self.root / "AGENTS.md").write_text("# Test workspace\n", encoding="utf-8")
+        (self.root / "TODO.md").write_text("# Tasks\n", encoding="utf-8")
+        (self.root / "state" / "current.md").write_text(
+            "# Current State\n\n**Last Updated:** 2026-08-20\n\n## Active priorities\n\n- Old\n",
+            encoding="utf-8",
+        )
+        (self.root / "state" / "current-log.md").write_text(
+            "# current.md update log\n\nPrevious dates follow.\n\n2026-08-18\n",
+            encoding="utf-8",
+        )
+        (self.root / "state" / "decisions.md").write_text(
+            "# Decisions Log\n\n| Date | Decision | Context / rationale | Rejected alternatives |\n"
+            "|---|---|---|---|\n",
+            encoding="utf-8",
+        )
+        for name in ("blockers.md", "weekly-priorities.md"):
+            (self.root / "state" / name).write_text(
+                f"# {name}\n\n**Last Updated:** 2026-08-20\n", encoding="utf-8"
+            )
+        for runtime in ("claude", "codex", "hermes"):
+            source = ROOT / "runtimes" / f"{runtime}.json"
+            (self.root / "runtimes" / f"{runtime}.json").write_bytes(source.read_bytes())
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _input(self, value: dict) -> Path:
+        path = self.root / "input.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return path
+
+    def _propose(self, workflow: str, payload: dict):
+        return create_proposal(self.root, workflow, payload, NOW)
+
+    def _apply(self, path: Path, document: dict, runtime: str = "codex"):
+        return apply_proposal(self.root, path, document["proposal_digest"], runtime)
+
+    def test_update_propose_apply_writes_receipt_and_history_once(self) -> None:
+        current = (
+            "# Current State\n\n**Last Updated:** 2026-08-20\n\n"
+            "## Active priorities\n\n- New\n"
+        )
+        proposal_path, proposal = self._propose(
+            "update", {"progress": ["Built the kernel"], "current_markdown": current}
+        )
+        self.assertTrue(proposal["proposal_id"].startswith("20260823T143000-update-"))
+        self.assertFalse((self.root / "sessions" / "2026-08-23.md").exists())
+        receipt_path, receipt = self._apply(proposal_path, proposal)
+        self.assertTrue(receipt_path.exists())
+        self.assertEqual("codex", receipt["runtime"])
+        self.assertIn("**Last Updated:** 2026-08-23", (self.root / "state/current.md").read_text())
+        history = (self.root / "state/current-log.md").read_text()
+        self.assertEqual(1, sum(line == "2026-08-20" for line in history.splitlines()))
+        self.assertIn("## Update: 14:30", (self.root / "sessions/2026-08-23.md").read_text())
+
+        second_path, second = create_proposal(
+            self.root,
+            "update",
+            {"progress": ["Ran tests"], "current_markdown": (self.root / "state/current.md").read_text()},
+            datetime.fromisoformat("2026-08-23T16:00:00-07:00"),
+        )
+        self._apply(second_path, second)
+        history = (self.root / "state/current-log.md").read_text()
+        self.assertEqual(1, sum(line == "2026-08-20" for line in history.splitlines()))
+        session = (self.root / "sessions/2026-08-23.md").read_text()
+        self.assertIn("## Update: 14:30", session)
+        self.assertIn("## Update: 16:00", session)
+
+    def test_end_appends_session_and_decision(self) -> None:
+        existing = self.root / "sessions/2026-08-23.md"
+        existing.write_text("# Session — 2026-08-23\n\n## Update: 10:00\n- Began\n", encoding="utf-8")
+        proposal_path, proposal = self._propose(
+            "end",
+            {
+                "what_happened": ["Finished deterministic apply"],
+                "decisions": [{
+                    "decision": "Use proposal | apply",
+                    "rationale": "Exact review",
+                    "rejected_alternatives": "Direct writes",
+                }],
+                "next_time": ["Add runtime smoke tests"],
+            },
+        )
+        self._apply(proposal_path, proposal, "hermes")
+        session = existing.read_text(encoding="utf-8")
+        self.assertIn("## Session 14:30", session)
+        self.assertIn("Finished deterministic apply", session)
+        decisions = (self.root / "state/decisions.md").read_text(encoding="utf-8")
+        self.assertIn("Use proposal \\| apply", decisions)
+
+    def test_exact_confirmation_and_optimistic_hashes_fail_closed(self) -> None:
+        proposal_path, proposal = self._propose("update", {"progress": ["One"]})
+        with self.assertRaisesRegex(ContextOSError, "exactly match"):
+            apply_proposal(self.root, proposal_path, "wrong", "claude")
+        (self.root / "sessions/2026-08-23.md").write_text("parallel writer\n", encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "stale proposal"):
+            self._apply(proposal_path, proposal, "claude")
+
+    def test_apply_lock_fails_closed_and_survives_no_write(self) -> None:
+        proposal_path, proposal = self._propose("update", {"progress": ["One"]})
+        lock = self.root / ".context-os/apply.lock"
+        lock.write_text("pid=other\n", encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "stale lock"):
+            self._apply(proposal_path, proposal)
+        self.assertFalse((self.root / "sessions/2026-08-23.md").exists())
+
+    def test_partial_apply_failure_rolls_back_prior_paths(self) -> None:
+        current_before = (self.root / "state/current.md").read_bytes()
+        history_before = (self.root / "state/current-log.md").read_bytes()
+        proposal_path, proposal = self._propose(
+            "update",
+            {
+                "progress": ["One"],
+                "current_markdown": "# Current State\n\n**Last Updated:** 2026-08-20\n\n- Changed\n",
+            },
+        )
+        real_replace = os.replace
+        calls = 0
+
+        def fail_second(source, target):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("injected replacement failure")
+            return real_replace(source, target)
+
+        with mock.patch("contextos.kernel.os.replace", side_effect=fail_second):
+            with self.assertRaisesRegex(ContextOSError, "rolled back"):
+                self._apply(proposal_path, proposal)
+        self.assertEqual(current_before, (self.root / "state/current.md").read_bytes())
+        self.assertEqual(history_before, (self.root / "state/current-log.md").read_bytes())
+        self.assertFalse((self.root / "sessions/2026-08-23.md").exists())
+        self.assertFalse(any((self.root / ".context-os/receipts").glob("*.json")))
+
+    def test_tampered_proposal_is_rejected(self) -> None:
+        proposal_path, proposal = self._propose("update", {"progress": ["One"]})
+        tampered = read_json(proposal_path)
+        tampered["changes"][0]["after_text"] += "tampered\n"
+        proposal_path.write_text(json.dumps(tampered), encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "digest"):
+            self._apply(proposal_path, proposal)
+
+    def test_setup_requires_explicit_populated_replacement(self) -> None:
+        (self.root / "identity").mkdir()
+        target = self.root / "identity/who-i-am.md"
+        target.write_text("# Ada\n\nReal biography.\n", encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "replace_populated"):
+            self._propose("setup", {"files": {"identity/who-i-am.md": "# Changed"}})
+        path, proposal = self._propose(
+            "setup",
+            {
+                "files": {"identity/who-i-am.md": "# Changed {{TODAY}}"},
+                "replace_populated": ["identity/who-i-am.md"],
+            },
+        )
+        self._apply(path, proposal)
+        self.assertEqual("# Changed 2026-08-23\n", target.read_text(encoding="utf-8"))
+
+    def test_setup_rejects_path_escape_and_unapproved_root(self) -> None:
+        with self.assertRaisesRegex(ContextOSError, "escapes"):
+            self._propose("setup", {"files": {"../outside.md": "no"}})
+        with self.assertRaisesRegex(ContextOSError, "approved context paths"):
+            self._propose("setup", {"files": {"scripts/unsafe.py": "no"}})
+
+    def test_apply_revalidates_workflow_paths_for_handcrafted_proposal(self) -> None:
+        proposal_path, proposal = self._propose("update", {"progress": ["One"]})
+        proposal["changes"][0]["path"] = ".git/hooks/pre-commit"
+        unsigned = dict(proposal)
+        unsigned.pop("proposal_digest")
+        proposal["proposal_digest"] = sha256_text(canonical_json(unsigned))
+        proposal_path.write_text(json.dumps(proposal), encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "reserved"):
+            self._apply(proposal_path, proposal)
+
+    def test_apply_rejects_setup_replacement_bypass(self) -> None:
+        (self.root / "identity").mkdir()
+        target = self.root / "identity/who-i-am.md"
+        proposal_path, proposal = self._propose(
+            "setup", {"files": {"identity/who-i-am.md": "# Initial"}}
+        )
+        target.write_text("# Existing\n\nReal [Your Name] biography.\n", encoding="utf-8")
+        proposal["changes"][0]["before_sha256"] = sha256_text(target.read_text(encoding="utf-8"))
+        unsigned = dict(proposal)
+        unsigned.pop("proposal_digest")
+        proposal["proposal_digest"] = sha256_text(canonical_json(unsigned))
+        proposal_path.write_text(json.dumps(proposal), encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "replacement approval"):
+            self._apply(proposal_path, proposal)
+
+    def test_end_missing_decision_log_is_clean_error(self) -> None:
+        (self.root / "state/decisions.md").unlink()
+        with self.assertRaisesRegex(ContextOSError, "decision log does not exist"):
+            self._propose(
+                "end",
+                {"what_happened": ["One"], "decisions": [{"decision": "Keep it deterministic"}]},
+            )
+
+    def test_start_is_read_only_and_reports_staleness(self) -> None:
+        before = {path: path.read_bytes() for path in self.root.rglob("*") if path.is_file()}
+        report = start_report(self.root, NOW)
+        after = {path: path.read_bytes() for path in self.root.rglob("*") if path.is_file()}
+        self.assertEqual(before, after)
+        self.assertFalse(report["state"]["state/current.md"]["stale"])
+        self.assertEqual(3, report["state"]["state/current.md"]["age_days"])
+
+    def test_install_and_doctor_are_machine_local(self) -> None:
+        target, installed = install_runtime(self.root, "hermes")
+        self.assertEqual(self.root / ".context-os/runtime.json", target)
+        self.assertEqual("hermes", installed["runtime"])
+        report = doctor(self.root, "hermes")
+        self.assertIn(report["status"], {"pass", "warn"})
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
+        manifest = json.loads((self.root / "runtimes/hermes.json").read_text())
+        manifest["capabilities"]["mcp"] = "advisory"
+        (self.root / "runtimes/hermes.json").write_text(json.dumps(manifest), encoding="utf-8")
+        drift = doctor(self.root, "hermes")
+        drift_check = next(item for item in drift["checks"] if item["name"] == "runtime-manifest-drift")
+        self.assertEqual("warn", drift_check["status"])
+
+    def test_doctor_uses_configured_state_and_selected_manifest_only(self) -> None:
+        custom = self.root / "custom-state"
+        (self.root / "state").rename(custom)
+        (self.root / "workspace.yaml").write_text("state_dir: custom-state\n", encoding="utf-8")
+        (self.root / "runtimes/codex.json").unlink()
+        report = doctor(self.root, "hermes")
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
+        self.assertTrue(any(item["name"] == "file:custom-state/current.md" for item in report["checks"]))
+
+    def test_runtime_manifest_is_required_for_receipt_claim(self) -> None:
+        proposal_path, proposal = self._propose("update", {"progress": ["One"]})
+        os.remove(self.root / "runtimes/codex.json")
+        with self.assertRaisesRegex(ContextOSError, "missing runtime manifest"):
+            self._apply(proposal_path, proposal)
+
+    def test_hook_must_fire_and_must_not_fire_controls(self) -> None:
+        must_fire = hook_report(
+            self.root, "pre-write", {"tool_input": {"file_path": str(self.root / "state/current.md")}}
+        )
+        self.assertEqual(1, len(must_fire["findings"]))
+        must_not_fire = hook_report(
+            self.root, "pre-write", {"tool_input": {"file_path": str(self.root / "README.md")}}
+        )
+        self.assertEqual([], must_not_fire["findings"])
+
+    def test_hook_handles_relative_paths_and_codex_patch_commands(self) -> None:
+        relative = hook_report(self.root, "pre-write", {"args": {"path": "state/blockers.md"}})
+        self.assertEqual(1, len(relative["findings"]))
+        patch = "*** Begin Patch\n*** Update File: state/current-log.md\n@@\n-old\n+new\n*** End Patch"
+        codex = hook_report(self.root, "pre-write", {"tool_input": {"command": patch}})
+        self.assertEqual(1, len(codex["findings"]))
+
+    def test_session_hook_surfaces_placeholder_but_not_initialized_state(self) -> None:
+        (self.root / "state/current.md").write_text(
+            "# Current\n\n**Last Updated:** [DATE]\n", encoding="utf-8"
+        )
+        self.assertTrue(hook_report(self.root, "session-start", {})["findings"])
+        (self.root / "state/current.md").write_text(
+            "# Current\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
+        )
+        self.assertEqual([], hook_report(self.root, "session-start", {})["findings"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts/context-os-hook.py"
+
+
+class CrossRuntimeHookTest(unittest.TestCase):
+    def run_hook(self, runtime: str, event: str, payload: dict) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(WRAPPER), runtime, event],
+            cwd=ROOT,
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_codex_adapter_declares_session_and_pre_write_events(self) -> None:
+        config = json.loads((ROOT / ".codex/hooks.json").read_text(encoding="utf-8"))
+        self.assertEqual({"SessionStart", "PreToolUse"}, set(config["hooks"]))
+        serialized = json.dumps(config)
+        self.assertIn("context-os-hook.py", serialized)
+        self.assertIn("commandWindows", serialized)
+        self.assertIn("powershell.exe", serialized)
+        pre_tool = config["hooks"]["PreToolUse"][0]
+        self.assertEqual("^apply_patch$", pre_tool["matcher"])
+
+    def test_codex_pre_write_must_fire_control(self) -> None:
+        result = self.run_hook(
+            "codex", "pre-write", {"tool_input": {"file_path": str(ROOT / "state/current.md")}}
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("proposal/apply", json.loads(result.stdout)["systemMessage"])
+
+    def test_codex_pre_write_must_not_fire_control(self) -> None:
+        result = self.run_hook(
+            "codex", "pre-write", {"tool_input": {"file_path": str(ROOT / "README.md")}}
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_codex_real_apply_patch_payload_and_relative_path_fire(self) -> None:
+        patch = "*** Begin Patch\n*** Update File: state/current.md\n@@\n-old\n+new\n*** End Patch"
+        result = self.run_hook("codex", "pre-write", {"tool_input": {"command": patch}})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("proposal/apply", json.loads(result.stdout)["systemMessage"])
+
+    def test_hermes_adapter_allows_with_advisory(self) -> None:
+        result = self.run_hook(
+            "hermes", "pre-write", {"args": {"path": str(ROOT / "state/decisions.md")}}
+        )
+        output = json.loads(result.stdout)
+        self.assertEqual("allow", output["action"])
+        self.assertIn("append-only", output["message"])
+
+    def test_malformed_input_is_visible_and_advisory(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(WRAPPER), "codex", "pre-write"],
+            cwd=ROOT,
+            input="not-json",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertIn("could not run", json.loads(result.stdout)["systemMessage"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_launch.py
+++ b/tests/test_runtime_launch.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RuntimeLaunchTest(unittest.TestCase):
+    """Opt-in, read-only smoke tests against installed runtime processes."""
+
+    def run_runtime(self, runtime: str) -> str:
+        if os.environ.get("CONTEXT_OS_RUNTIME_TESTS") != "1":
+            self.skipTest("set CONTEXT_OS_RUNTIME_TESTS=1 to launch authenticated runtimes")
+        binary = shutil.which(runtime)
+        if not binary:
+            self.skipTest(f"{runtime} is not installed")
+        prompt = (
+            f"Read AGENTS.md and runtimes/{runtime}.json in this public fixture. "
+            f"Do not write files or use external data. If the {runtime} manifest declares "
+            "setup, start, update, and end invocations and AGENTS.md requires proposal/apply, "
+            f"reply with exactly CONTEXT_OS_RUNTIME={runtime}. Otherwise explain the mismatch."
+        )
+        if runtime == "claude":
+            command = [
+                binary, "-p", prompt, "--allowedTools", "Read,Glob,Grep",
+                "--permission-mode", "plan", "--no-session-persistence", "--max-budget-usd", "0.50",
+            ]
+        elif runtime == "codex":
+            command = [binary, "exec", "--sandbox", "read-only", prompt]
+        else:
+            command = [
+                binary, "chat", "-q", prompt, "-Q", "--ignore-user-config",
+                "--max-turns", "20", "--run-budget", "120", "--source", "tool",
+            ]
+        completed = subprocess.run(
+            command, cwd=ROOT, text=True, capture_output=True, timeout=180, check=False
+        )
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        return completed.stdout
+
+    def test_claude_discovers_contract(self) -> None:
+        self.assertIn("CONTEXT_OS_RUNTIME=claude", self.run_runtime("claude"))
+
+    def test_codex_discovers_contract(self) -> None:
+        self.assertIn("CONTEXT_OS_RUNTIME=codex", self.run_runtime("codex"))
+
+    def test_hermes_discovers_contract(self) -> None:
+        self.assertIn("CONTEXT_OS_RUNTIME=hermes", self.run_runtime("hermes"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from contextos.kernel import ContextOSError, runtime_manifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RuntimeManifestTest(unittest.TestCase):
+    def test_manifests_have_complete_lifecycle_and_capabilities(self) -> None:
+        required_capabilities = {
+            "agent_skills", "explicit_invocation", "project_hooks",
+            "blocking_pre_tool_hook", "mcp", "native_memory", "proposal_apply",
+        }
+        for runtime in ("claude", "codex", "hermes"):
+            with self.subTest(runtime=runtime):
+                manifest = json.loads((ROOT / "runtimes" / f"{runtime}.json").read_text(encoding="utf-8"))
+                self.assertEqual(1, manifest["schema_version"])
+                self.assertEqual(runtime, manifest["runtime"])
+                self.assertEqual({"setup", "start", "update", "end"}, set(manifest["invocation"]))
+                self.assertEqual(required_capabilities, set(manifest["capabilities"]))
+                self.assertTrue(manifest["install"]["next_steps"])
+
+    def test_short_aliases_match_runtime_invocations(self) -> None:
+        claude = json.loads((ROOT / "runtimes/claude.json").read_text())
+        codex = json.loads((ROOT / "runtimes/codex.json").read_text())
+        hermes = json.loads((ROOT / "runtimes/hermes.json").read_text())
+        for name in ("setup", "start", "update", "end"):
+            self.assertEqual(f"/{name}", claude["invocation"][name])
+            self.assertEqual(f"${name}", codex["invocation"][name])
+            self.assertEqual(f"/{name}", hermes["invocation"][name])
+
+    def test_kernel_rejects_schema_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "runtimes").mkdir()
+            manifest = json.loads((ROOT / "runtimes/codex.json").read_text(encoding="utf-8"))
+            manifest["capabilities"]["mcp"] = "invented"
+            (root / "runtimes/codex.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ContextOSError, "invalid runtime manifest"):
+                runtime_manifest(root, "codex")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a deterministic proposal/apply kernel for setup, update, and end workflows
- add capability manifests and adapters for Claude Code, Codex, and Hermes
- make lifecycle confirmation, path enforcement, locking, rollback, receipts, and privacy boundaries provider-neutral
- add portable aliases, onboarding documentation, hook controls, and conformance tests

## Verification

- ash scripts/validate-all.sh
- 168 tests passed; 11 intentional runtime/auth skips
- portability, hooks, local links, integration catalog, and JSON checks passed
- Claude final blocker review: no blocking findings
- Hermes adversarial review findings were addressed; its final rerun was unavailable because the configured provider had exhausted credits

## Security and privacy

- proposal digests provide integrity, while the host permission prompt remains the human confirmation boundary
- apply independently revalidates workflow-specific paths and populated-file replacement policy
- proposals and receipts remain Gitignored and may contain sensitive local state
- native runtime memory is not copied into repository state