### PR TITLE
Give workspace readiness one definition

### DIFF
--- a/.agents/skills/context-end/SKILL.md
+++ b/.agents/skills/context-end/SKILL.md
@@ -28,7 +28,7 @@ Create a reviewed JSON payload under `.context-os/inputs/` with:
   `blockers_markdown`, or `weekly_priorities_markdown`, only when that state
   materially changed.
 
-Run `python3 -m contextos propose end --input <payload.json>`. The kernel owns
+Run `bash scripts/contextos.sh propose end --input <payload.json>`. The kernel owns
 session append behavior, decision rows, dates, exact paths, the single
 `Last Updated` line, and same-day history. Present every returned diff and its
 proposal digest. The digest binds the exact content but does not authenticate a
@@ -39,7 +39,7 @@ human approver; rely on the host permission boundary for explicit confirmation.
 After explicit approval of that exact diff, run:
 
 ```text
-python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-runtime>
 ```
 
 The kernel must refuse altered proposals, changed targets, path escapes, or a

--- a/.agents/skills/context-setup/SKILL.md
+++ b/.agents/skills/context-setup/SKILL.md
@@ -50,13 +50,13 @@ mapping repository-relative paths to complete desired content. Add a path to
 `replace_populated` only after explicit approval to replace that populated file.
 Use `{{TODAY}}` where the deterministic local date belongs.
 
-Run `python3 -m contextos propose setup --input <payload.json>`. Present every
+Run `bash scripts/contextos.sh propose setup --input <payload.json>`. Present every
 returned diff and its proposal digest. The digest binds the exact content but
 does not authenticate a human approver; rely on the host permission boundary.
 After explicit approval of that exact proposal, run:
 
 ```text
-python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-runtime>
 ```
 
 The kernel must refuse path escapes, writes outside context paths, unapproved

--- a/.agents/skills/context-start/SKILL.md
+++ b/.agents/skills/context-start/SKILL.md
@@ -9,10 +9,10 @@ Resume from durable repository state instead of reconstructing context from chat
 
 ## Procedure
 
-1. Run `python3 -m contextos start` from the repository root. Treat its JSON as
+1. Run `bash scripts/contextos.sh start` from the repository root. Treat its JSON as
    the deterministic inventory of configured paths, freshness, latest session,
    and repository revision. If the kernel is unavailable, stop and recommend
-   `python3 -m contextos doctor`; do not silently substitute another lifecycle
+   `bash scripts/contextos.sh doctor`; do not silently substitute another lifecycle
    implementation.
 2. Determine today's local date and day of week. Read `ROUTING.md`, then load:
    - the configured `current.md`;

--- a/.agents/skills/context-update/SKILL.md
+++ b/.agents/skills/context-update/SKILL.md
@@ -19,7 +19,7 @@ Save continuity with minimal churn through the deterministic lifecycle kernel.
 3. Run:
 
    ```text
-   python3 -m contextos propose update --input <payload.json>
+   bash scripts/contextos.sh propose update --input <payload.json>
    ```
 
    The kernel owns session append behavior, dates, the single `Last Updated`
@@ -29,7 +29,7 @@ Save continuity with minimal churn through the deterministic lifecycle kernel.
 4. Wait for explicit approval of that exact proposal. Then run:
 
    ```text
-   python3 -m contextos apply <proposal> --confirm <digest> --runtime <active-runtime>
+   bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-runtime>
    ```
 
    If any target changed after proposal creation, create and review a new

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" codex session-start",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex session-start\"",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"$root = git rev-parse --show-toplevel; & (Join-Path $root 'scripts/context-os-hook.ps1') codex session-start\"",
             "timeout": 10
           }
         ]
@@ -21,7 +21,7 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" codex pre-write",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex pre-write\"",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"$root = git rev-parse --show-toplevel; & (Join-Path $root 'scripts/context-os-hook.ps1') codex pre-write\"",
             "timeout": 10
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" codex session-start",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" codex session-start",
             "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex session-start\"",
             "timeout": 10
           }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" codex pre-write",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" codex pre-write",
             "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"$root = git rev-parse --show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') codex pre-write\"",
             "timeout": 10
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,12 @@ remain supported.
 
 ## Lifecycle kernel
 
-- `python3 -m contextos start` is the read-only continuity inventory.
+- `bash scripts/contextos.sh start` is the read-only continuity inventory.
 - Setup, update, and end use `propose` then exact-digest `apply`; never edit
   lifecycle state directly.
 - Present every proposal diff. Apply only after explicit approval of that exact
   proposal and report its receipt.
-- Run `python3 -m contextos doctor` when discovery, runtime setup, a lock, or
+- Run `bash scripts/contextos.sh doctor` when discovery, runtime setup, a lock, or
   copied skills may be stale.
 
 ## Context routing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - Workspace readiness now has one definition. `start`, `doctor`, and the session-start hook share a single predicate keyed on `state/current.md`; previously the hook and `start` could report opposite verdicts for the same workspace. `weekly-priorities.md` and `blockers.md` freshness is still reported, under a separate `state-freshness` check, but no longer gates readiness — leaving them empty is a valid steady state, not an unfinished setup.
+- Future-dated `state/current.md` timestamps no longer satisfy the shared readiness predicate, and the native Windows Codex hooks now honor the same `CONTEXTOS_PYTHON` override and Python 3.9 floor as POSIX hooks.
 - `setup` now stamps `**Last Updated:**` on the state files that `start` and `doctor` read, so a completed setup reports as initialized without depending on the agent to hand-write the line.
 - `start`'s `next_action` names the command to run instead of referring to "the explicit setup workflow" abstractly.
 - `CONTEXTOS_PYTHON` is honored exactly: an override that does not resolve to a working interpreter now fails loudly instead of silently falling back to a different one. The interpreter floor is Python 3.9, matching the kernel's use of `str.removeprefix`, instead of any Python 3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,15 @@
 - `state/current-log.md`, the seed file required by the shared checkpoint and close workflows.
 - A validated, opt-in integrations catalog with generated documentation, explicit credential/data/side-effect boundaries, and no automatic installation or activation. Initial links cover Agent Skills, Agent Workspace, AI Tools for Creators, and Substack MCP.
 - Reviewed optional entries for Tolaria MCP, the official Obsidian CLI, Beads for Gemini CLI, and Granola's hosted MCP, with conservative sensitive-read, remote-write, overwrite, deletion, arbitrary-execution, publish, destructive, OAuth, retention, residency, and transcript gates.
+- `scripts/contextos.sh` and `scripts/context-os-hook.sh`, thin wrappers that run the lifecycle kernel and hook entry point through `scripts/python-env.sh`. The Codex and Hermes hook adapters and the four lifecycle skills now use them instead of hardcoding `python3`.
+- `CONTEXTOS_PYTHON` for pinning an explicit interpreter, documented in the getting-started prerequisites.
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- Workspace readiness now has one definition. `start`, `doctor`, and the session-start hook share a single predicate keyed on `state/current.md`; previously the hook and `start` could report opposite verdicts for the same workspace. `weekly-priorities.md` and `blockers.md` freshness is still reported, under a separate `state-freshness` check, but no longer gates readiness — leaving them empty is a valid steady state, not an unfinished setup.
+- `setup` now stamps `**Last Updated:**` on the state files that `start` and `doctor` read, so a completed setup reports as initialized without depending on the agent to hand-write the line.
+- `start`'s `next_action` names the command to run instead of referring to "the explicit setup workflow" abstractly.
+- `CONTEXTOS_PYTHON` is honored exactly: an override that does not resolve to a working interpreter now fails loudly instead of silently falling back to a different one. The interpreter floor is Python 3.9, matching the kernel's use of `str.removeprefix`, instead of any Python 3.
 - `scripts/setup.sh` no longer relies on GNU-only `sed -i`; literal-name replacement and sample-route cleanup now use the documented Python 3 dependency.
 - Replaced the deprecated Notion npm-server instructions with Notion's hosted OAuth MCP path for Claude Code and Codex.
 - Aligned manual claude.ai setup prompts with portable skill paths and approval-gated local setup instead of claiming slash-command or commit parity.

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -12,9 +12,9 @@ runtimes. Merge it into user configuration only after reviewing its commands.
 Kernel proposal/apply enforcement does not depend on these hooks.
 
 The YAML example is POSIX-oriented. On Windows, use an equivalent command such
-as `powershell.exe -NoProfile -NonInteractive -Command "$root = git rev-parse
---show-toplevel; python (Join-Path $root 'scripts/context-os-hook.py') hermes
-pre-write"` for the pre-tool event (and replace `pre-write` with
+as `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+"$root = git rev-parse --show-toplevel; & (Join-Path $root
+'scripts/context-os-hook.ps1') hermes pre-write"` for the pre-tool event (and replace `pre-write` with
 `session-start` for the session event). Hermes hook policy remains advisory.
 
 Hermes `MEMORY.md` and `USER.md` remain host-local. Never point the kernel at

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,9 +1,9 @@
 # Hermes adapter
 
-Run `python3 -m contextos install --runtime hermes` from the repository root.
+Run `bash scripts/contextos.sh install --runtime hermes` from the repository root.
 Expose `.agents/skills/` as an external Hermes skill directory, or install the
 four short aliases together with their four `context-*` cores. Hermes copies
-installed skills, so `python3 -m contextos doctor --runtime hermes` should be
+installed skills, so `bash scripts/contextos.sh doctor --runtime hermes` should be
 part of updates and copied skills should be refreshed after a source change.
 
 The optional [`hooks.example.yaml`](hooks.example.yaml) maps Hermes lifecycle

--- a/adapters/hermes/hooks.example.yaml
+++ b/adapters/hermes/hooks.example.yaml
@@ -1,8 +1,8 @@
 # Merge only after reviewing the exact commands and Hermes hook trust boundary.
 hooks:
   - event: on_session_start
-    command: "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" hermes session-start"
+    command: "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" hermes session-start"
   - event: pre_tool_call
-    command: "python3 \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.py\" hermes pre-write"
+    command: "bash \"$(git rev-parse --show-toplevel)/scripts/context-os-hook.sh\" hermes pre-write"
     when:
       tools: [patch, write_file, terminal]

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -21,6 +21,12 @@ LAST_UPDATED_RE = re.compile(r"^\*\*Last Updated:\*\*\s*(.+?)\s*$", re.MULTILINE
 REAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 SETUP_ROOTS = {"identity", "projects", "state"}
 SETUP_FILES = {"ROUTING.md", "TODO.md", "CLAUDE.md", "AGENTS.md"}
+STATE_THRESHOLDS = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
+INITIALIZATION_FILE = "current.md"
+SETUP_NEXT_ACTION = (
+    "Run the explicit setup workflow (bash scripts/setup.sh, then the $context-setup "
+    "skill) before starting a session."
+)
 RUNTIME_NAMES = {"claude", "codex", "hermes"}
 CAPABILITY_VALUES = {"native", "adapter", "advisory", "unsupported"}
 CAPABILITY_KEYS = {
@@ -185,7 +191,7 @@ def _advance_current(
         pending[history] = f"{before}{marker}\n\n{old_date}\n\n{after.lstrip()}"
 
 
-def _advance_dated_state(path: Path, desired: str, today: str) -> str:
+def _advance_dated_state(path: Path, desired: str, today: str, required: bool = True) -> str:
     label = path.as_posix()
     normalized = desired.rstrip() + "\n"
     matches = LAST_UPDATED_RE.findall(normalized)
@@ -199,6 +205,10 @@ def _advance_dated_state(path: Path, desired: str, today: str) -> str:
     # their next lifecycle write instead of failing setup or session end.
     lines = normalized.splitlines()
     if not lines or not lines[0].startswith("# "):
+        # Setup stamps reviewed content opportunistically; a lifecycle write to a
+        # file the kernel already owns must not silently skip the timestamp.
+        if not required:
+            return normalized
         raise ContextOSError(
             f"{label} must begin with a level-one heading when adding **Last Updated:**"
         )
@@ -302,6 +312,11 @@ def render_setup(workspace: Workspace, payload: dict[str, Any], now: datetime) -
     replace = set(ensure_string_list(payload.get("replace_populated"), "replace_populated"))
     if not isinstance(files, dict) or not files:
         raise ContextOSError("files must be a non-empty object mapping paths to content")
+    today = now.strftime("%Y-%m-%d")
+    # Setup owns the freshness line on the state files start/doctor read, so a
+    # completed setup reports as initialized without relying on the agent to
+    # hand-write **Last Updated:** into reviewed content.
+    dated_state = {workspace.state_dir / filename for filename in STATE_THRESHOLDS}
     pending: dict[Path, str] = {}
     for raw_path, raw_content in files.items():
         if not isinstance(raw_path, str):
@@ -312,9 +327,11 @@ def render_setup(workspace: Workspace, payload: dict[str, Any], now: datetime) -
         skill_path = len(Path(relative).parts) >= 3 and Path(relative).parts[:2] == (".agents", "skills")
         if top not in SETUP_ROOTS and relative not in SETUP_FILES and not skill_path:
             raise ContextOSError(f"setup cannot write outside approved context paths: {relative}")
-        content = ensure_text(raw_content, f"files[{raw_path}]").replace("{{TODAY}}", now.strftime("%Y-%m-%d"))
+        content = ensure_text(raw_content, f"files[{raw_path}]").replace("{{TODAY}}", today)
         if path.exists() and _is_populated(path.read_text(encoding="utf-8")) and relative not in replace:
             raise ContextOSError(f"populated file requires replace_populated approval: {relative}")
+        if path in dated_state:
+            content = _advance_dated_state(path, content, today, required=False)
         pending[path] = content.rstrip() + "\n"
     return pending
 
@@ -635,20 +652,34 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     }
 
 
+def _is_initialized(workspace: Workspace) -> bool:
+    """Single readiness predicate shared by start, doctor, and the session hook.
+
+    Only current.md gates readiness. weekly-priorities.md and blockers.md are
+    legitimately left at their shipped template by users who have neither, so
+    requiring a real date on all three would report an initialized workspace as
+    needing setup forever. Their freshness is still reported separately.
+    """
+    current = workspace.state_dir / INITIALIZATION_FILE
+    if not current.exists():
+        return False
+    content = current.read_text(encoding="utf-8")
+    if PLACEHOLDER_DATE in content:
+        return False
+    match = LAST_UPDATED_RE.search(content)
+    return bool(match and REAL_DATE_RE.fullmatch(match.group(1).strip()))
+
+
 def _initialization_state(
     workspace: Workspace, today: date
 ) -> tuple[bool, dict[str, dict[str, Any]]]:
-    thresholds = {"current.md": 3, "weekly-priorities.md": 5, "blockers.md": 7}
     state = {
         relative_path(workspace.root, workspace.state_dir / filename): _state_freshness(
             workspace.state_dir / filename, today, threshold
         )
-        for filename, threshold in thresholds.items()
+        for filename, threshold in STATE_THRESHOLDS.items()
     }
-    initialized = all(
-        item["freshness_status"] in {"fresh", "stale"} for item in state.values()
-    )
-    return initialized, state
+    return _is_initialized(workspace), state
 
 
 def start_report(root: Path, now: datetime) -> dict[str, Any]:
@@ -659,7 +690,7 @@ def start_report(root: Path, now: datetime) -> dict[str, Any]:
         "schema_version": SCHEMA_VERSION,
         "generated_at": now.isoformat(),
         "initialized": initialized,
-        "next_action": None if initialized else "Run the explicit setup workflow before starting a session.",
+        "next_action": None if initialized else SETUP_NEXT_ACTION,
         "state": files,
         "latest_session": relative_path(root, sessions[0]) if sessions else None,
         "task_file": relative_path(root, workspace.task_file),
@@ -700,14 +731,22 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
         rel = relative_path(root, path)
         add(f"file:{rel}", "pass" if path.exists() else "fail", rel)
     initialized, initialization_files = _initialization_state(workspace, utc_now().date())
-    unknown = [
+    gate = relative_path(root, workspace.state_dir / INITIALIZATION_FILE)
+    add(
+        "initialization-state",
+        "pass" if initialized else "warn",
+        "ready" if initialized else f"guided setup required; {gate} carries no real **Last Updated:** date",
+    )
+    unresolved = [
         path for path, item in initialization_files.items()
         if item["freshness_status"] in {"missing", "unknown", "future"}
     ]
     add(
-        "initialization-state",
-        "pass" if initialized else "warn",
-        "ready" if initialized else f"guided setup required; unresolved freshness: {', '.join(unknown)}",
+        "state-freshness",
+        "pass" if not unresolved else "warn",
+        "all tracked state files carry a real date"
+        if not unresolved
+        else f"no usable **Last Updated:** date in: {', '.join(unresolved)}",
     )
     selected = runtime
     local_runtime = root / ".context-os" / "runtime.json"
@@ -778,9 +817,8 @@ def hook_report(root: Path, event: str, payload: dict[str, Any]) -> dict[str, An
     findings: list[dict[str, str]] = []
     workspace = load_workspace(root)
     if event == "session-start":
-        current = workspace.state_dir / "current.md"
-        if current.exists() and PLACEHOLDER_DATE in current.read_text(encoding="utf-8"):
-            findings.append({"severity": "advisory", "message": "Context OS is not initialized; run the explicit setup workflow."})
+        if not _is_initialized(workspace):
+            findings.append({"severity": "advisory", "message": f"Context OS is not initialized. {SETUP_NEXT_ACTION}"})
         lock = root / ".context-os" / "apply.lock"
         if lock.exists():
             findings.append({"severity": "warning", "message": f"A lifecycle apply lock exists at {lock}. Run context-os doctor before writing."})

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -652,7 +652,7 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     }
 
 
-def _is_initialized(workspace: Workspace) -> bool:
+def _is_initialized(workspace: Workspace, today: date | None = None) -> bool:
     """Single readiness predicate shared by start, doctor, and the session hook.
 
     Only current.md gates readiness. weekly-priorities.md and blockers.md are
@@ -661,13 +661,12 @@ def _is_initialized(workspace: Workspace) -> bool:
     needing setup forever. Their freshness is still reported separately.
     """
     current = workspace.state_dir / INITIALIZATION_FILE
-    if not current.exists():
-        return False
-    content = current.read_text(encoding="utf-8")
-    if PLACEHOLDER_DATE in content:
-        return False
-    match = LAST_UPDATED_RE.search(content)
-    return bool(match and REAL_DATE_RE.fullmatch(match.group(1).strip()))
+    freshness = _state_freshness(
+        current,
+        today if today is not None else utc_now().date(),
+        STATE_THRESHOLDS[INITIALIZATION_FILE],
+    )
+    return freshness["freshness_status"] in {"fresh", "stale"}
 
 
 def _initialization_state(
@@ -679,7 +678,7 @@ def _initialization_state(
         )
         for filename, threshold in STATE_THRESHOLDS.items()
     }
-    return _is_initialized(workspace), state
+    return _is_initialized(workspace, today), state
 
 
 def start_report(root: Path, now: datetime) -> dict[str, Any]:

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -17,13 +17,13 @@ Use `$start`, `$update`, and `$end` for the daily loop. The namespaced
 Setup records a gitignored local runtime selection. Inspect it with:
 
 ```bash
-python3 -m contextos doctor --runtime codex
+bash scripts/contextos.sh doctor --runtime codex
 ```
 
 ## Deterministic writes
 
 The skills do not directly mutate lifecycle state. They create reviewed input,
-run `python3 -m contextos propose`, present exact diffs, and run `apply` only
+run `bash scripts/contextos.sh propose`, present exact diffs, and run `apply` only
 after the user approves the displayed digest. The receipt is the portable proof
 of which paths and hashes changed. The kernel never commits or pushes.
 
@@ -57,7 +57,7 @@ SSOTs.
 ## Verify
 
 ```bash
-python3 -m contextos doctor --runtime codex
+bash scripts/contextos.sh doctor --runtime codex
 bash scripts/validate-all.sh
 ```
 

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -20,9 +20,9 @@ Claude files are host adapters. All lifecycle names require explicit invocation.
 The mutation protocol is always:
 
 1. the agent drafts reviewed JSON input under ignored `.context-os/inputs/`;
-2. `python3 -m contextos propose` emits exact diffs and a proposal digest;
+2. `bash scripts/contextos.sh propose` emits exact diffs and a proposal digest;
 3. the agent presents those diffs and waits;
-4. `python3 -m contextos apply` receives that exact digest; and
+4. `bash scripts/contextos.sh apply` receives that exact digest; and
 5. the kernel verifies target hashes, takes an exclusive lock, writes only the
    proposal paths, and records a receipt.
 
@@ -76,5 +76,5 @@ import safe. Their Claude adapters appear in the command index below.
 Uploading these files to claude.ai does not activate commands, hooks, tool
 permissions, or skill metadata. See `docs/claude-projects-sync.md`.
 
-Run `python3 -m contextos doctor` for runtime and state diagnostics, then
+Run `bash scripts/contextos.sh doctor` for runtime and state diagnostics, then
 `bash scripts/validate-all.sh` after repository changes.

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -10,7 +10,7 @@ models, tool names, or native memory.
    the durable, reviewable source of truth.
 2. **Portable intent:** `.agents/skills/context-*` gathers facts and asks for
    judgment without owning mutation mechanics.
-3. **Deterministic kernel:** `python3 -m contextos` owns paths, rendering,
+3. **Deterministic kernel:** `bash scripts/contextos.sh` owns paths, rendering,
    invariants, proposals, locks, optimistic hashes, applies, and receipts.
 4. **Runtime adapters:** `.claude/`, `.codex/`, and `adapters/hermes/` map host
    discovery and hooks to the portable layers.
@@ -20,11 +20,11 @@ models, tool names, or native memory.
 ## Commands
 
 ```text
-python3 -m contextos start [--now ISO_TIMESTAMP]
-python3 -m contextos propose setup|update|end --input payload.json [--now ISO_TIMESTAMP]
-python3 -m contextos apply proposal.json --confirm SHA256 --runtime claude|codex|hermes
-python3 -m contextos install --runtime claude|codex|hermes
-python3 -m contextos doctor [--runtime claude|codex|hermes]
+bash scripts/contextos.sh start [--now ISO_TIMESTAMP]
+bash scripts/contextos.sh propose setup|update|end --input payload.json [--now ISO_TIMESTAMP]
+bash scripts/contextos.sh apply proposal.json --confirm SHA256 --runtime claude|codex|hermes
+bash scripts/contextos.sh install --runtime claude|codex|hermes
+bash scripts/contextos.sh doctor [--runtime claude|codex|hermes]
 ```
 
 `--now` exists for deterministic fixtures. Production calls use local time.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,9 +6,15 @@ Codex, and Hermes can use as shared state.
 
 ## Before you clone
 
-You need Git, Bash, Python 3, and at least one supported local agent: Claude
-Code, Codex, or Hermes. claude.ai can help produce files but cannot maintain a
-local checkout directly.
+You need Git, Bash, Python 3.9 or newer, and at least one supported local
+agent: Claude Code, Codex, or Hermes. claude.ai can help produce files but
+cannot maintain a local checkout directly.
+
+Python may be installed as either `python3` or `python`; the repository resolves
+whichever works. To pin a specific interpreter — a virtualenv, or one of several
+installed versions — set `CONTEXTOS_PYTHON` to its path or command. That setting
+is honored exactly: if it does not resolve to a working Python 3.9+, setup and
+validation stop instead of falling back to a different interpreter.
 
 Decide where the repository will live. If it will contain personal, client, employer, financial, or unpublished project context, use a private remote. Repository visibility is only one control; do not store credentials, raw account exports, or information you would not want every configured agent to read.
 
@@ -96,7 +102,7 @@ Remove any unsupported inference, stale claim, duplicate fact, or context that i
 Then run:
 
 ```bash
-python3 -m contextos doctor
+bash scripts/contextos.sh doctor
 bash scripts/validate-all.sh
 git diff --check
 git status --short

--- a/scripts/context-os-hook.ps1
+++ b/scripts/context-os-hook.ps1
@@ -11,8 +11,12 @@ function Test-ContextOsPython {
     if (-not (Get-Command -Name $Candidate -ErrorAction SilentlyContinue)) {
         return $false
     }
-    & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" 2>$null
-    return $LASTEXITCODE -eq 0
+    try {
+        & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" 2>$null
+        return $LASTEXITCODE -eq 0
+    } catch {
+        return $false
+    }
 }
 
 $pythonCommand = $null
@@ -20,7 +24,8 @@ if ($env:CONTEXTOS_PYTHON) {
     if (Test-ContextOsPython $env:CONTEXTOS_PYTHON) {
         $pythonCommand = $env:CONTEXTOS_PYTHON
     } else {
-        Write-Error "CONTEXTOS_PYTHON is not a working Python 3.9+ interpreter. Fix or unset it; an explicit interpreter is never silently replaced."
+        [Console]::Error.WriteLine("CONTEXTOS_PYTHON is set to '$($env:CONTEXTOS_PYTHON)', which is not a working Python 3.9+ interpreter.")
+        [Console]::Error.WriteLine("Fix or unset it; an explicit interpreter is never silently replaced with another one.")
         exit 1
     }
 } else {
@@ -33,7 +38,7 @@ if ($env:CONTEXTOS_PYTHON) {
 }
 
 if (-not $pythonCommand) {
-    Write-Error "Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON."
+    [Console]::Error.WriteLine("Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON.")
     exit 1
 }
 

--- a/scripts/context-os-hook.ps1
+++ b/scripts/context-os-hook.ps1
@@ -12,7 +12,7 @@ function Test-ContextOsPython {
         return $false
     }
     try {
-        & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" 2>$null
+        & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >$null 2>&1
         return $LASTEXITCODE -eq 0
     } catch {
         return $false

--- a/scripts/context-os-hook.ps1
+++ b/scripts/context-os-hook.ps1
@@ -11,12 +11,18 @@ function Test-ContextOsPython {
     if (-not (Get-Command -Name $Candidate -ErrorAction SilentlyContinue)) {
         return $false
     }
+    $previousErrorActionPreference = $ErrorActionPreference
+    $probeSucceeded = $false
     try {
-        & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >$null 2>&1
-        return $LASTEXITCODE -eq 0
+        $ErrorActionPreference = "Continue"
+        & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" >$null 2>$null
+        $probeSucceeded = $LASTEXITCODE -eq 0
     } catch {
-        return $false
+        $probeSucceeded = $false
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
     }
+    return $probeSucceeded
 }
 
 $pythonCommand = $null

--- a/scripts/context-os-hook.ps1
+++ b/scripts/context-os-hook.ps1
@@ -1,0 +1,41 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$HookArguments
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-ContextOsPython {
+    param([string]$Candidate)
+
+    if (-not (Get-Command -Name $Candidate -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+    & $Candidate -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)" 2>$null
+    return $LASTEXITCODE -eq 0
+}
+
+$pythonCommand = $null
+if ($env:CONTEXTOS_PYTHON) {
+    if (Test-ContextOsPython $env:CONTEXTOS_PYTHON) {
+        $pythonCommand = $env:CONTEXTOS_PYTHON
+    } else {
+        Write-Error "CONTEXTOS_PYTHON is not a working Python 3.9+ interpreter. Fix or unset it; an explicit interpreter is never silently replaced."
+        exit 1
+    }
+} else {
+    foreach ($candidate in @("python3", "python")) {
+        if (Test-ContextOsPython $candidate) {
+            $pythonCommand = $candidate
+            break
+        }
+    }
+}
+
+if (-not $pythonCommand) {
+    Write-Error "Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON."
+    exit 1
+}
+
+& $pythonCommand (Join-Path $PSScriptRoot "context-os-hook.py") @HookArguments
+exit $LASTEXITCODE

--- a/scripts/context-os-hook.sh
+++ b/scripts/context-os-hook.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# POSIX hook entry point. Wraps context-os-hook.py with the repository's
+# resolved Python interpreter so hosts that expose Python 3 only as `python`
+# still get lifecycle advisories.
+#
+#   bash scripts/context-os-hook.sh codex session-start
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/python-env.sh"
+
+exec "$CONTEXTOS_PYTHON_CMD" "$SCRIPT_DIR/context-os-hook.py" "$@"

--- a/scripts/contextos.sh
+++ b/scripts/contextos.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the lifecycle kernel with the repository's resolved Python interpreter.
+# Use this instead of `python3 -m contextos` so hosts that expose Python 3 only
+# as `python` work, and so CONTEXTOS_PYTHON is honored.
+#
+#   bash scripts/contextos.sh start
+#   bash scripts/contextos.sh propose end --input <payload.json>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/python-env.sh"
+
+cd "$(cd "$SCRIPT_DIR/.." && pwd)"
+exec "$CONTEXTOS_PYTHON_CMD" -m contextos "$@"

--- a/scripts/python-env.sh
+++ b/scripts/python-env.sh
@@ -1,25 +1,43 @@
 #!/usr/bin/env bash
-# Resolve one working Python 3 command for repository shell workflows.
-# CONTEXTOS_PYTHON may name an explicit interpreter path or command.
+# Resolve one working Python command for repository shell workflows.
+#
+# Discovery order is CONTEXTOS_PYTHON, then python3, then python. The floor is
+# Python 3.9 because the kernel uses str.removeprefix.
+#
+# CONTEXTOS_PYTHON is an explicit instruction, not a hint: if it is set and does
+# not work, this fails loudly rather than running against a different
+# interpreter than the one that was asked for.
 
 CONTEXTOS_PYTHON_CMD=""
-python_candidates=()
-if [ -n "${CONTEXTOS_PYTHON:-}" ]; then
-  python_candidates+=("$CONTEXTOS_PYTHON")
-fi
-python_candidates+=(python3 python)
 
-for candidate in "${python_candidates[@]}"; do
-  if command -v "$candidate" >/dev/null 2>&1 &&
-    "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' >/dev/null 2>&1; then
-    CONTEXTOS_PYTHON_CMD="$candidate"
-    break
+_contextos_python_works() {
+  command -v "$1" >/dev/null 2>&1 &&
+    "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1
+}
+
+if [ -n "${CONTEXTOS_PYTHON:-}" ]; then
+  if _contextos_python_works "$CONTEXTOS_PYTHON"; then
+    CONTEXTOS_PYTHON_CMD="$CONTEXTOS_PYTHON"
+  else
+    echo "CONTEXTOS_PYTHON is set to '$CONTEXTOS_PYTHON', which is not a working Python 3.9+ interpreter." >&2
+    echo "Fix or unset it; an explicit interpreter is never silently replaced with another one." >&2
+    unset -f _contextos_python_works
+    return 1 2>/dev/null || exit 1
   fi
-done
-unset python_candidates candidate
+else
+  for candidate in python3 python; do
+    if _contextos_python_works "$candidate"; then
+      CONTEXTOS_PYTHON_CMD="$candidate"
+      break
+    fi
+  done
+  unset candidate
+fi
+
+unset -f _contextos_python_works
 
 if [ -z "$CONTEXTOS_PYTHON_CMD" ]; then
-  echo "Python 3 is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
+  echo "Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
   return 1 2>/dev/null || exit 1
 fi
 

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -179,6 +179,12 @@ fi
 "$resolved_bash" "$ROOT/scripts/contextos.sh" doctor >/dev/null \
   || fail "scripts/contextos.sh could not run the lifecycle kernel"
 
+# User-facing documentation must use the same interpreter-neutral entry point
+# that setup and lifecycle skills use. CHANGELOG preserves historical commands.
+if git grep -n -F 'python3 -m contextos' -- '*.md' ':(exclude)CHANGELOG.md'; then
+  fail "user-facing documentation bypasses scripts/contextos.sh"
+fi
+
 invalid_metadata="$portability_tmp/invalid-openai.yaml"
 cp .agents/skills/context-start/agents/openai.yaml "$invalid_metadata"
 printf 'malformed: [\n' >> "$invalid_metadata"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -146,6 +146,39 @@ fallback_python=$(
 )
 [ "$fallback_python" = "python" ] || fail "Python resolver did not fall back from python3 to python"
 
+# An explicit CONTEXTOS_PYTHON is an instruction, not a hint. A working override
+# must win, and a broken one must fail loudly instead of silently resolving to a
+# different interpreter than the one that was asked for.
+override_python=$(
+  CONTEXTOS_PYTHON="$resolved_python" "$resolved_bash" -c \
+    'source "$1"; printf "%s" "$CONTEXTOS_PYTHON_CMD"' _ "$ROOT/scripts/python-env.sh"
+)
+[ "$override_python" = "$resolved_python" ] || fail "CONTEXTOS_PYTHON override was not honored"
+
+if CONTEXTOS_PYTHON="$portability_tmp/no-such-python" "$resolved_bash" -c \
+  'source "$1"' _ "$ROOT/scripts/python-env.sh" >/dev/null 2>&1; then
+  fail "unresolvable CONTEXTOS_PYTHON silently fell back to another interpreter"
+fi
+
+# The kernel uses str.removeprefix, so a Python 3 older than 3.9 must be rejected
+# rather than accepted and left to fail later.
+old_python_bin="$portability_tmp/old-python-bin"
+mkdir -p "$old_python_bin"
+printf '#!%s\nif [ "$1" = "-c" ]; then exit 1; fi\nexit 1\n' "$resolved_bash" > "$old_python_bin/python3"
+chmod +x "$old_python_bin/python3"
+old_python_path="$old_python_bin"
+if command -v cygpath >/dev/null 2>&1; then
+  old_python_path=$(cygpath -u "$old_python_bin")
+fi
+if PATH="$old_python_path" CONTEXTOS_PYTHON= "$resolved_bash" -c \
+  'source "$1"' _ "$ROOT/scripts/python-env.sh" >/dev/null 2>&1; then
+  fail "Python resolver accepted an interpreter that failed the version probe"
+fi
+
+# The lifecycle wrapper must run the kernel through the resolver.
+"$resolved_bash" "$ROOT/scripts/contextos.sh" doctor >/dev/null \
+  || fail "scripts/contextos.sh could not run the lifecycle kernel"
+
 invalid_metadata="$portability_tmp/invalid-openai.yaml"
 cp .agents/skills/context-start/agents/openai.yaml "$invalid_metadata"
 printf 'malformed: [\n' >> "$invalid_metadata"
@@ -305,8 +338,11 @@ name_line=$(grep -n 'Name to place in CLAUDE.md' scripts/setup.sh | cut -d: -f1)
 test -n "$warning_line" && test -n "$name_line" && test "$warning_line" -lt "$name_line" || fail "privacy warning did not precede personalization"
 
 for skill in context-setup context-update context-end; do
-  grep -Fq 'python3 -m contextos propose' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route mutation through the kernel"
-  grep -Fq 'python3 -m contextos apply' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route approval through the kernel"
+  grep -Fq 'scripts/contextos.sh propose' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route mutation through the kernel"
+  if grep -Fq 'python3 -m contextos' ".agents/skills/$skill/SKILL.md"; then
+    fail "$skill hardcodes python3 instead of the resolved interpreter wrapper"
+  fi
+  grep -Fq 'scripts/contextos.sh apply' ".agents/skills/$skill/SKILL.md" || fail "$skill does not route approval through the kernel"
 done
 
 test -f .codex/hooks.json || fail "missing Codex hook adapter"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -319,7 +319,69 @@ class KernelTest(unittest.TestCase):
         )
         self.assertEqual("warn", initialization["status"])
         self.assertIn("state/current.md", initialization["detail"])
+    def test_readiness_predicate_is_shared_by_start_doctor_and_hook(self) -> None:
+        """current.md gates readiness, and all three consumers must agree on it."""
+        for filename in ("weekly-priorities.md", "blockers.md"):
+            (self.root / "state" / filename).write_bytes((ROOT / "state" / filename).read_bytes())
 
+        # current.md is dated; the other two are untouched shipped templates.
+        report = start_report(self.root, NOW)
+        self.assertTrue(report["initialized"])
+        self.assertIsNone(report["next_action"])
+        self.assertEqual([], hook_report(self.root, "session-start", {})["findings"])
+        initialization = next(
+            item for item in doctor(self.root)["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("pass", initialization["status"])
+
+        # Reverting current.md to the template must flip all three together.
+        (self.root / "state/current.md").write_bytes((ROOT / "state/current.md").read_bytes())
+        self.assertFalse(start_report(self.root, NOW)["initialized"])
+        messages = [
+            finding["message"] for finding in hook_report(self.root, "session-start", {})["findings"]
+        ]
+        self.assertTrue(any("not initialized" in message for message in messages), messages)
+        initialization = next(
+            item for item in doctor(self.root)["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("warn", initialization["status"])
+
+    def test_unset_optional_state_is_reported_without_blocking_readiness(self) -> None:
+        """An empty blockers file is a valid steady state, not an unfinished setup."""
+        (self.root / "state/blockers.md").write_bytes((ROOT / "state/blockers.md").read_bytes())
+        report = start_report(self.root, NOW)
+        self.assertTrue(report["initialized"])
+        self.assertEqual("unknown", report["state"]["state/blockers.md"]["freshness_status"])
+        freshness = next(
+            item for item in doctor(self.root)["checks"] if item["name"] == "state-freshness"
+        )
+        self.assertEqual("warn", freshness["status"])
+        self.assertIn("state/blockers.md", freshness["detail"])
+
+    def test_next_action_names_the_command_to_run(self) -> None:
+        (self.root / "state/current.md").write_bytes((ROOT / "state/current.md").read_bytes())
+        self.assertIn("scripts/setup.sh", start_report(self.root, NOW)["next_action"])
+
+    def test_setup_stamps_freshness_on_tracked_state_files(self) -> None:
+        """A completed setup must report as initialized without hand-written dates."""
+        payload = {
+            "files": {
+                "state/current.md": (
+                    "# Current State\n\n## Active priorities\n\n1. Ship the fix\n"
+                ),
+                "state/blockers.md": (
+                    "# Blockers\n\n**Last Updated:** [DATE]\n\n- Waiting on review\n"
+                ),
+            },
+            "replace_populated": ["state/current.md", "state/blockers.md"],
+        }
+        proposal_path, proposal = self._propose("setup", payload)
+        self._apply(proposal_path, proposal)
+        for filename in ("current.md", "blockers.md"):
+            content = (self.root / "state" / filename).read_text(encoding="utf-8")
+            self.assertIn("**Last Updated:** 2026-08-23", content)
+            self.assertEqual(1, content.count("**Last Updated:**"))
+        self.assertTrue(start_report(self.root, NOW)["initialized"])
     def test_install_and_doctor_are_machine_local(self) -> None:
         target, installed = install_runtime(self.root, "hermes")
         self.assertEqual(self.root / ".context-os/runtime.json", target)

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -312,6 +312,10 @@ class KernelTest(unittest.TestCase):
         self.assertLess(current["age_days"], 0)
         self.assertIsNone(current["stale"])
         self.assertFalse(report["initialized"])
+        messages = [
+            finding["message"] for finding in hook_report(self.root, "session-start", {})["findings"]
+        ]
+        self.assertTrue(any("not initialized" in message for message in messages), messages)
 
         diagnosis = doctor(self.root)
         initialization = next(
@@ -319,6 +323,7 @@ class KernelTest(unittest.TestCase):
         )
         self.assertEqual("warn", initialization["status"])
         self.assertIn("state/current.md", initialization["detail"])
+
     def test_readiness_predicate_is_shared_by_start_doctor_and_hook(self) -> None:
         """current.md gates readiness, and all three consumers must agree on it."""
         for filename in ("weekly-priorities.md", "blockers.md"):

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -70,6 +70,13 @@ class KernelTest(unittest.TestCase):
     def _apply(self, path: Path, document: dict, runtime: str = "codex"):
         return apply_proposal(self.root, path, document["proposal_digest"], runtime)
 
+    def _write_undated_state(self, *filenames: str) -> None:
+        for filename in filenames:
+            (self.root / "state" / filename).write_text(
+                f"# {filename}\n\n**Last Updated:** [DATE]\n",
+                encoding="utf-8",
+            )
+
     def test_update_propose_apply_writes_receipt_and_history_once(self) -> None:
         current = (
             "# Current State\n\n**Last Updated:** 2026-08-20\n\n"
@@ -283,8 +290,7 @@ class KernelTest(unittest.TestCase):
         self.assertIsNone(report["next_action"])
 
     def test_fresh_clone_reports_setup_required_from_real_templates(self) -> None:
-        for filename in ("current.md", "weekly-priorities.md", "blockers.md"):
-            (self.root / "state" / filename).write_bytes((ROOT / "state" / filename).read_bytes())
+        self._write_undated_state("current.md", "weekly-priorities.md", "blockers.md")
 
         report = start_report(self.root, NOW)
         self.assertFalse(report["initialized"])
@@ -326,8 +332,7 @@ class KernelTest(unittest.TestCase):
 
     def test_readiness_predicate_is_shared_by_start_doctor_and_hook(self) -> None:
         """current.md gates readiness, and all three consumers must agree on it."""
-        for filename in ("weekly-priorities.md", "blockers.md"):
-            (self.root / "state" / filename).write_bytes((ROOT / "state" / filename).read_bytes())
+        self._write_undated_state("weekly-priorities.md", "blockers.md")
 
         # current.md is dated; the other two are untouched shipped templates.
         report = start_report(self.root, NOW)
@@ -340,7 +345,7 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("pass", initialization["status"])
 
         # Reverting current.md to the template must flip all three together.
-        (self.root / "state/current.md").write_bytes((ROOT / "state/current.md").read_bytes())
+        self._write_undated_state("current.md")
         self.assertFalse(start_report(self.root, NOW)["initialized"])
         messages = [
             finding["message"] for finding in hook_report(self.root, "session-start", {})["findings"]
@@ -353,7 +358,7 @@ class KernelTest(unittest.TestCase):
 
     def test_unset_optional_state_is_reported_without_blocking_readiness(self) -> None:
         """An empty blockers file is a valid steady state, not an unfinished setup."""
-        (self.root / "state/blockers.md").write_bytes((ROOT / "state/blockers.md").read_bytes())
+        self._write_undated_state("blockers.md")
         report = start_report(self.root, NOW)
         self.assertTrue(report["initialized"])
         self.assertEqual("unknown", report["state"]["state/blockers.md"]["freshness_status"])
@@ -364,7 +369,7 @@ class KernelTest(unittest.TestCase):
         self.assertIn("state/blockers.md", freshness["detail"])
 
     def test_next_action_names_the_command_to_run(self) -> None:
-        (self.root / "state/current.md").write_bytes((ROOT / "state/current.md").read_bytes())
+        self._write_undated_state("current.md")
         self.assertIn("scripts/setup.sh", start_report(self.root, NOW)["next_action"])
 
     def test_setup_stamps_freshness_on_tracked_state_files(self) -> None:

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -33,6 +34,9 @@ class CrossRuntimeHookTest(unittest.TestCase):
         self.assertIn("commandWindows", serialized)
         self.assertIn("powershell.exe", serialized)
         self.assertNotIn("; python ", serialized)
+        hermes_readme = (ROOT / "adapters/hermes/README.md").read_text(encoding="utf-8")
+        self.assertIn("context-os-hook.ps1", hermes_readme)
+        self.assertNotIn("; python ", hermes_readme)
         pre_tool = config["hooks"]["PreToolUse"][0]
         self.assertEqual("^apply_patch$", pre_tool["matcher"])
 
@@ -64,17 +68,47 @@ class CrossRuntimeHookTest(unittest.TestCase):
         self.assertEqual(0, must_fire.returncode, must_fire.stderr)
         self.assertIn("proposal/apply", json.loads(must_fire.stdout)["systemMessage"])
 
-        session_start = subprocess.run(
-            [*command[:-1], "session-start"],
-            cwd=ROOT,
-            env=environment,
-            input="{}",
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        self.assertEqual(0, session_start.returncode, session_start.stderr)
-        self.assertIn("not initialized", json.loads(session_start.stdout)["systemMessage"])
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fake_python = Path(temporary_directory) / "python.cmd"
+            fake_python.write_text(
+                '@echo off\nif "%~1"=="-c" exit /b 0\n'
+                'echo {"systemMessage":"%~3 forwarded"}\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(fake_python)
+            session_start = subprocess.run(
+                [*command[:-1], "session-start"],
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, session_start.returncode, session_start.stderr)
+            self.assertEqual(
+                "session-start forwarded",
+                json.loads(session_start.stdout)["systemMessage"],
+            )
+
+            chatty_python = Path(temporary_directory) / "chatty-python.cmd"
+            chatty_python.write_text(
+                '@echo off\necho not-a-working-interpreter\nexit /b 1\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(chatty_python)
+            rejected_chatty_override = subprocess.run(
+                command,
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(0, rejected_chatty_override.returncode)
+            self.assertEqual("", rejected_chatty_override.stdout)
+            self.assertIn("never silently replaced", rejected_chatty_override.stderr)
 
         environment["CONTEXTOS_PYTHON"] = sys.executable
         must_not_fire = subprocess.run(

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -39,7 +39,7 @@ class CrossRuntimeHookTest(unittest.TestCase):
     @unittest.skipUnless(sys.platform == "win32", "native PowerShell adapter test")
     def test_windows_wrapper_honors_override_and_hook_controls(self) -> None:
         environment = os.environ.copy()
-        environment["CONTEXTOS_PYTHON"] = sys.executable
+        environment.pop("CONTEXTOS_PYTHON", None)
         command = [
             "powershell.exe",
             "-NoProfile",
@@ -64,6 +64,19 @@ class CrossRuntimeHookTest(unittest.TestCase):
         self.assertEqual(0, must_fire.returncode, must_fire.stderr)
         self.assertIn("proposal/apply", json.loads(must_fire.stdout)["systemMessage"])
 
+        session_start = subprocess.run(
+            [*command[:-1], "session-start"],
+            cwd=ROOT,
+            env=environment,
+            input="{}",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, session_start.returncode, session_start.stderr)
+        self.assertIn("not initialized", json.loads(session_start.stdout)["systemMessage"])
+
+        environment["CONTEXTOS_PYTHON"] = sys.executable
         must_not_fire = subprocess.run(
             command,
             cwd=ROOT,
@@ -87,6 +100,7 @@ class CrossRuntimeHookTest(unittest.TestCase):
             check=False,
         )
         self.assertNotEqual(0, invalid_override.returncode)
+        self.assertIn(str(ROOT / "no-such-python"), invalid_override.stderr)
         self.assertIn("never silently replaced", invalid_override.stderr)
 
     def test_codex_pre_write_must_fire_control(self) -> None:

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -44,6 +44,8 @@ class CrossRuntimeHookTest(unittest.TestCase):
     def test_windows_wrapper_honors_override_and_hook_controls(self) -> None:
         environment = os.environ.copy()
         environment.pop("CONTEXTOS_PYTHON", None)
+        config = json.loads((ROOT / ".codex/hooks.json").read_text(encoding="utf-8"))
+        production_pre_write = config["hooks"]["PreToolUse"][0]["hooks"][0]["commandWindows"]
         command = [
             "powershell.exe",
             "-NoProfile",
@@ -56,8 +58,13 @@ class CrossRuntimeHookTest(unittest.TestCase):
             "pre-write",
         ]
 
+        # Native Windows CI exercises the exact production command. When the
+        # Python suite itself is launched below MSYS, use -File because the
+        # parent shell changes stdin-handle behavior before PowerShell starts.
+        must_fire_command = command if os.environ.get("MSYSTEM") else production_pre_write
+
         must_fire = subprocess.run(
-            command,
+            must_fire_command,
             cwd=ROOT,
             env=environment,
             input=json.dumps({"tool_input": {"file_path": str(ROOT / "state/current.md")}}),
@@ -109,6 +116,28 @@ class CrossRuntimeHookTest(unittest.TestCase):
             self.assertNotEqual(0, rejected_chatty_override.returncode)
             self.assertEqual("", rejected_chatty_override.stdout)
             self.assertIn("never silently replaced", rejected_chatty_override.stderr)
+
+            stderr_python = Path(temporary_directory) / "stderr-python.cmd"
+            stderr_python.write_text(
+                '@echo off\nif "%~1"=="-c" (echo harmless-probe-warning 1>&2 & exit /b 0)\n'
+                'echo {"systemMessage":"%~3 forwarded"}\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(stderr_python)
+            accepted_stderr_override = subprocess.run(
+                [*command[:-1], "session-start"],
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, accepted_stderr_override.returncode, accepted_stderr_override.stderr)
+            self.assertEqual(
+                "session-start forwarded",
+                json.loads(accepted_stderr_override.stdout)["systemMessage"],
+            )
 
         environment["CONTEXTOS_PYTHON"] = sys.executable
         must_not_fire = subprocess.run(

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -9,6 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WRAPPER = ROOT / "scripts/context-os-hook.py"
+WINDOWS_WRAPPER = ROOT / "scripts/context-os-hook.ps1"
 
 
 class CrossRuntimeHookTest(unittest.TestCase):
@@ -27,11 +29,65 @@ class CrossRuntimeHookTest(unittest.TestCase):
         self.assertEqual({"SessionStart", "PreToolUse"}, set(config["hooks"]))
         serialized = json.dumps(config)
         self.assertIn("context-os-hook.sh", serialized)
-        self.assertIn("context-os-hook.py", serialized)
+        self.assertIn("context-os-hook.ps1", serialized)
         self.assertIn("commandWindows", serialized)
         self.assertIn("powershell.exe", serialized)
+        self.assertNotIn("; python ", serialized)
         pre_tool = config["hooks"]["PreToolUse"][0]
         self.assertEqual("^apply_patch$", pre_tool["matcher"])
+
+    @unittest.skipUnless(sys.platform == "win32", "native PowerShell adapter test")
+    def test_windows_wrapper_honors_override_and_hook_controls(self) -> None:
+        environment = os.environ.copy()
+        environment["CONTEXTOS_PYTHON"] = sys.executable
+        command = [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_WRAPPER),
+            "codex",
+            "pre-write",
+        ]
+
+        must_fire = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            input=json.dumps({"tool_input": {"file_path": str(ROOT / "state/current.md")}}),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, must_fire.returncode, must_fire.stderr)
+        self.assertIn("proposal/apply", json.loads(must_fire.stdout)["systemMessage"])
+
+        must_not_fire = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            input=json.dumps({"tool_input": {"file_path": str(ROOT / "README.md")}}),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, must_not_fire.returncode, must_not_fire.stderr)
+        self.assertEqual("", must_not_fire.stdout)
+
+        environment["CONTEXTOS_PYTHON"] = str(ROOT / "no-such-python")
+        invalid_override = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            input="{}",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(0, invalid_override.returncode)
+        self.assertIn("never silently replaced", invalid_override.stderr)
 
     def test_codex_pre_write_must_fire_control(self) -> None:
         result = self.run_hook(

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -26,6 +26,7 @@ class CrossRuntimeHookTest(unittest.TestCase):
         config = json.loads((ROOT / ".codex/hooks.json").read_text(encoding="utf-8"))
         self.assertEqual({"SessionStart", "PreToolUse"}, set(config["hooks"]))
         serialized = json.dumps(config)
+        self.assertIn("context-os-hook.sh", serialized)
         self.assertIn("context-os-hook.py", serialized)
         self.assertIn("commandWindows", serialized)
         self.assertIn("powershell.exe", serialized)


### PR DESCRIPTION
Stacked on #43 — targets `fix/issue-42-onboarding-readiness`, not `main`. Addresses review findings 1-5 from my review of that PR.

## What was wrong

**Readiness had two definitions.** The session-start hook called a workspace initialized iff `current.md` lacked `[DATE]`; `start`/`doctor` required a real `**Last Updated:**` date on all three state files. Verified they disagreed — with `current.md` dated and blockers/weekly left as shipped templates, the hook reported no findings while `start` reported `initialized: false`.

**The three-file rule made `initialized: false` permanent.** `render_setup` writes payload content verbatim and never stamped the freshness line, and `render_end` only stamps blockers/weekly when the payload carries them — which `context-end/SKILL.md` says to send "only when that state materially changed." A user with no blockers never sends `blockers_markdown`, so `blockers.md` kept `[DATE]` forever and `doctor` warned `guided setup required` on every run.

**`CONTEXTOS_PYTHON` failed open.** `CONTEXTOS_PYTHON=/nonexistent/py` silently resolved to `python3` — so a typo'd or moved venv path made `validate-all.sh` report "all checks passed" against a different interpreter than the one that was asked for.

## What changed

- **One predicate.** `_is_initialized` is keyed on `current.md` and shared by `start`, `doctor`, and the session hook. `weekly-priorities.md` and `blockers.md` freshness is still reported — under a new `state-freshness` doctor check — but no longer gates readiness. An empty blockers file is a valid steady state, not an unfinished setup.
- **Setup owns the freshness line.** `render_setup` stamps `**Last Updated:**` on the state files that `start` and `doctor` read, so a completed setup reports as initialized without depending on the agent to hand-write it. `_advance_dated_state` grew a `required` flag: strict for lifecycle writes to files the kernel owns, tolerant for reviewed setup content.
- **`next_action` names the command** instead of referring to "the explicit setup workflow" abstractly.
- **`CONTEXTOS_PYTHON` is honored exactly** — an override that does not resolve is now a hard error, never a fallback.
- **Interpreter floor is Python 3.9**, matching the kernel's use of `str.removeprefix` (kernel.py:795), instead of any Python 3.
- **`scripts/contextos.sh` and `scripts/context-os-hook.sh`** carry the resolver to the call sites that still hardcoded `python3`: the Codex and Hermes hook adapters, the four lifecycle skills, and the docs.
- CHANGELOG entries added, per `docs/repo-maintenance.md:91`.

## Two judgment calls to push back on

1. **The skills and docs now say `bash scripts/contextos.sh <cmd>` instead of `python3 -m contextos <cmd>`.** This is the most opinionated change here — it moves the documented interface right before launch. It is the actual fix for "setup reports ready on a `python`-only host, then every lifecycle skill fails," but if you would rather keep `python3 -m contextos` as the canonical form and only ship the wrapper as an escape hatch, that is a one-line revert of the doc/skill sweep.

2. **I did not fold the two Claude hooks onto the shared resolver**, even though I flagged the duplication in review. `tests/test-hooks.sh` copies `worktree-guard.sh` into a bare fixture repo, which caught it: hook files are meant to work when copied standalone into another repo, where a shared `scripts/` helper does not exist. Their inline `python3 || python` probe is deliberate, not an oversight. Left as-is.

## Not addressed

Findings 6, 7, and the minor items from the review — `context-start/SKILL.md` and `/today` still don't read `initialized`/`next_action`; `stale` is still `bool | None` at `SCHEMA_VERSION: 1`; `_advance_dated_state` still inserts above `**Week of:**` on a legacy upgrade; `_state_freshness` still raises `ValueError` on `2026-02-30`. Happy to take any of these in a follow-up.

## Validation

`bash scripts/validate-all.sh` — 175 tests, 11 skipped, all checks passed (up from 171; four new kernel tests plus resolver coverage in `test-portability.sh`).

New tests pin the things that were broken:
- `test_readiness_predicate_is_shared_by_start_doctor_and_hook` — asserts all three consumers flip together.
- `test_unset_optional_state_is_reported_without_blocking_readiness` — an untouched `blockers.md` is reported, not treated as unfinished setup.
- `test_setup_stamps_freshness_on_tracked_state_files` — setup output reports as initialized.
- `test_next_action_names_the_command_to_run`.
- `test-portability.sh` now covers the `CONTEXTOS_PYTHON` override path (honored when it works, hard error when it doesn't), the sub-3.9 rejection, and the wrapper end-to-end. The previous fallback test cleared the variable, so that path had no coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Picking this up in another session

Everything needed to continue is on GitHub; nothing is required from the session that produced this.

**Get the branch.** It exists only on the remote — the local branch and review worktree were cleaned up after pushing.

```bash
cd ~/claude-context-os
git fetch origin fix/pr43-review-followups
git worktree add ../acos-pr45 fix/pr43-review-followups   # HEAD should be 27a22ff
```

**Read the review this answers first.** The findings, the line-anchored inline comments, and the reproductions that motivated each change are on #43 — start there, not with this diff. The `#43` comment thread also records that half of finding 4 was withdrawn and why.

**Re-validate before changing anything:**

```bash
bash scripts/validate-all.sh
```

Expect `175 tests, 11 skipped` and `All validation passed`. That number went up from 171; if it reads 171, the branch is not checked out.

**Two decisions are open and belong to @conorbronsdon**, not to whoever picks this up — see "Two judgment calls to push back on" above. The second one (skills and docs moving to `bash scripts/contextos.sh`) is the one to resolve before merge, since it changes the documented interface. It is an isolated sweep and reverts cleanly on its own:

```bash
git log -1 --stat 27a22ff   # the doc/skill files are the .md + AGENTS.md entries
```

**Reproductions**, if you want to confirm the fixes rather than trust them:

- Findings 1 and 2: copy the shipped `state/` templates into a scratch workspace, put a real date only in `current.md`, then check that `start_report`, `hook_report(..., "session-start")`, and `doctor` all agree. Before this branch they did not.
- Finding 3: `CONTEXTOS_PYTHON=/nonexistent/py bash scripts/contextos.sh doctor` must exit 1 with a message naming the bad override. Before this branch it silently ran under `python3`.

**Not tracked anywhere else.** This work has no entry in the `personal-context` repo — no `state/` update, no `sessions/` log, no memory. These two PRs are the whole record.
