### PR TITLE
Correct the interpreter floor to 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Future-dated `state/current.md` timestamps no longer satisfy the shared readiness predicate, and the native Windows Codex hooks now honor the same `CONTEXTOS_PYTHON` override and Python 3.9 floor as POSIX hooks.
 - `setup` now stamps `**Last Updated:**` on the state files that `start` and `doctor` read, so a completed setup reports as initialized without depending on the agent to hand-write the line.
 - `start`'s `next_action` names the command to run instead of referring to "the explicit setup workflow" abstractly.
-- `CONTEXTOS_PYTHON` is honored exactly: an override that does not resolve to a working interpreter now fails loudly instead of silently falling back to a different one. The interpreter floor is Python 3.9, matching the kernel's use of `str.removeprefix`, instead of any Python 3.
+- `CONTEXTOS_PYTHON` is honored exactly: an override that does not resolve to a working interpreter now fails loudly instead of silently falling back to a different one. The interpreter floor is Python 3.10, matching `contextos/kernel.py`'s use of `Path.write_text(newline=...)`, instead of any Python 3.
 - `scripts/setup.sh` no longer relies on GNU-only `sed -i`; literal-name replacement and sample-route cleanup now use the documented Python 3 dependency.
 - Replaced the deprecated Notion npm-server instructions with Notion's hosted OAuth MCP path for Claude Code and Codex.
 - Aligned manual claude.ai setup prompts with portable skill paths and approval-gated local setup instead of claiming slash-command or commit parity.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,14 +6,14 @@ Codex, and Hermes can use as shared state.
 
 ## Before you clone
 
-You need Git, Bash, Python 3.9 or newer, and at least one supported local
+You need Git, Bash, Python 3.10 or newer, and at least one supported local
 agent: Claude Code, Codex, or Hermes. claude.ai can help produce files but
 cannot maintain a local checkout directly.
 
 Python may be installed as either `python3` or `python`; the repository resolves
 whichever works. To pin a specific interpreter — a virtualenv, or one of several
 installed versions — set `CONTEXTOS_PYTHON` to its path or command. That setting
-is honored exactly: if it does not resolve to a working Python 3.9+, setup and
+is honored exactly: if it does not resolve to a working Python 3.10+, setup and
 validation stop instead of falling back to a different interpreter.
 
 Decide where the repository will live. If it will contain personal, client, employer, financial, or unpublished project context, use a private remote. Repository visibility is only one control; do not store credentials, raw account exports, or information you would not want every configured agent to read.

--- a/scripts/python-env.sh
+++ b/scripts/python-env.sh
@@ -2,7 +2,9 @@
 # Resolve one working Python command for repository shell workflows.
 #
 # Discovery order is CONTEXTOS_PYTHON, then python3, then python. The floor is
-# Python 3.9 because the kernel uses str.removeprefix.
+# Python 3.10 because contextos/kernel.py calls Path.write_text(newline=...),
+# whose newline kwarg is 3.10+. str.removeprefix reads like a 3.9 floor; it is
+# not the binding constraint.
 #
 # CONTEXTOS_PYTHON is an explicit instruction, not a hint: if it is set and does
 # not work, this fails loudly rather than running against a different
@@ -12,14 +14,14 @@ CONTEXTOS_PYTHON_CMD=""
 
 _contextos_python_works() {
   command -v "$1" >/dev/null 2>&1 &&
-    "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1
+    "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1
 }
 
 if [ -n "${CONTEXTOS_PYTHON:-}" ]; then
   if _contextos_python_works "$CONTEXTOS_PYTHON"; then
     CONTEXTOS_PYTHON_CMD="$CONTEXTOS_PYTHON"
   else
-    echo "CONTEXTOS_PYTHON is set to '$CONTEXTOS_PYTHON', which is not a working Python 3.9+ interpreter." >&2
+    echo "CONTEXTOS_PYTHON is set to '$CONTEXTOS_PYTHON', which is not a working Python 3.10+ interpreter." >&2
     echo "Fix or unset it; an explicit interpreter is never silently replaced with another one." >&2
     unset -f _contextos_python_works
     return 1 2>/dev/null || exit 1
@@ -37,7 +39,7 @@ fi
 unset -f _contextos_python_works
 
 if [ -z "$CONTEXTOS_PYTHON_CMD" ]; then
-  echo "Python 3.9 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
+  echo "Python 3.10 or newer is required. Install it as 'python3' or 'python', or set CONTEXTOS_PYTHON." >&2
   return 1 2>/dev/null || exit 1
 fi
 


### PR DESCRIPTION
Stacked on #45. One-line correction to a number I got wrong.

Finding 5 of my review on #43 said to use `sys.version_info >= (3, 9)`, reasoning from `str.removeprefix` in `kernel.py:795`. #45 implemented that faithfully. **The number was wrong.**

`contextos/kernel.py` calls `Path.write_text(newline=...)` in four places (lines 348, 485, 513, 614), and the `newline` kwarg is **3.10+**. So a 3.9 interpreter passed `python-env.sh`'s probe and then died on the first `propose`:

```
TypeError: write_text() got an unexpected keyword argument 'newline'
```

That is the exact failure mode #45 exists to prevent — an interpreter that satisfies the check and then breaks in use.

## How it surfaced

The minimum-Python CI job added in #55. I pinned it at 3.9, ran an AST scan at `feature_version=(3,9)` first, fixed what that found, and expected green. It errored 11 tests anyway. A runtime signature difference is invisible to static analysis — it needed a job actually running the interpreter, which is the argument for that job existing.

## Changes

- `scripts/python-env.sh`: probe `>= (3, 10)`, both error messages, and a comment recording *why* 3.10 rather than the 3.9 the source reads like
- `docs/getting-started.md`: prerequisite and the `CONTEXTOS_PYTHON` note
- `CHANGELOG.md`: the floor entry

Validation: `scripts/validate-all.sh` — 175 tests, 11 skipped, all checks passed.

Merge this into #45 before #45 merges, or squash them — either works, they touch the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)