### PR TITLE
Make fresh-clone readiness truthful

### DIFF
--- a/.agents/skills/context-end/SKILL.md
+++ b/.agents/skills/context-end/SKILL.md
@@ -28,7 +28,7 @@ Create a reviewed JSON payload under `.context-os/inputs/` with:
   `blockers_markdown`, or `weekly_priorities_markdown`, only when that state
   materially changed.
 
-Run `python3 -m contextos propose end --input <payload.json>`. The kernel owns
+Run `bash scripts/contextos.sh propose end --input <payload.json>`. The kernel owns
 session append behavior, decision rows, dates, exact paths, the single
 `Last Updated` line, and same-day history. Present every returned diff and its
 proposal digest. The digest binds the exact content but does not authenticate a
@@ -39,7 +39,7 @@ human approver; rely on the host permission boundary for explicit confirmation.
 After explicit approval of that exact diff, run:
 
 ```text
-python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-runtime>
 ```
 
 The kernel must refuse altered proposals, changed targets, path escapes, or a

--- a/.agents/skills/context-setup/SKILL.md
+++ b/.agents/skills/context-setup/SKILL.md
@@ -50,13 +50,13 @@ mapping repository-relative paths to complete desired content. Add a path to
 `replace_populated` only after explicit approval to replace that populated file.
 Use `{{TODAY}}` where the deterministic local date belongs.
 
-Run `python3 -m contextos propose setup --input <payload.json>`. Present every
+Run `bash scripts/contextos.sh propose setup --input <payload.json>`. Present every
 returned diff and its proposal digest. The digest binds the exact content but
 does not authenticate a human approver; rely on the host permission boundary.
 After explicit approval of that exact proposal, run:
 
 ```text
-python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-runtime>
 ```
 
 The kernel must refuse path escapes, writes outside context paths, unapproved

--- a/.agents/skills/context-start/SKILL.md
+++ b/.agents/skills/context-start/SKILL.md
@@ -9,10 +9,10 @@ Resume from durable repository state instead of reconstructing context from chat
 
 ## Procedure
 
-1. Run `python3 -m contextos start` from the repository root. Treat its JSON as
+1. Run `bash scripts/contextos.sh start` from the repository root. Treat its JSON as
    the deterministic inventory of configured paths, freshness, latest session,
    and repository revision. If the kernel is unavailable, stop and recommend
-   `python3 -m contextos doctor`; do not silently substitute another lifecycle
+   `bash scripts/contextos.sh doctor`; do not silently substitute another lifecycle
    implementation.
 2. Determine today's local date and day of week. Read `ROUTING.md`, then load:
    - the configured `current.md`;

--- a/.agents/skills/context-update/SKILL.md
+++ b/.agents/skills/context-update/SKILL.md
@@ -19,7 +19,7 @@ Save continuity with minimal churn through the deterministic lifecycle kernel.
 3. Run:
 
    ```text
-   python3 -m contextos propose update --input <payload.json>
+   bash scripts/contextos.sh propose update --input <payload.json>
    ```
 
    The kernel owns session append behavior, dates, the single `Last Updated`
@@ -29,7 +29,7 @@ Save continuity with minimal churn through the deterministic lifecycle kernel.
 4. Wait for explicit approval of that exact proposal. Then run:
 
    ```text
-   python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+   bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-runtime>
    ```
 
    If any target changed after proposal creation, create and review a new

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -8,7 +8,7 @@ The PreToolUse hooks require Python 3 to parse Claude's JSON input. Setup checks
 
 | Hook | Event | Purpose | Blocks? |
 |------|-------|---------|---------|
-| `session-start.sh` | `SessionStart` | Surfaces stale state files, inbox items, overdue TODOs | no |
+| `session-start.sh` | `SessionStart` | Reports shared kernel readiness, then nudges toward `/start` | no |
 | `branch-hygiene.sh` | `SessionStart` | Surfaces non-default HEAD on guarded repos (catches silent branch-switches by parallel sessions) | no |
 | `ssot-guard.sh` | `PreToolUse` (Edit/Write) | Warns when editing SSOT files to prevent fact duplication | no |
 | `worktree-guard.sh` | `PreToolUse` (Edit/Write) | Blocks edits to a guarded repo's primary checkout when >1 Claude session is running | **yes** |
@@ -70,7 +70,7 @@ Hooks are enabled for the project by the checked-in `.claude/settings.json`. Per
 
 ## Customizing
 
-- Edit the stale-days threshold in `session-start.sh` (default: 3 days)
+- Adjust lifecycle freshness thresholds in `contextos/kernel.py`
 - Add your own SSOT patterns in `ssot-guard.sh`
 - Add/remove repos in `guarded-repos.txt` (no script edits needed)
 - Create new hooks for other events (`PreToolUse`, `PostToolUse`, etc.)

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -2,7 +2,7 @@
 
 These scripts run automatically during Claude Code sessions. Most are **advisory** — they print warnings but never block. `worktree-guard.sh` is the exception: it blocks edits to a guarded repo's primary checkout when more than one Claude session is running.
 
-The PreToolUse hooks require Python 3 to parse Claude's JSON input. Setup checks for it. The advisory hook emits a visible dependency warning if it is missing; a configured blocking guard fails closed rather than silently allowing an unsafe edit.
+The lifecycle SessionStart adapter and PreToolUse hooks require Python 3. Setup checks for it. Advisory hooks emit a visible dependency warning if it is missing; a configured blocking guard fails closed rather than silently allowing an unsafe edit.
 
 ## Files
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -12,7 +12,7 @@ if [ ! -f "$HOOK_WRAPPER" ]; then
 fi
 
 set +e
-HOOK_OUTPUT=$(bash "$HOOK_WRAPPER" claude session-start 2>&1)
+HOOK_OUTPUT=$(bash "$HOOK_WRAPPER" claude session-start </dev/null 2>&1)
 HOOK_STATUS=$?
 set -e
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
 # session-start.sh — Advisory hook for session start.
-# Detects first-run (unconfigured identity) and nudges toward /setup.
+# Uses the lifecycle kernel's shared readiness predicate and nudges toward /start.
 # This hook is ADVISORY — it prints reminders but never blocks (always exits 0).
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+HOOK_WRAPPER="$REPO_ROOT/scripts/context-os-hook.sh"
 
-# Check if identity files still have placeholder content
-if grep -q "\[Your Name\]" "$REPO_ROOT/CLAUDE.md" 2>/dev/null; then
-  echo ""
-  echo "  Looks like you haven't set up yet. Run /setup to get started."
-  echo ""
-else
+if [ ! -f "$HOOK_WRAPPER" ]; then
+  echo "  Context OS readiness check is unavailable; scripts/context-os-hook.sh is missing."
+  exit 0
+fi
+
+set +e
+HOOK_OUTPUT=$(bash "$HOOK_WRAPPER" claude session-start 2>&1)
+HOOK_STATUS=$?
+set -e
+
+if [ -n "$HOOK_OUTPUT" ]; then
+  printf '%s\n' "$HOOK_OUTPUT"
+fi
+
+if [ "$HOOK_STATUS" -eq 0 ] && [ -z "$HOOK_OUTPUT" ]; then
   echo ""
   echo "  Tip: Run /start for a full session briefing."
   echo ""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,8 +7,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" codex session-start",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex session-start\"",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" codex session-start",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"$root = git rev-parse --show-toplevel; & (Join-Path $root 'scripts/context-os-hook.ps1') codex session-start\"",
             "timeout": 10
           }
         ]
@@ -20,8 +20,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" codex pre-write",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex pre-write\"",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" codex pre-write",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"$root = git rev-parse --show-toplevel; & (Join-Path $root 'scripts/context-os-hook.ps1') codex pre-write\"",
             "timeout": 10
           }
         ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,12 @@ remain supported.
 
 ## Lifecycle kernel
 
-- `python3 -m contextos start` is the read-only continuity inventory.
+- `bash scripts/contextos.sh start` is the read-only continuity inventory.
 - Setup, update, and end use `propose` then exact-digest `apply`; never edit
   lifecycle state directly.
 - Present every proposal diff. Apply only after explicit approval of that exact
   proposal and report its receipt.
-- Run `python3 -m contextos doctor` when discovery, runtime setup, a lock, or
+- Run `bash scripts/contextos.sh doctor` when discovery, runtime setup, a lock, or
   copied skills may be stale.
 
 ## Context routing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,16 @@
 - `state/current-log.md`, the seed file required by the shared checkpoint and close workflows.
 - A validated, opt-in integrations catalog with generated documentation, explicit credential/data/side-effect boundaries, and no automatic installation or activation. Initial links cover Agent Skills, Agent Workspace, AI Tools for Creators, and Substack MCP.
 - Reviewed optional entries for Tolaria MCP, the official Obsidian CLI, Beads for Gemini CLI, and Granola's hosted MCP, with conservative sensitive-read, remote-write, overwrite, deletion, arbitrary-execution, publish, destructive, OAuth, retention, residency, and transcript gates.
+- `scripts/contextos.sh` and `scripts/context-os-hook.sh`, thin wrappers that run the lifecycle kernel and hook entry point through `scripts/python-env.sh`. The Codex and Hermes hook adapters and the four lifecycle skills now use them instead of hardcoding `python3`.
+- `CONTEXTOS_PYTHON` for pinning an explicit interpreter, documented in the getting-started prerequisites.
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- Workspace readiness now has one definition. `start`, `doctor`, and the session-start hook share a single predicate keyed on `state/current.md`; previously the hook and `start` could report opposite verdicts for the same workspace. `weekly-priorities.md` and `blockers.md` freshness is still reported, under a separate `state-freshness` check, but no longer gates readiness — leaving them empty is a valid steady state, not an unfinished setup.
+- Future-dated `state/current.md` timestamps no longer satisfy the shared readiness predicate, and the native Windows Codex hooks now honor the same `CONTEXTOS_PYTHON` override and Python 3.9 floor as POSIX hooks.
+- `setup` now stamps `**Last Updated:**` on the state files that `start` and `doctor` read, so a completed setup reports as initialized without depending on the agent to hand-write the line.
+- `start`'s `next_action` names the command to run instead of referring to "the explicit setup workflow" abstractly.
+- `CONTEXTOS_PYTHON` is honored exactly: an override that does not resolve to a working interpreter now fails loudly instead of silently falling back to a different one. The interpreter floor is Python 3.9, matching the kernel's use of `str.removeprefix`, instead of any Python 3.
 - `scripts/setup.sh` no longer relies on GNU-only `sed -i`; literal-name replacement and sample-route cleanup now use the documented Python 3 dependency.
 - Replaced the deprecated Notion npm-server instructions with Notion's hosted OAuth MCP path for Claude Code and Codex.
 - Aligned manual claude.ai setup prompts with portable skill paths and approval-gated local setup instead of claiming slash-command or commit parity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixed
 - Workspace readiness now has one definition. `start`, `doctor`, and the session-start hook share a single predicate keyed on `state/current.md`; previously the hook and `start` could report opposite verdicts for the same workspace. `weekly-priorities.md` and `blockers.md` freshness is still reported, under a separate `state-freshness` check, but no longer gates readiness — leaving them empty is a valid steady state, not an unfinished setup.
 - Future-dated `state/current.md` timestamps no longer satisfy the shared readiness predicate, and the native Windows Codex hooks now honor the same `CONTEXTOS_PYTHON` override and Python 3.9 floor as POSIX hooks.
+- Calendar-invalid or unreadable state timestamps now report `unknown` instead of crashing `start`, `doctor`, or advisory session hooks; Claude's configured SessionStart adapter now uses the shared readiness predicate too.
 - `setup` now stamps `**Last Updated:**` on the state files that `start` and `doctor` read, so a completed setup reports as initialized without depending on the agent to hand-write the line.
 - `start`'s `next_action` names the command to run instead of referring to "the explicit setup workflow" abstractly.
 - `CONTEXTOS_PYTHON` is honored exactly: an override that does not resolve to a working interpreter now fails loudly instead of silently falling back to a different one. The interpreter floor is Python 3.9, matching the kernel's use of `str.removeprefix`, instead of any Python 3.

--- a/TODO.md
+++ b/TODO.md
@@ -6,13 +6,6 @@ Canonical task backlog. `state/current.md` is the curated top-of-mind view for `
 
 ---
 
-## Getting started
-
-- [ ] Run through `SETUP-PROMPTS.md` to fill in identity and project files
-- [ ] Try `/start` to see a session briefing
-- [ ] Try `/end` at the end of a session to log your work
-- [ ] Build your first custom skill (see `docs/agent-template.md`)
-
-## Ideas
+## Tasks and ideas
 
 [Add tasks, goals, and ideas here as they come up. Organize into sections that make sense for your work.]

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,9 +1,9 @@
 # Hermes adapter
 
-Run `python3 -m contextos install --runtime hermes` from the repository root.
+Run `bash scripts/contextos.sh install --runtime hermes` from the repository root.
 Expose `.agents/skills/` as an external Hermes skill directory, or install the
 four short aliases together with their four `context-*` cores. Hermes copies
-installed skills, so `python3 -m contextos doctor --runtime hermes` should be
+installed skills, so `bash scripts/contextos.sh doctor --runtime hermes` should be
 part of updates and copied skills should be refreshed after a source change.
 
 The optional [`hooks.example.yaml`](hooks.example.yaml) maps Hermes lifecycle
@@ -12,9 +12,9 @@ runtimes. Merge it into user configuration only after reviewing its commands.
 Kernel proposal/apply enforcement does not depend on these hooks.
 
 The YAML example is POSIX-oriented. On Windows, use an equivalent command such
-as `powershell.exe -NoProfile -NonInteractive -Command "$root = git rev-parse
---show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') hermes
-pre-write"` for the pre-tool event (and replace `pre-write` with
+as `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+"$root = git rev-parse --show-toplevel; & (Join-Path $root
+'scripts/context-os-hook.ps1') hermes pre-write"` for the pre-tool event (and replace `pre-write` with
 `session-start` for the session event). Hermes hook policy remains advisory.
 
 Hermes `MEMORY.md` and `USER.md` remain host-local. Never point the kernel at

--- a/adapters/hermes/hooks.example.yaml
+++ b/adapters/hermes/hooks.example.yaml
@@ -1,8 +1,8 @@
 # Merge only after reviewing the exact commands and Hermes hook trust boundary.
 hooks:
   - event: on_session_start
-    command: "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" hermes session-start"
+    command: "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" hermes session-start"
   - event: pre_tool_call
-    command: "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" hermes pre-write"
+    command: "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" hermes pre-write"
     when:
       tools: [patch, write_file, terminal]

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -628,10 +628,17 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     updated = None
     age = None
     if path.exists():
-        match = LAST_UPDATED_RE.search(path.read_text(encoding="utf-8"))
-        if match and REAL_DATE_RE.fullmatch(match.group(1).strip()):
-            updated = match.group(1).strip()
-            age = (today - datetime.strptime(updated, "%Y-%m-%d").date()).days
+        try:
+            match = LAST_UPDATED_RE.search(path.read_text(encoding="utf-8"))
+            if match and REAL_DATE_RE.fullmatch(match.group(1).strip()):
+                candidate = match.group(1).strip()
+                parsed = datetime.strptime(candidate, "%Y-%m-%d").date()
+                updated = candidate
+                age = (today - parsed).days
+        except (OSError, UnicodeError, ValueError):
+            # Diagnostics and advisory hooks must report unreadable or invalid
+            # state as unknown rather than crashing on the file they diagnose.
+            pass
     if not path.exists():
         status = "missing"
     elif age is None:

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -202,9 +202,16 @@ def _advance_dated_state(path: Path, desired: str, today: str) -> str:
         raise ContextOSError(
             f"{label} must begin with a level-one heading when adding **Last Updated:**"
         )
-    remainder = "\n".join(lines[1:]).lstrip()
-    suffix = f"\n\n{remainder}" if remainder else "\n"
-    return f"{lines[0]}\n\n**Last Updated:** {today}{suffix}"
+    insert_at = 1
+    if path.name == "weekly-priorities.md":
+        for index, line in enumerate(lines[1:], start=1):
+            if line.startswith("**Week of:**"):
+                insert_at = index + 1
+                break
+    before = "\n".join(lines[:insert_at]).rstrip()
+    after = "\n".join(lines[insert_at:]).strip()
+    suffix = f"\n\n{after}\n" if after else "\n"
+    return f"{before}\n\n**Last Updated:** {today}{suffix}"
 
 
 def _session_append(path: Path, block: str, date: str) -> str:
@@ -612,6 +619,8 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
         status = "missing"
     elif age is None:
         status = "unknown"
+    elif age < 0:
+        status = "future"
     elif age > threshold:
         status = "stale"
     else:
@@ -622,7 +631,7 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
         "age_days": age,
         "stale_after_days": threshold,
         "freshness_status": status,
-        "stale": None if age is None else age > threshold,
+        "stale": None if age is None or age < 0 else age > threshold,
     }
 
 
@@ -693,7 +702,7 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
     initialized, initialization_files = _initialization_state(workspace, utc_now().date())
     unknown = [
         path for path, item in initialization_files.items()
-        if item["freshness_status"] in {"missing", "unknown"}
+        if item["freshness_status"] in {"missing", "unknown", "future"}
     ]
     add(
         "initialization-state",

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -21,6 +21,12 @@ LAST_UPDATED_RE = re.compile(r"^\*\*Last Updated:\*\*\s*(.+?)\s*$", re.MULTILINE
 REAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 SETUP_ROOTS = {"identity", "projects", "state"}
 SETUP_FILES = {"ROUTING.md", "TODO.md", "CLAUDE.md", "AGENTS.md"}
+STATE_THRESHOLDS = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
+INITIALIZATION_FILE = "current.md"
+SETUP_NEXT_ACTION = (
+    "Run the explicit setup workflow (bash scripts/setup.sh, then the $context-setup "
+    "skill) before starting a session."
+)
 RUNTIME_NAMES = {"claude", "codex", "hermes"}
 CAPABILITY_VALUES = {"native", "adapter", "advisory", "unsupported"}
 CAPABILITY_KEYS = {
@@ -185,7 +191,7 @@ def _advance_current(
         pending[history] = f"{before}{marker}\n\n{old_date}\n\n{after.lstrip()}"
 
 
-def _advance_dated_state(path: Path, desired: str, today: str) -> str:
+def _advance_dated_state(path: Path, desired: str, today: str, required: bool = True) -> str:
     label = path.as_posix()
     normalized = desired.rstrip() + "\n"
     matches = LAST_UPDATED_RE.findall(normalized)
@@ -199,6 +205,10 @@ def _advance_dated_state(path: Path, desired: str, today: str) -> str:
     # their next lifecycle write instead of failing setup or session end.
     lines = normalized.splitlines()
     if not lines or not lines[0].startswith("# "):
+        # Setup stamps reviewed content opportunistically; a lifecycle write to a
+        # file the kernel already owns must not silently skip the timestamp.
+        if not required:
+            return normalized
         raise ContextOSError(
             f"{label} must begin with a level-one heading when adding **Last Updated:**"
         )
@@ -302,6 +312,11 @@ def render_setup(workspace: Workspace, payload: dict[str, Any], now: datetime) -
     replace = set(ensure_string_list(payload.get("replace_populated"), "replace_populated"))
     if not isinstance(files, dict) or not files:
         raise ContextOSError("files must be a non-empty object mapping paths to content")
+    today = now.strftime("%Y-%m-%d")
+    # Setup owns the freshness line on the state files start/doctor read, so a
+    # completed setup reports as initialized without relying on the agent to
+    # hand-write **Last Updated:** into reviewed content.
+    dated_state = {workspace.state_dir / filename for filename in STATE_THRESHOLDS}
     pending: dict[Path, str] = {}
     for raw_path, raw_content in files.items():
         if not isinstance(raw_path, str):
@@ -312,9 +327,11 @@ def render_setup(workspace: Workspace, payload: dict[str, Any], now: datetime) -
         skill_path = len(Path(relative).parts) >= 3 and Path(relative).parts[:2] == (".agents", "skills")
         if top not in SETUP_ROOTS and relative not in SETUP_FILES and not skill_path:
             raise ContextOSError(f"setup cannot write outside approved context paths: {relative}")
-        content = ensure_text(raw_content, f"files[{raw_path}]").replace("{{TODAY}}", now.strftime("%Y-%m-%d"))
+        content = ensure_text(raw_content, f"files[{raw_path}]").replace("{{TODAY}}", today)
         if path.exists() and _is_populated(path.read_text(encoding="utf-8")) and relative not in replace:
             raise ContextOSError(f"populated file requires replace_populated approval: {relative}")
+        if path in dated_state:
+            content = _advance_dated_state(path, content, today, required=False)
         pending[path] = content.rstrip() + "\n"
     return pending
 
@@ -635,20 +652,33 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     }
 
 
+def _is_initialized(workspace: Workspace, today: date | None = None) -> bool:
+    """Single readiness predicate shared by start, doctor, and the session hook.
+
+    Only current.md gates readiness. weekly-priorities.md and blockers.md are
+    legitimately left at their shipped template by users who have neither, so
+    requiring a real date on all three would report an initialized workspace as
+    needing setup forever. Their freshness is still reported separately.
+    """
+    current = workspace.state_dir / INITIALIZATION_FILE
+    freshness = _state_freshness(
+        current,
+        today if today is not None else utc_now().date(),
+        STATE_THRESHOLDS[INITIALIZATION_FILE],
+    )
+    return freshness["freshness_status"] in {"fresh", "stale"}
+
+
 def _initialization_state(
     workspace: Workspace, today: date
 ) -> tuple[bool, dict[str, dict[str, Any]]]:
-    thresholds = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
     state = {
         relative_path(workspace.root, workspace.state_dir / filename): _state_freshness(
             workspace.state_dir / filename, today, threshold
         )
-        for filename, threshold in thresholds.items()
+        for filename, threshold in STATE_THRESHOLDS.items()
     }
-    initialized = all(
-        item["freshness_status"] in {"fresh", "stale"} for item in state.values()
-    )
-    return initialized, state
+    return _is_initialized(workspace, today), state
 
 
 def start_report(root: Path, now: datetime) -> dict[str, Any]:
@@ -659,7 +689,7 @@ def start_report(root: Path, now: datetime) -> dict[str, Any]:
         "schema_version": SCHEMA_VERSION,
         "generated_at": now.isoformat(),
         "initialized": initialized,
-        "next_action": None if initialized else "Run the explicit setup workflow before starting a session.",
+        "next_action": None if initialized else SETUP_NEXT_ACTION,
         "state": files,
         "latest_session": relative_path(root, sessions[0]) if sessions else None,
         "task_file": relative_path(root, workspace.task_file),
@@ -700,14 +730,22 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
         rel = relative_path(root, path)
         add(f"file:{rel}", "pass" if path.exists() else "fail", rel)
     initialized, initialization_files = _initialization_state(workspace, utc_now().date())
-    unknown = [
+    gate = relative_path(root, workspace.state_dir / INITIALIZATION_FILE)
+    add(
+        "initialization-state",
+        "pass" if initialized else "warn",
+        "ready" if initialized else f"guided setup required; {gate} carries no real **Last Updated:** date",
+    )
+    unresolved = [
         path for path, item in initialization_files.items()
         if item["freshness_status"] in {"missing", "unknown", "future"}
     ]
     add(
-        "initialization-state",
-        "pass" if initialized else "warn",
-        "ready" if initialized else f"guided setup required; unresolved freshness: {', '.join(unknown)}",
+        "state-freshness",
+        "pass" if not unresolved else "warn",
+        "all tracked state files carry a real date"
+        if not unresolved
+        else f"no usable **Last Updated:** date in: {', '.join(unresolved)}",
     )
     selected = runtime
     local_runtime = root / ".context-os" / "runtime.json"
@@ -778,9 +816,8 @@ def hook_report(root: Path, event: str, payload: dict[str, Any]) -> dict[str, An
     findings: list[dict[str, str]] = []
     workspace = load_workspace(root)
     if event == "session-start":
-        current = workspace.state_dir / "current.md"
-        if current.exists() and PLACEHOLDER_DATE in current.read_text(encoding="utf-8"):
-            findings.append({"severity": "advisory", "message": "Context OS is not initialized; run the explicit setup workflow."})
+        if not _is_initialized(workspace):
+            findings.append({"severity": "advisory", "message": f"Context OS is not initialized. {SETUP_NEXT_ACTION}"})
         lock = root / ".context-os" / "apply.lock"
         if lock.exists():
             findings.append({"severity": "warning", "message": f"A lifecycle apply lock exists at {lock}. Run context-os doctor before writing."})

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -150,10 +150,12 @@ def read_json(path: Path) -> dict[str, Any]:
     return value
 
 
-def _replace_last_updated(content: str, today: str) -> tuple[str, str | None]:
+def _replace_last_updated(
+    content: str, today: str, label: str = "lifecycle state"
+) -> tuple[str, str | None]:
     matches = LAST_UPDATED_RE.findall(content)
     if len(matches) != 1:
-        raise ContextOSError("state/current.md must contain exactly one **Last Updated:** line")
+        raise ContextOSError(f"{label} must contain exactly one **Last Updated:** line")
     old = matches[0].strip()
     updated = LAST_UPDATED_RE.sub(f"**Last Updated:** {today}", content, count=1)
     return updated, old if REAL_DATE_RE.fullmatch(old) else None
@@ -169,7 +171,9 @@ def _advance_current(
 ) -> None:
     current = workspace.state_dir / "current.md"
     history = workspace.state_dir / "current-log.md"
-    updated, old_date = _replace_last_updated(desired.rstrip() + "\n", today)
+    updated, old_date = _replace_last_updated(
+        desired.rstrip() + "\n", today, "state/current.md"
+    )
     pending[current] = updated
     history_text = history.read_text(encoding="utf-8") if history.exists() else "# current.md update log\n\n"
     newest = _newest_history_date(history_text)
@@ -179,6 +183,28 @@ def _advance_current(
             raise ContextOSError("state/current-log.md is missing its required heading")
         before, after = history_text.split(marker, 1)
         pending[history] = f"{before}{marker}\n\n{old_date}\n\n{after.lstrip()}"
+
+
+def _advance_dated_state(path: Path, desired: str, today: str) -> str:
+    label = path.as_posix()
+    normalized = desired.rstrip() + "\n"
+    matches = LAST_UPDATED_RE.findall(normalized)
+    if len(matches) > 1:
+        raise ContextOSError(f"{label} must contain at most one **Last Updated:** line")
+    if matches:
+        updated, _ = _replace_last_updated(normalized, today, label)
+        return updated
+
+    # Workspaces created before freshness metadata was added should upgrade on
+    # their next lifecycle write instead of failing setup or session end.
+    lines = normalized.splitlines()
+    if not lines or not lines[0].startswith("# "):
+        raise ContextOSError(
+            f"{label} must begin with a level-one heading when adding **Last Updated:**"
+        )
+    remainder = "\n".join(lines[1:]).lstrip()
+    suffix = f"\n\n{remainder}" if remainder else "\n"
+    return f"{lines[0]}\n\n**Last Updated:** {today}{suffix}"
 
 
 def _session_append(path: Path, block: str, date: str) -> str:
@@ -231,7 +257,10 @@ def render_end(workspace: Workspace, payload: dict[str, Any], now: datetime) -> 
         _advance_current(workspace, ensure_text(payload["current_markdown"], "current_markdown"), today, pending)
     for field, filename in (("blockers_markdown", "blockers.md"), ("weekly_priorities_markdown", "weekly-priorities.md")):
         if field in payload:
-            pending[workspace.state_dir / filename] = ensure_text(payload[field], field).rstrip() + "\n"
+            path = workspace.state_dir / filename
+            pending[path] = _advance_dated_state(
+                path, ensure_text(payload[field], field), today
+            )
     if decisions:
         decision_path = workspace.state_dir / "decisions.md"
         if not decision_path.exists():
@@ -571,28 +600,57 @@ def runtime_manifest(root: Path, runtime: str) -> dict[str, Any]:
     return manifest
 
 
+def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
+    updated = None
+    age = None
+    if path.exists():
+        match = LAST_UPDATED_RE.search(path.read_text(encoding="utf-8"))
+        if match and REAL_DATE_RE.fullmatch(match.group(1).strip()):
+            updated = match.group(1).strip()
+            age = (today - datetime.strptime(updated, "%Y-%m-%d").date()).days
+    if not path.exists():
+        status = "missing"
+    elif age is None:
+        status = "unknown"
+    elif age > threshold:
+        status = "stale"
+    else:
+        status = "fresh"
+    return {
+        "exists": path.exists(),
+        "last_updated": updated,
+        "age_days": age,
+        "stale_after_days": threshold,
+        "freshness_status": status,
+        "stale": None if age is None else age > threshold,
+    }
+
+
+def _initialization_state(
+    workspace: Workspace, today: date
+) -> tuple[bool, dict[str, dict[str, Any]]]:
+    thresholds = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
+    state = {
+        relative_path(workspace.root, workspace.state_dir / filename): _state_freshness(
+            workspace.state_dir / filename, today, threshold
+        )
+        for filename, threshold in thresholds.items()
+    }
+    initialized = all(
+        item["freshness_status"] in {"fresh", "stale"} for item in state.values()
+    )
+    return initialized, state
+
+
 def start_report(root: Path, now: datetime) -> dict[str, Any]:
     workspace = load_workspace(root)
-    thresholds = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
-    files: dict[str, Any] = {}
-    today = now.date()
-    for filename, threshold in thresholds.items():
-        path = workspace.state_dir / filename
-        age = None
-        updated = None
-        if path.exists():
-            match = LAST_UPDATED_RE.search(path.read_text(encoding="utf-8"))
-            if match and REAL_DATE_RE.fullmatch(match.group(1).strip()):
-                updated = match.group(1).strip()
-                age = (today - datetime.strptime(updated, "%Y-%m-%d").date()).days
-        files[relative_path(root, path)] = {
-            "exists": path.exists(), "last_updated": updated, "age_days": age,
-            "stale_after_days": threshold, "stale": age is not None and age > threshold,
-        }
+    initialized, files = _initialization_state(workspace, now.date())
     sessions = sorted(workspace.sessions_dir.glob("????-??-??.md"), reverse=True) if workspace.sessions_dir.exists() else []
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": now.isoformat(),
+        "initialized": initialized,
+        "next_action": None if initialized else "Run the explicit setup workflow before starting a session.",
         "state": files,
         "latest_session": relative_path(root, sessions[0]) if sessions else None,
         "task_file": relative_path(root, workspace.task_file),
@@ -632,6 +690,16 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
     for path in required_paths:
         rel = relative_path(root, path)
         add(f"file:{rel}", "pass" if path.exists() else "fail", rel)
+    initialized, initialization_files = _initialization_state(workspace, utc_now().date())
+    unknown = [
+        path for path, item in initialization_files.items()
+        if item["freshness_status"] in {"missing", "unknown"}
+    ]
+    add(
+        "initialization-state",
+        "pass" if initialized else "warn",
+        "ready" if initialized else f"guided setup required; unresolved freshness: {', '.join(unknown)}",
+    )
     selected = runtime
     local_runtime = root / ".context-os" / "runtime.json"
     if selected is None and local_runtime.exists():

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -17,13 +17,13 @@ Use `$start`, `$update`, and `$end` for the daily loop. The namespaced
 Setup records a gitignored local runtime selection. Inspect it with:
 
 ```bash
-python3 -m contextos doctor --runtime codex
+bash scripts/contextos.sh doctor --runtime codex
 ```
 
 ## Deterministic writes
 
 The skills do not directly mutate lifecycle state. They create reviewed input,
-run `python3 -m contextos propose`, present exact diffs, and run `apply` only
+run `bash scripts/contextos.sh propose`, present exact diffs, and run `apply` only
 after the user approves the displayed digest. The receipt is the portable proof
 of which paths and hashes changed. The kernel never commits or pushes.
 
@@ -57,7 +57,7 @@ SSOTs.
 ## Verify
 
 ```bash
-python3 -m contextos doctor --runtime codex
+bash scripts/contextos.sh doctor --runtime codex
 bash scripts/validate-all.sh
 ```
 

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -20,9 +20,9 @@ Claude files are host adapters. All lifecycle names require explicit invocation.
 The mutation protocol is always:
 
 1. the agent drafts reviewed JSON input under ignored `.context-os/inputs/`;
-2. `python3 -m contextos propose` emits exact diffs and a proposal digest;
+2. `bash scripts/contextos.sh propose` emits exact diffs and a proposal digest;
 3. the agent presents those diffs and waits;
-4. `python3 -m contextos apply` receives that exact digest; and
+4. `bash scripts/contextos.sh apply` receives that exact digest; and
 5. the kernel verifies target hashes, takes an exclusive lock, writes only the
    proposal paths, and records a receipt.
 
@@ -76,5 +76,5 @@ import safe. Their Claude adapters appear in the command index below.
 Uploading these files to claude.ai does not activate commands, hooks, tool
 permissions, or skill metadata. See `docs/claude-projects-sync.md`.
 
-Run `python3 -m contextos doctor` for runtime and state diagnostics, then
+Run `bash scripts/contextos.sh doctor` for runtime and state diagnostics, then
 `bash scripts/validate-all.sh` after repository changes.

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -10,7 +10,7 @@ models, tool names, or native memory.
    the durable, reviewable source of truth.
 2. **Portable intent:** `.agents/skills/context-*` gathers facts and asks for
    judgment without owning mutation mechanics.
-3. **Deterministic kernel:** `python3 -m contextos` owns paths, rendering,
+3. **Deterministic kernel:** `bash scripts/contextos.sh` owns paths, rendering,
    invariants, proposals, locks, optimistic hashes, applies, and receipts.
 4. **Runtime adapters:** `.claude/`, `.codex/`, and `adapters/hermes/` map host
    discovery and hooks to the portable layers.
@@ -20,11 +20,11 @@ models, tool names, or native memory.
 ## Commands
 
 ```text
-python3 -m contextos start [--now ISO_TIMESTAMP]
-python3 -m contextos propose setup|update|end --input payload.json [--now ISO_TIMESTAMP]
-python3 -m contextos apply proposal.json --confirm SHA256 --runtime claude|codex|hermes
-python3 -m contextos install --runtime claude|codex|hermes
-python3 -m contextos doctor [--runtime claude|codex|hermes]
+bash scripts/contextos.sh start [--now ISO_TIMESTAMP]
+bash scripts/contextos.sh propose setup|update|end --input payload.json [--now ISO_TIMESTAMP]
+bash scripts/contextos.sh apply proposal.json --confirm SHA256 --runtime claude|codex|hermes
+bash scripts/contextos.sh install --runtime claude|codex|hermes
+bash scripts/contextos.sh doctor [--runtime claude|codex|hermes]
 ```
 
 `--now` exists for deterministic fixtures. Production calls use local time.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,9 +6,15 @@ Codex, and Hermes can use as shared state.
 
 ## Before you clone
 
-You need Git, Bash, Python 3, and at least one supported local agent: Claude
-Code, Codex, or Hermes. claude.ai can help produce files but cannot maintain a
-local checkout directly.
+You need Git, Bash, Python 3.9 or newer, and at least one supported local
+agent: Claude Code, Codex, or Hermes. claude.ai can help produce files but
+cannot maintain a local checkout directly.
+
+Python may be installed as either `python3` or `python`; the repository resolves
+whichever works. To pin a specific interpreter — a virtualenv, or one of several
+installed versions — set `CONTEXTOS_PYTHON` to its path or command. That setting
+is honored exactly: if it does not resolve to a working Python 3.9+, setup and
+validation stop instead of falling back to a different interpreter.
 
 Decide where the repository will live. If it will contain personal, client, employer, financial, or unpublished project context, use a private remote. Repository visibility is only one control; do not store credentials, raw account exports, or information you would not want every configured agent to read.
 
@@ -96,7 +102,7 @@ Remove any unsupported inference, stale claim, duplicate fact, or context that i
 Then run:
 
 ```bash
-python3 -m contextos doctor
+bash scripts/contextos.sh doctor
 bash scripts/validate-all.sh
 git diff --check
 git status --short

--- a/scripts/context-os-hook.ps1
+++ b/scripts/context-os-hook.ps1
@@ -1,0 +1,52 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$HookArguments
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-ContextOsPython {
+    param([string]$Candidate)
+
+    if (-not (Get-Command -Name $Candidate -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+    $previousErrorActionPreference = $ErrorActionPreference
+    $probeSucceeded = $false
+    try {
+        $ErrorActionPreference = "Continue"
+        & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >$null 2>$null
+        $probeSucceeded = $LASTEXITCODE -eq 0
+    } catch {
+        $probeSucceeded = $false
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    return $probeSucceeded
+}
+
+$pythonCommand = $null
+if ($env:CONTEXTOS_PYTHON) {
+    if (Test-ContextOsPython $env:CONTEXTOS_PYTHON) {
+        $pythonCommand = $env:CONTEXTOS_PYTHON
+    } else {
+        [Console]::Error.WriteLine("CONTEXTOS_PYTHON is set to '$($env:CONTEXTOS_PYTHON)', which is not a working Python 3.9+ interpreter.")
+        [Console]::Error.WriteLine("Fix or unset it; an explicit interpreter is never silently replaced with another one.")
+        exit 1
+    }
+} else {
+    foreach ($candidate in @("python3", "python")) {
+        if (Test-ContextOsPython $candidate) {
+            $pythonCommand = $candidate
+            break
+        }
+    }
+}
+
+if (-not $pythonCommand) {
+    [Console]::Error.WriteLine("Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON.")
+    exit 1
+}
+
+& $pythonCommand (Join-Path $PSScriptRoot "context-os-hook.py") @HookArguments
+exit $LASTEXITCODE

--- a/scripts/context-os-hook.py
+++ b/scripts/context-os-hook.py
@@ -32,7 +32,7 @@ def main() -> int:
         else:
             print(json.dumps({"action": "allow", "message": "\n".join(messages)}))
         return 0
-    except (ContextOSError, json.JSONDecodeError) as exc:
+    except (ContextOSError, json.JSONDecodeError, OSError, UnicodeError) as exc:
         # These hooks are advisory. Surface malformed input instead of silently
         # passing, but do not create a second mutation-enforcement path.
         message = f"Context OS advisory hook could not run: {exc}"

--- a/scripts/context-os-hook.sh
+++ b/scripts/context-os-hook.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# POSIX hook entry point. Wraps context-os-hook.py with the repository's
+# resolved Python interpreter so hosts that expose Python 3 only as `python`
+# still get lifecycle advisories.
+#
+#   bash scripts/context-os-hook.sh codex session-start
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/python-env.sh"
+
+exec "$CONTEXTOS_PYTHON_CMD" "$SCRIPT_DIR/context-os-hook.py" "$@"

--- a/scripts/contextos.sh
+++ b/scripts/contextos.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the lifecycle kernel with the repository's resolved Python interpreter.
+# Use this instead of `python3 -m contextos` so hosts that expose Python 3 only
+# as `python` work, and so CONTEXTOS_PYTHON is honored.
+#
+#   bash scripts/contextos.sh start
+#   bash scripts/contextos.sh propose end --input <payload.json>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/python-env.sh"
+
+cd "$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "$CONTEXTOS_PYTHON_CMD" -m contextos "$@"

--- a/scripts/python-env.sh
+++ b/scripts/python-env.sh
@@ -1,25 +1,43 @@
 #!/usr/bin/env bash
-# Resolve one working Python 3 command for repository shell workflows.
-# CONTEXTOS_PYTHON may name an explicit interpreter path or command.
+# Resolve one working Python command for repository shell workflows.
+#
+# Discovery order is CONTEXTOS_PYTHON, then python3, then python. The floor is
+# Python 3.9 because the kernel uses str.removeprefix.
+#
+# CONTEXTOS_PYTHON is an explicit instruction, not a hint: if it is set and does
+# not work, this fails loudly rather than running against a different
+# interpreter than the one that was asked for.
 
 CONTEXTOS_PYTHON_CMD=""
-python_candidates=()
-if [ -n "${CONTEXTOS_PYTHON:-}" ]; then
-  python_candidates+=("$CONTEXTOS_PYTHON")
-fi
-python_candidates+=(python3 python)
 
-for candidate in "${python_candidates[@]}"; do
-  if command -v "$candidate" >/dev/null 2>&1 &&
-    "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' >/dev/null 2>&1; then
-    CONTEXTOS_PYTHON_CMD="$candidate"
-    break
+_contextos_python_works() {
+  command -v "$1" >/dev/null 2>&1 &&
+    "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1
+}
+
+if [ -n "${CONTEXTOS_PYTHON:-}" ]; then
+  if _contextos_python_works "$CONTEXTOS_PYTHON"; then
+    CONTEXTOS_PYTHON_CMD="$CONTEXTOS_PYTHON"
+  else
+    echo "CONTEXTOS_PYTHON is set to '$CONTEXTOS_PYTHON', which is not a working Python 3.9+ interpreter." >&2
+    echo "Fix or unset it; an explicit interpreter is never silently replaced with another one." >&2
+    unset -f _contextos_python_works
+    return 1 2>/dev/null || exit 1
   fi
-done
-unset python_candidates candidate
+else
+  for candidate in python3 python; do
+    if _contextos_python_works "$candidate"; then
+      CONTEXTOS_PYTHON_CMD="$candidate"
+      break
+    fi
+  done
+  unset candidate
+fi
+
+unset -f _contextos_python_works
 
 if [ -z "$CONTEXTOS_PYTHON_CMD" ]; then
-  echo "Python 3 is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
+  echo "Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
   return 1 2>/dev/null || exit 1
 fi
 

--- a/scripts/python-env.sh
+++ b/scripts/python-env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Resolve one working Python 3 command for repository shell workflows.
+# CONTEXTOS_PYTHON may name an explicit interpreter path or command.
+
+CONTEXTOS_PYTHON_CMD=""
+python_candidates=()
+if [ -n "${CONTEXTOS_PYTHON:-}" ]; then
+  python_candidates+=("$CONTEXTOS_PYTHON")
+fi
+python_candidates+=(python3 python)
+
+for candidate in "${python_candidates[@]}"; do
+  if command -v "$candidate" >/dev/null 2>&1 &&
+    "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' >/dev/null 2>&1; then
+    CONTEXTOS_PYTHON_CMD="$candidate"
+    break
+  fi
+done
+unset python_candidates candidate
+
+if [ -z "$CONTEXTOS_PYTHON_CMD" ]; then
+  echo "Python 3 is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+export CONTEXTOS_PYTHON_CMD

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,10 +44,7 @@ case "$AGENT_TARGET" in
     ;;
 esac
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Python 3 is required for setup and validation." >&2
-  exit 1
-fi
+source "$SCRIPT_DIR/python-env.sh"
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -99,7 +96,7 @@ read -rp "  Name to place in CLAUDE.md (or press Enter to skip): " USER_NAME
 
 if [ -n "$USER_NAME" ]; then
   if grep -Fq '[Your Name]' CLAUDE.md; then
-    python3 - "$USER_NAME" <<'PY'
+    "$CONTEXTOS_PYTHON_CMD" - "$USER_NAME" <<'PY'
 from pathlib import Path
 import sys
 
@@ -143,7 +140,7 @@ if [ -d "projects/example-musician" ]; then
   if prompt_yn "  Remove the example musician project? (You can always reference it on GitHub)" "n"; then
     rm -rf projects/example-musician
     # Clean any explicit sample-project route without platform-specific sed flags.
-    python3 - <<'PY'
+    "$CONTEXTOS_PYTHON_CMD" - <<'PY'
 from pathlib import Path
 
 path = Path("ROUTING.md")
@@ -240,7 +237,7 @@ else
   echo "    Missing: git"
 fi
 
-echo "    Found: python3"
+echo "    Found: $CONTEXTOS_PYTHON_CMD (Python 3)"
 
 if command -v gws &>/dev/null; then
   echo "    Found: gws (Google Workspace CLI)"
@@ -252,11 +249,11 @@ echo "    Optional add-ons: see references/integrations.md (nothing is installed
 
 echo ""
 echo "  Checking the provider-neutral lifecycle kernel..."
-if python3 -m contextos doctor >/dev/null; then
+if "$CONTEXTOS_PYTHON_CMD" -m contextos doctor >/dev/null; then
   echo "    Found: context-os kernel"
 else
   echo "    Kernel doctor found a required repository problem." >&2
-  python3 -m contextos doctor >&2 || true
+  "$CONTEXTOS_PYTHON_CMD" -m contextos doctor >&2 || true
   exit 1
 fi
 
@@ -319,7 +316,7 @@ fi
 
 case "$SELECTED_AGENT" in
   claude)
-    python3 -m contextos install --runtime claude >/dev/null
+    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime claude >/dev/null
     echo "  Claude Code auto-memory is enabled by default and may write machine-local memory."
     echo "  Inspect it with /memory; to opt out, set autoMemoryEnabled: false in"
     echo "  .claude/settings.local.json. Setup does not change that host setting."
@@ -335,7 +332,7 @@ case "$SELECTED_AGENT" in
     fi
     ;;
   codex)
-    python3 -m contextos install --runtime codex >/dev/null
+    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime codex >/dev/null
     printf '  1. cd %q && codex\n' "$REPO_ROOT"
     echo '  2. Type: $setup'
     echo "     Codex will interview you and build your context files."
@@ -347,7 +344,7 @@ case "$SELECTED_AGENT" in
     fi
     ;;
   hermes)
-    python3 -m contextos install --runtime hermes >/dev/null
+    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime hermes >/dev/null
     printf '  1. cd %q && hermes\n' "$REPO_ROOT"
     echo "  2. Hermes reads AGENTS.md automatically. Expose .agents/skills/ as an"
     echo "     external skill directory, then type /setup. If you copy skills instead,"

--- a/scripts/validate-all.sh
+++ b/scripts/validate-all.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
+source "$ROOT/scripts/python-env.sh"
 
 bash scripts/validate-skills.sh
 bash scripts/check-links.sh
@@ -14,10 +15,10 @@ while IFS= read -r -d '' script; do
   bash -n "$script"
 done < <(find .claude/hooks scripts tests -name '*.sh' -print0)
 
-python3 -m unittest discover -s tests -p 'test_*.py'
-python3 scripts/integrations.py check
+"$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_*.py'
+"$CONTEXTOS_PYTHON_CMD" scripts/integrations.py check
 
-python3 - <<'PY'
+"$CONTEXTOS_PYTHON_CMD" - <<'PY'
 import json
 from pathlib import Path
 

--- a/state/blockers.md
+++ b/state/blockers.md
@@ -1,5 +1,7 @@
 # Blockers
 
+**Last Updated:** [DATE]
+
 Active blockers preventing progress on priorities. Remove when resolved.
 
 <!-- Template:

--- a/state/weekly-priorities.md
+++ b/state/weekly-priorities.md
@@ -2,6 +2,8 @@
 
 **Week of:** [DATE]
 
+**Last Updated:** [DATE]
+
 ## Top 3 this week
 
 1. [Must ship / must do]

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -45,6 +45,31 @@ if command -v cygpath >/dev/null 2>&1; then
 else
   TEMP_ROOT_WIN=$TEMP_ROOT
 fi
+
+# Claude's configured SessionStart adapter must use the same current.md
+# readiness predicate as start and doctor, while remaining advisory.
+SESSION_REPO="$TEMP_ROOT_WIN/session-repo"
+mkdir -p "$SESSION_REPO/.claude/hooks" "$SESSION_REPO/scripts" "$SESSION_REPO/state"
+cp "$ROOT/.claude/hooks/session-start.sh" "$SESSION_REPO/.claude/hooks/session-start.sh"
+cp "$ROOT/scripts/context-os-hook.py" "$ROOT/scripts/context-os-hook.sh" \
+  "$ROOT/scripts/python-env.sh" "$SESSION_REPO/scripts/"
+cp -R "$ROOT/contextos" "$SESSION_REPO/contextos"
+printf '# Test workspace\n' > "$SESSION_REPO/AGENTS.md"
+git -C "$SESSION_REPO" init -q -b main
+
+printf '# Current State\n\n**Last Updated:** [DATE]\n' > "$SESSION_REPO/state/current.md"
+SESSION_SETUP_OUTPUT=$(cd "$SESSION_REPO" && bash .claude/hooks/session-start.sh)
+printf '%s' "$SESSION_SETUP_OUTPUT" | grep -q 'not initialized' \
+  || fail "Claude session-start must fire when current.md is uninitialized"
+
+printf '# Current State\n\n**Last Updated:** %s\n' "$(date +%F)" > "$SESSION_REPO/state/current.md"
+SESSION_READY_OUTPUT=$(cd "$SESSION_REPO" && bash .claude/hooks/session-start.sh)
+if printf '%s' "$SESSION_READY_OUTPUT" | grep -q 'not initialized'; then
+  fail "Claude session-start fired the setup advisory for initialized state"
+fi
+printf '%s' "$SESSION_READY_OUTPUT" | grep -q 'Tip: Run /start' \
+  || fail "Claude session-start omitted the initialized-state /start tip"
+
 TEST_REPO="$TEMP_ROOT_WIN/guarded-repo"
 mkdir -p "$TEST_REPO/.claude/hooks" "$TEMP_ROOT/bin"
 git -C "$TEMP_ROOT_WIN" init -q -b main guarded-repo

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
+source "$ROOT/scripts/python-env.sh"
 
 SSOT_OUTPUT=$(printf '%s' '{"tool_input":{"file_path":"/tmp/context/state/current.md"}}' | \
   bash "$ROOT/.claude/hooks/ssot-guard.sh")
-if ! printf '%s' "$SSOT_OUTPUT" | python3 -c '
+if ! printf '%s' "$SSOT_OUTPUT" | "$CONTEXTOS_PYTHON_CMD" -c '
 import json, sys
 payload = json.load(sys.stdin)
 assert "current.md is updated" in payload["systemMessage"]
@@ -16,7 +17,7 @@ fi
 
 SSOT_WINDOWS_OUTPUT=$(printf '%s' '{"tool_input":{"file_path":"C:\\repo\\state\\decisions.md"}}' | \
   bash "$ROOT/.claude/hooks/ssot-guard.sh")
-if ! printf '%s' "$SSOT_WINDOWS_OUTPUT" | python3 -c '
+if ! printf '%s' "$SSOT_WINDOWS_OUTPUT" | "$CONTEXTOS_PYTHON_CMD" -c '
 import json, sys
 payload = json.load(sys.stdin)
 assert "decisions.md is append-only" in payload["systemMessage"]
@@ -26,7 +27,7 @@ assert "decisions.md is append-only" in payload["systemMessage"]
 fi
 
 MALFORMED_OUTPUT=$(printf '%s' 'not-json' | bash "$ROOT/.claude/hooks/ssot-guard.sh")
-if ! printf '%s' "$MALFORMED_OUTPUT" | python3 -c '
+if ! printf '%s' "$MALFORMED_OUTPUT" | "$CONTEXTOS_PYTHON_CMD" -c '
 import json, sys
 payload = json.load(sys.stdin)
 assert "malformed input" in payload["systemMessage"]
@@ -76,7 +77,7 @@ fi
 
 
 BACKSLASH_PATH=$(printf '%s' "$TEST_REPO/note.md" | tr '/' '\\')
-BACKSLASH_PAYLOAD=$(python3 -c '
+BACKSLASH_PAYLOAD=$("$CONTEXTOS_PYTHON_CMD" -c '
 import json, sys
 print(json.dumps({"tool_input": {"file_path": sys.argv[1]}}))
 ' "$BACKSLASH_PATH")

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 source "$ROOT/scripts/python-env.sh"
 
+fail() {
+  echo "hooks: $*" >&2
+  exit 1
+}
+
 SSOT_OUTPUT=$(printf '%s' '{"tool_input":{"file_path":"/tmp/context/state/current.md"}}' | \
   bash "$ROOT/.claude/hooks/ssot-guard.sh")
 if ! printf '%s' "$SSOT_OUTPUT" | "$CONTEXTOS_PYTHON_CMD" -c '
@@ -69,6 +74,11 @@ if printf '%s' "$SESSION_READY_OUTPUT" | grep -q 'not initialized'; then
 fi
 printf '%s' "$SESSION_READY_OUTPUT" | grep -q 'Tip: Run /start' \
   || fail "Claude session-start omitted the initialized-state /start tip"
+
+printf '\377' > "$SESSION_REPO/workspace.yaml"
+SESSION_ENCODING_OUTPUT=$(cd "$SESSION_REPO" && bash .claude/hooks/session-start.sh)
+printf '%s' "$SESSION_ENCODING_OUTPUT" | grep -q 'advisory hook could not run' \
+  || fail "Claude session-start did not surface an unreadable workspace config"
 
 TEST_REPO="$TEMP_ROOT_WIN/guarded-repo"
 mkdir -p "$TEST_REPO/.claude/hooks" "$TEMP_ROOT/bin"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
+source "$ROOT/scripts/python-env.sh"
 
 fail() {
   echo "portability: $*" >&2
@@ -30,9 +31,9 @@ for index in "${!skills[@]}"; do
   test -f "$command_file" || fail "missing $command_file"
 
   tr -d '\r' < "$skill_file" | grep -qx "name: $skill" || fail "$skill_file name does not match its directory"
-  python3 tests/validate-openai-metadata.py "$metadata_file" "$skill" || fail "$metadata_file failed schema validation"
+  "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py "$metadata_file" "$skill" || fail "$metadata_file failed schema validation"
   grep -Fq ".agents/skills/$skill/SKILL.md" "$command_file" || fail "$command_file does not route to $skill"
-  python3 tests/validate-openai-metadata.py --command "$command_file" "$command" || fail "$command_file failed frontmatter validation"
+  "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$command_file" "$command" || fail "$command_file failed frontmatter validation"
 
   lines=$(wc -l < "$skill_file")
   [ "$lines" -le 180 ] || fail "$skill_file is too long to remain a focused workflow core"
@@ -52,7 +53,7 @@ for index in "${!aliases[@]}"; do
   test -f "$metadata_file" || fail "missing $metadata_file"
   tr -d '\r' < "$alias_file" | grep -qx "name: $alias_name" || fail "$alias_file name does not match its directory"
   grep -Fq "../$core_name/SKILL.md" "$alias_file" || fail "$alias_file does not route to $core_name"
-  python3 tests/validate-openai-metadata.py "$metadata_file" "$alias_name" || fail "$metadata_file failed schema validation"
+  "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py "$metadata_file" "$alias_name" || fail "$metadata_file failed schema validation"
   [ "$(wc -l < "$alias_file")" -le 15 ] || fail "$alias_file is no longer a thin alias"
 done
 
@@ -66,7 +67,7 @@ side_effecting_commands=(
   reconcile recover setup today update end
 )
 for command in "${side_effecting_commands[@]}"; do
-  python3 tests/validate-openai-metadata.py --command ".claude/commands/$command.md" "$command" \
+  "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command ".claude/commands/$command.md" "$command" \
     || fail ".claude/commands/$command.md failed strict side-effecting frontmatter validation"
 done
 
@@ -126,31 +127,50 @@ if command -v cygpath >/dev/null 2>&1; then
   portability_tmp=$(cygpath -m "$portability_tmp")
 fi
 trap 'rm -rf "$portability_tmp"' EXIT
+
+# Windows commonly exposes Python 3 as `python` without a usable `python3`.
+# Exercise that fallback with an isolated PATH so a host python3 cannot mask it.
+python_fallback_bin="$portability_tmp/python-fallback-bin"
+mkdir -p "$python_fallback_bin"
+python_fallback_path="$python_fallback_bin"
+if command -v cygpath >/dev/null 2>&1; then
+  python_fallback_path=$(cygpath -u "$python_fallback_bin")
+fi
+resolved_bash=$(command -v bash)
+resolved_python=$(command -v "$CONTEXTOS_PYTHON_CMD")
+printf '#!%s\nexec %q "$@"\n' "$resolved_bash" "$resolved_python" > "$python_fallback_bin/python"
+chmod +x "$python_fallback_bin/python"
+fallback_python=$(
+  PATH="$python_fallback_path" CONTEXTOS_PYTHON= "$resolved_bash" -c \
+    'source "$1"; printf "%s" "$CONTEXTOS_PYTHON_CMD"' _ "$ROOT/scripts/python-env.sh"
+)
+[ "$fallback_python" = "python" ] || fail "Python resolver did not fall back from python3 to python"
+
 invalid_metadata="$portability_tmp/invalid-openai.yaml"
 cp .agents/skills/context-start/agents/openai.yaml "$invalid_metadata"
 printf 'malformed: [\n' >> "$invalid_metadata"
-if python3 tests/validate-openai-metadata.py "$invalid_metadata" context-start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py "$invalid_metadata" context-start >/dev/null 2>&1; then
   fail "malformed openai.yaml metadata passed validation"
 fi
 
 invalid_policy="$portability_tmp/string-policy-openai.yaml"
 sed 's/allow_implicit_invocation: false/allow_implicit_invocation: "false"/' \
   .agents/skills/context-start/agents/openai.yaml > "$invalid_policy"
-if python3 tests/validate-openai-metadata.py "$invalid_policy" context-start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py "$invalid_policy" context-start >/dev/null 2>&1; then
   fail "string-valued invocation policy passed validation"
 fi
 
 invalid_prompt="$portability_tmp/prefixed-skill-openai.yaml"
 sed 's/\$context-start /\$context-started /' \
   .agents/skills/context-start/agents/openai.yaml > "$invalid_prompt"
-if python3 tests/validate-openai-metadata.py "$invalid_prompt" context-start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py "$invalid_prompt" context-start >/dev/null 2>&1; then
   fail "prefixed skill token passed metadata validation"
 fi
 
 control_prompt="$portability_tmp/control-prompt-openai.yaml"
 sed 's/brief me/brief\\u000a me/' \
   .agents/skills/context-start/agents/openai.yaml > "$control_prompt"
-if python3 tests/validate-openai-metadata.py "$control_prompt" context-start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py "$control_prompt" context-start >/dev/null 2>&1; then
   fail "escaped control character passed metadata validation"
 fi
 
@@ -164,40 +184,40 @@ tr -d '\r' < .claude/commands/dream.md > "$normalized_dream"
 body_only_command="$portability_tmp/body-only-start.md"
 sed '/^disable-model-invocation: true$/d' "$normalized_start" > "$body_only_command"
 printf '\ndisable-model-invocation: true\n' >> "$body_only_command"
-if python3 tests/validate-openai-metadata.py --command "$body_only_command" start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$body_only_command" start >/dev/null 2>&1; then
   fail "body-only invocation gate passed command validation"
 fi
 
 unrestricted_start="$portability_tmp/unrestricted-start.md"
 sed 's/^allowed-tools:.*/allowed-tools: [Read, Bash]/' "$normalized_start" > "$unrestricted_start"
-if python3 tests/validate-openai-metadata.py --command "$unrestricted_start" start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$unrestricted_start" start >/dev/null 2>&1; then
   fail "unrestricted inline Bash grant passed command validation"
 fi
 
 wildcard_start="$portability_tmp/wildcard-start.md"
 sed 's/^allowed-tools:.*/allowed-tools: "Read, Glob, Bash(gws drive files list:*)"/' "$normalized_start" > "$wildcard_start"
-if python3 tests/validate-openai-metadata.py --command "$wildcard_start" start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$wildcard_start" start >/dev/null 2>&1; then
   fail "gws trailing-wildcard pre-approval passed command validation"
 fi
 
 for bad_scalar in false null 123; do
   typed_command="$portability_tmp/non-string-description-$bad_scalar.md"
   sed "s/^description:.*/description: $bad_scalar/" "$normalized_setup" > "$typed_command"
-  if python3 tests/validate-openai-metadata.py --command "$typed_command" setup >/dev/null 2>&1; then
+  if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$typed_command" setup >/dev/null 2>&1; then
     fail "$bad_scalar command description passed scalar-type validation"
   fi
 done
 
 boolean_tools="$portability_tmp/boolean-tools-start.md"
 sed 's/^allowed-tools:.*/allowed-tools: false/' "$normalized_start" > "$boolean_tools"
-if python3 tests/validate-openai-metadata.py --command "$boolean_tools" start >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$boolean_tools" start >/dev/null 2>&1; then
   fail "boolean allowed-tools passed scalar-type validation"
 fi
 
 duplicate_gate="$portability_tmp/duplicate-gate-dream.md"
 sed '/^disable-model-invocation: true$/a disable-model-invocation: false' \
   "$normalized_dream" > "$duplicate_gate"
-if python3 tests/validate-openai-metadata.py --command "$duplicate_gate" dream >/dev/null 2>&1; then
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$duplicate_gate" dream >/dev/null 2>&1; then
   fail "duplicate false invocation gate passed command validation"
 fi
 
@@ -270,7 +290,7 @@ git -C "$no_remote_fixture" diff --quiet || fail "no-remote default-no path wrot
 
 memory_notice_fixture="$portability_tmp/claude-memory-notice"
 make_setup_fixture "$memory_notice_fixture"
-memory_notice_output=$(printf 'y\n\nn\nn\nn\n' | (cd "$memory_notice_fixture" && PATH="$(dirname "$(command -v python3)"):$(dirname "$(command -v git)"):/usr/bin:/bin" bash scripts/setup.sh --agent claude))
+memory_notice_output=$(printf 'y\n\nn\nn\nn\n' | (cd "$memory_notice_fixture" && PATH="$(dirname "$(command -v "$CONTEXTOS_PYTHON_CMD")"):$(dirname "$(command -v git)"):/usr/bin:/bin" bash scripts/setup.sh --agent claude))
 grep -Fq 'auto-memory is enabled by default' <<<"$memory_notice_output" || fail "local Claude onboarding omitted auto-memory default"
 grep -Fq 'Inspect it with /memory' <<<"$memory_notice_output" || fail "local Claude onboarding omitted /memory inspection"
 grep -Fq 'autoMemoryEnabled: false' <<<"$memory_notice_output" || fail "local Claude onboarding omitted opt-out setting"
@@ -292,9 +312,9 @@ done
 test -f .codex/hooks.json || fail "missing Codex hook adapter"
 test -f adapters/hermes/hooks.example.yaml || fail "missing Hermes hook adapter"
 test -f contextos/__main__.py || fail "missing deterministic lifecycle kernel"
-python3 -m unittest discover -s tests -p 'test_contextos_kernel.py' >/dev/null \
+"$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_contextos_kernel.py' >/dev/null \
   || fail "kernel conformance failed"
-python3 -m unittest discover -s tests -p 'test_runtime_manifests.py' >/dev/null \
+"$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_runtime_manifests.py' >/dev/null \
   || fail "kernel or runtime manifest conformance failed"
 
 echo "Portability checks passed"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -146,6 +146,45 @@ fallback_python=$(
 )
 [ "$fallback_python" = "python" ] || fail "Python resolver did not fall back from python3 to python"
 
+# An explicit CONTEXTOS_PYTHON is an instruction, not a hint. A working override
+# must win, and a broken one must fail loudly instead of silently resolving to a
+# different interpreter than the one that was asked for.
+override_python=$(
+  CONTEXTOS_PYTHON="$resolved_python" "$resolved_bash" -c \
+    'source "$1"; printf "%s" "$CONTEXTOS_PYTHON_CMD"' _ "$ROOT/scripts/python-env.sh"
+)
+[ "$override_python" = "$resolved_python" ] || fail "CONTEXTOS_PYTHON override was not honored"
+
+if CONTEXTOS_PYTHON="$portability_tmp/no-such-python" "$resolved_bash" -c \
+  'source "$1"' _ "$ROOT/scripts/python-env.sh" >/dev/null 2>&1; then
+  fail "unresolvable CONTEXTOS_PYTHON silently fell back to another interpreter"
+fi
+
+# The kernel uses str.removeprefix, so a Python 3 older than 3.9 must be rejected
+# rather than accepted and left to fail later.
+old_python_bin="$portability_tmp/old-python-bin"
+mkdir -p "$old_python_bin"
+printf '#!%s\nif [ "$1" = "-c" ]; then exit 1; fi\nexit 1\n' "$resolved_bash" > "$old_python_bin/python3"
+chmod +x "$old_python_bin/python3"
+old_python_path="$old_python_bin"
+if command -v cygpath >/dev/null 2>&1; then
+  old_python_path=$(cygpath -u "$old_python_bin")
+fi
+if PATH="$old_python_path" CONTEXTOS_PYTHON= "$resolved_bash" -c \
+  'source "$1"' _ "$ROOT/scripts/python-env.sh" >/dev/null 2>&1; then
+  fail "Python resolver accepted an interpreter that failed the version probe"
+fi
+
+# The lifecycle wrapper must run the kernel through the resolver.
+"$resolved_bash" "$ROOT/scripts/contextos.sh" doctor >/dev/null \
+  || fail "scripts/contextos.sh could not run the lifecycle kernel"
+
+# User-facing documentation must use the same interpreter-neutral entry point
+# that setup and lifecycle skills use. CHANGELOG preserves historical commands.
+if git grep -n -F 'python3 -m contextos' -- '*.md' ':(exclude)CHANGELOG.md'; then
+  fail "user-facing documentation bypasses scripts/contextos.sh"
+fi
+
 invalid_metadata="$portability_tmp/invalid-openai.yaml"
 cp .agents/skills/context-start/agents/openai.yaml "$invalid_metadata"
 printf 'malformed: [\n' >> "$invalid_metadata"
@@ -305,8 +344,11 @@ name_line=$(grep -n 'Name to place in CLAUDE.md' scripts/setup.sh | cut -d: -f1)
 test -n "$warning_line" && test -n "$name_line" && test "$warning_line" -lt "$name_line" || fail "privacy warning did not precede personalization"
 
 for skill in context-setup context-update context-end; do
-  grep -Fq 'python3 -m contextos propose' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route mutation through the kernel"
-  grep -Fq 'python3 -m contextos apply' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route approval through the kernel"
+  grep -Fq 'scripts/contextos.sh propose' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route mutation through the kernel"
+  if grep -Fq 'python3 -m contextos' ".agents/skills/$skill/SKILL.md"; then
+    fail "$skill hardcodes python3 instead of the resolved interpreter wrapper"
+  fi
+  grep -Fq 'scripts/contextos.sh apply' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route approval through the kernel"
 done
 
 test -f .codex/hooks.json || fail "missing Codex hook adapter"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -330,6 +330,23 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("warn", initialization["status"])
         self.assertIn("state/current.md", initialization["detail"])
 
+    def test_invalid_or_unreadable_dates_are_unknown_in_every_readiness_consumer(self) -> None:
+        current = self.root / "state/current.md"
+        for content in (
+            b"# Current State\n\n**Last Updated:** 2026-13-01\n",
+            b"# Current State\n\n**Last Updated:** \xff\n",
+        ):
+            current.write_bytes(content)
+            report = start_report(self.root, NOW)
+            self.assertFalse(report["initialized"])
+            self.assertEqual("unknown", report["state"]["state/current.md"]["freshness_status"])
+            self.assertTrue(hook_report(self.root, "session-start", {})["findings"])
+            initialization = next(
+                item for item in doctor(self.root)["checks"]
+                if item["name"] == "initialization-state"
+            )
+            self.assertEqual("warn", initialization["status"])
+
     def test_readiness_predicate_is_shared_by_start_doctor_and_hook(self) -> None:
         """current.md gates readiness, and all three consumers must agree on it."""
         self._write_undated_state("weekly-priorities.md", "blockers.md")

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -123,6 +123,40 @@ class KernelTest(unittest.TestCase):
         decisions = (self.root / "state/decisions.md").read_text(encoding="utf-8")
         self.assertIn("Use proposal \\| apply", decisions)
 
+    def test_end_advances_freshness_for_changed_weekly_priorities_and_blockers(self) -> None:
+        blockers = (self.root / "state/blockers.md").read_text(encoding="utf-8") + "\n- Waiting on review\n"
+        weekly = (self.root / "state/weekly-priorities.md").read_text(encoding="utf-8") + "\n- Ship readiness fix\n"
+        proposal_path, proposal = self._propose(
+            "end",
+            {
+                "what_happened": ["Updated lifecycle state"],
+                "blockers_markdown": blockers,
+                "weekly_priorities_markdown": weekly,
+            },
+        )
+        self._apply(proposal_path, proposal)
+        for filename in ("blockers.md", "weekly-priorities.md"):
+            content = (self.root / "state" / filename).read_text(encoding="utf-8")
+            self.assertIn("**Last Updated:** 2026-08-23", content)
+            self.assertEqual(1, content.count("**Last Updated:**"))
+
+    def test_end_upgrades_legacy_dated_state_without_freshness_metadata(self) -> None:
+        blockers = "# Blockers\n\n- Waiting on review\n"
+        weekly = "# Weekly Priorities\n\n**Week of:** 2026-08-18\n\n1. Ship fix\n"
+        proposal_path, proposal = self._propose(
+            "end",
+            {
+                "what_happened": ["Updated legacy lifecycle state"],
+                "blockers_markdown": blockers,
+                "weekly_priorities_markdown": weekly,
+            },
+        )
+        self._apply(proposal_path, proposal)
+        for filename in ("blockers.md", "weekly-priorities.md"):
+            content = (self.root / "state" / filename).read_text(encoding="utf-8")
+            self.assertIn("**Last Updated:** 2026-08-23", content)
+            self.assertEqual(1, content.count("**Last Updated:**"))
+
     def test_exact_confirmation_and_optimistic_hashes_fail_closed(self) -> None:
         proposal_path, proposal = self._propose("update", {"progress": ["One"]})
         with self.assertRaisesRegex(ContextOSError, "exactly match"):
@@ -237,6 +271,27 @@ class KernelTest(unittest.TestCase):
         self.assertEqual(before, after)
         self.assertFalse(report["state"]["state/current.md"]["stale"])
         self.assertEqual(3, report["state"]["state/current.md"]["age_days"])
+        self.assertEqual("fresh", report["state"]["state/current.md"]["freshness_status"])
+        self.assertTrue(report["initialized"])
+        self.assertIsNone(report["next_action"])
+
+    def test_fresh_clone_reports_setup_required_from_real_templates(self) -> None:
+        for filename in ("current.md", "weekly-priorities.md", "blockers.md"):
+            (self.root / "state" / filename).write_bytes((ROOT / "state" / filename).read_bytes())
+
+        report = start_report(self.root, NOW)
+        self.assertFalse(report["initialized"])
+        self.assertIn("setup workflow", report["next_action"])
+        for item in report["state"].values():
+            self.assertEqual("unknown", item["freshness_status"])
+            self.assertIsNone(item["stale"])
+
+        diagnosis = doctor(self.root)
+        initialization = next(
+            item for item in diagnosis["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("warn", initialization["status"])
+        self.assertIn("guided setup required", initialization["detail"])
 
     def test_install_and_doctor_are_machine_local(self) -> None:
         target, installed = install_runtime(self.root, "hermes")

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -156,6 +156,13 @@ class KernelTest(unittest.TestCase):
             content = (self.root / "state" / filename).read_text(encoding="utf-8")
             self.assertIn("**Last Updated:** 2026-08-23", content)
             self.assertEqual(1, content.count("**Last Updated:**"))
+        weekly_content = (self.root / "state/weekly-priorities.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertLess(
+            weekly_content.index("**Week of:**"),
+            weekly_content.index("**Last Updated:**"),
+        )
 
     def test_exact_confirmation_and_optimistic_hashes_fail_closed(self) -> None:
         proposal_path, proposal = self._propose("update", {"progress": ["One"]})
@@ -292,6 +299,26 @@ class KernelTest(unittest.TestCase):
         )
         self.assertEqual("warn", initialization["status"])
         self.assertIn("guided setup required", initialization["detail"])
+
+    def test_future_dated_state_is_not_treated_as_initialized(self) -> None:
+        (self.root / "state/current.md").write_text(
+            "# Current State\n\n**Last Updated:** 2099-01-01\n",
+            encoding="utf-8",
+        )
+
+        report = start_report(self.root, NOW)
+        current = report["state"]["state/current.md"]
+        self.assertEqual("future", current["freshness_status"])
+        self.assertLess(current["age_days"], 0)
+        self.assertIsNone(current["stale"])
+        self.assertFalse(report["initialized"])
+
+        diagnosis = doctor(self.root)
+        initialization = next(
+            item for item in diagnosis["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("warn", initialization["status"])
+        self.assertIn("state/current.md", initialization["detail"])
 
     def test_install_and_doctor_are_machine_local(self) -> None:
         target, installed = install_runtime(self.root, "hermes")

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -70,6 +70,13 @@ class KernelTest(unittest.TestCase):
     def _apply(self, path: Path, document: dict, runtime: str = "codex"):
         return apply_proposal(self.root, path, document["proposal_digest"], runtime)
 
+    def _write_undated_state(self, *filenames: str) -> None:
+        for filename in filenames:
+            (self.root / "state" / filename).write_text(
+                f"# {filename}\n\n**Last Updated:** [DATE]\n",
+                encoding="utf-8",
+            )
+
     def test_update_propose_apply_writes_receipt_and_history_once(self) -> None:
         current = (
             "# Current State\n\n**Last Updated:** 2026-08-20\n\n"
@@ -283,8 +290,7 @@ class KernelTest(unittest.TestCase):
         self.assertIsNone(report["next_action"])
 
     def test_fresh_clone_reports_setup_required_from_real_templates(self) -> None:
-        for filename in ("current.md", "weekly-priorities.md", "blockers.md"):
-            (self.root / "state" / filename).write_bytes((ROOT / "state" / filename).read_bytes())
+        self._write_undated_state("current.md", "weekly-priorities.md", "blockers.md")
 
         report = start_report(self.root, NOW)
         self.assertFalse(report["initialized"])
@@ -312,6 +318,10 @@ class KernelTest(unittest.TestCase):
         self.assertLess(current["age_days"], 0)
         self.assertIsNone(current["stale"])
         self.assertFalse(report["initialized"])
+        messages = [
+            finding["message"] for finding in hook_report(self.root, "session-start", {})["findings"]
+        ]
+        self.assertTrue(any("not initialized" in message for message in messages), messages)
 
         diagnosis = doctor(self.root)
         initialization = next(
@@ -320,6 +330,68 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("warn", initialization["status"])
         self.assertIn("state/current.md", initialization["detail"])
 
+    def test_readiness_predicate_is_shared_by_start_doctor_and_hook(self) -> None:
+        """current.md gates readiness, and all three consumers must agree on it."""
+        self._write_undated_state("weekly-priorities.md", "blockers.md")
+
+        # current.md is dated; the other two are untouched shipped templates.
+        report = start_report(self.root, NOW)
+        self.assertTrue(report["initialized"])
+        self.assertIsNone(report["next_action"])
+        self.assertEqual([], hook_report(self.root, "session-start", {})["findings"])
+        initialization = next(
+            item for item in doctor(self.root)["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("pass", initialization["status"])
+
+        # Reverting current.md to the template must flip all three together.
+        self._write_undated_state("current.md")
+        self.assertFalse(start_report(self.root, NOW)["initialized"])
+        messages = [
+            finding["message"] for finding in hook_report(self.root, "session-start", {})["findings"]
+        ]
+        self.assertTrue(any("not initialized" in message for message in messages), messages)
+        initialization = next(
+            item for item in doctor(self.root)["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("warn", initialization["status"])
+
+    def test_unset_optional_state_is_reported_without_blocking_readiness(self) -> None:
+        """An empty blockers file is a valid steady state, not an unfinished setup."""
+        self._write_undated_state("blockers.md")
+        report = start_report(self.root, NOW)
+        self.assertTrue(report["initialized"])
+        self.assertEqual("unknown", report["state"]["state/blockers.md"]["freshness_status"])
+        freshness = next(
+            item for item in doctor(self.root)["checks"] if item["name"] == "state-freshness"
+        )
+        self.assertEqual("warn", freshness["status"])
+        self.assertIn("state/blockers.md", freshness["detail"])
+
+    def test_next_action_names_the_command_to_run(self) -> None:
+        self._write_undated_state("current.md")
+        self.assertIn("scripts/setup.sh", start_report(self.root, NOW)["next_action"])
+
+    def test_setup_stamps_freshness_on_tracked_state_files(self) -> None:
+        """A completed setup must report as initialized without hand-written dates."""
+        payload = {
+            "files": {
+                "state/current.md": (
+                    "# Current State\n\n## Active priorities\n\n1. Ship the fix\n"
+                ),
+                "state/blockers.md": (
+                    "# Blockers\n\n**Last Updated:** [DATE]\n\n- Waiting on review\n"
+                ),
+            },
+            "replace_populated": ["state/current.md", "state/blockers.md"],
+        }
+        proposal_path, proposal = self._propose("setup", payload)
+        self._apply(proposal_path, proposal)
+        for filename in ("current.md", "blockers.md"):
+            content = (self.root / "state" / filename).read_text(encoding="utf-8")
+            self.assertIn("**Last Updated:** 2026-08-23", content)
+            self.assertEqual(1, content.count("**Last Updated:**"))
+        self.assertTrue(start_report(self.root, NOW)["initialized"])
     def test_install_and_doctor_are_machine_local(self) -> None:
         target, installed = install_runtime(self.root, "hermes")
         self.assertEqual(self.root / ".context-os/runtime.json", target)

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WRAPPER = ROOT / "scripts/context-os-hook.py"
+WINDOWS_WRAPPER = ROOT / "scripts/context-os-hook.ps1"
 
 
 class CrossRuntimeHookTest(unittest.TestCase):
@@ -26,11 +29,142 @@ class CrossRuntimeHookTest(unittest.TestCase):
         config = json.loads((ROOT / ".codex/hooks.json").read_text(encoding="utf-8"))
         self.assertEqual({"SessionStart", "PreToolUse"}, set(config["hooks"]))
         serialized = json.dumps(config)
-        self.assertIn("context-os-hook.py", serialized)
+        self.assertIn("context-os-hook.sh", serialized)
+        self.assertIn("context-os-hook.ps1", serialized)
         self.assertIn("commandWindows", serialized)
         self.assertIn("powershell.exe", serialized)
+        self.assertNotIn("; python ", serialized)
+        hermes_readme = (ROOT / "adapters/hermes/README.md").read_text(encoding="utf-8")
+        self.assertIn("context-os-hook.ps1", hermes_readme)
+        self.assertNotIn("; python ", hermes_readme)
         pre_tool = config["hooks"]["PreToolUse"][0]
         self.assertEqual("^apply_patch$", pre_tool["matcher"])
+
+    @unittest.skipUnless(sys.platform == "win32", "native PowerShell adapter test")
+    def test_windows_wrapper_honors_override_and_hook_controls(self) -> None:
+        environment = os.environ.copy()
+        environment.pop("CONTEXTOS_PYTHON", None)
+        config = json.loads((ROOT / ".codex/hooks.json").read_text(encoding="utf-8"))
+        production_pre_write = config["hooks"]["PreToolUse"][0]["hooks"][0]["commandWindows"]
+        command = [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_WRAPPER),
+            "codex",
+            "pre-write",
+        ]
+
+        # Native Windows CI exercises the exact production command. When the
+        # Python suite itself is launched below MSYS, use -File because the
+        # parent shell changes stdin-handle behavior before PowerShell starts.
+        must_fire_command = command if os.environ.get("MSYSTEM") else production_pre_write
+
+        must_fire = subprocess.run(
+            must_fire_command,
+            cwd=ROOT,
+            env=environment,
+            input=json.dumps({"tool_input": {"file_path": str(ROOT / "state/current.md")}}),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, must_fire.returncode, must_fire.stderr)
+        self.assertIn("proposal/apply", json.loads(must_fire.stdout)["systemMessage"])
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fake_python = Path(temporary_directory) / "python.cmd"
+            fake_python.write_text(
+                '@echo off\nif "%~1"=="-c" exit /b 0\n'
+                'echo {"systemMessage":"%~3 forwarded"}\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(fake_python)
+            session_start = subprocess.run(
+                [*command[:-1], "session-start"],
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, session_start.returncode, session_start.stderr)
+            self.assertEqual(
+                "session-start forwarded",
+                json.loads(session_start.stdout)["systemMessage"],
+            )
+
+            chatty_python = Path(temporary_directory) / "chatty-python.cmd"
+            chatty_python.write_text(
+                '@echo off\necho not-a-working-interpreter\nexit /b 1\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(chatty_python)
+            rejected_chatty_override = subprocess.run(
+                command,
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(0, rejected_chatty_override.returncode)
+            self.assertEqual("", rejected_chatty_override.stdout)
+            self.assertIn("never silently replaced", rejected_chatty_override.stderr)
+
+            stderr_python = Path(temporary_directory) / "stderr-python.cmd"
+            stderr_python.write_text(
+                '@echo off\nif "%~1"=="-c" (echo harmless-probe-warning 1>&2 & exit /b 0)\n'
+                'echo {"systemMessage":"%~3 forwarded"}\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(stderr_python)
+            accepted_stderr_override = subprocess.run(
+                [*command[:-1], "session-start"],
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, accepted_stderr_override.returncode, accepted_stderr_override.stderr)
+            self.assertEqual(
+                "session-start forwarded",
+                json.loads(accepted_stderr_override.stdout)["systemMessage"],
+            )
+
+        environment["CONTEXTOS_PYTHON"] = sys.executable
+        must_not_fire = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            input=json.dumps({"tool_input": {"file_path": str(ROOT / "README.md")}}),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, must_not_fire.returncode, must_not_fire.stderr)
+        self.assertEqual("", must_not_fire.stdout)
+
+        environment["CONTEXTOS_PYTHON"] = str(ROOT / "no-such-python")
+        invalid_override = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            input="{}",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(0, invalid_override.returncode)
+        self.assertIn(str(ROOT / "no-such-python"), invalid_override.stderr)
+        self.assertIn("never silently replaced", invalid_override.stderr)
 
     def test_codex_pre_write_must_fire_control(self) -> None:
         result = self.run_hook(


### PR DESCRIPTION
Closes #42. Makes fresh-clone readiness and freshness reporting truthful, migrates timestamps safely for existing workspaces, rejects future-dated state as initialized, and supports Python 3 through either python3 or python. Validation: scripts/validate-all.sh (172 tests, 11 skipped; all checks passed).