### PR TITLE
Fix Windows line-ending churn during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- `scripts/setup.sh` now preserves LF line endings when its inline Python helpers update `CLAUDE.md` or `ROUTING.md`, keeping Windows setup diffs narrow under `core.autocrlf=false`.
 - `docs/optimizing-context.md` and `docs/mcp-efficiency.md` were unreachable — nothing outside the changelog linked them. Both are now in the README documentation table. `docs/launch-copy.md` is linked from `docs/positioning.md`.
 - `docs/maintenance.md` and `docs/repo-maintenance.md` gave two overlapping descriptions of the same session and weekly cadence. Each now states its scope and links the other; the workspace cadence lives in `maintenance.md`, repository conventions in `repo-maintenance.md`.
 - `tests/test_dream_paths.py` and `tests/test_mine_gemini_workflows.py` now carry `from __future__ import annotations`, matching the seven other Python files that already do.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -101,7 +101,11 @@ from pathlib import Path
 import sys
 
 path = Path("CLAUDE.md")
-path.write_text(path.read_text(encoding="utf-8").replace("[Your Name]", sys.argv[1]), encoding="utf-8")
+path.write_text(
+    path.read_text(encoding="utf-8").replace("[Your Name]", sys.argv[1]),
+    encoding="utf-8",
+    newline="\n",
+)
 PY
     track_setup_path "CLAUDE.md"
     echo "  → Updated CLAUDE.md with your name"
@@ -145,7 +149,11 @@ from pathlib import Path
 
 path = Path("ROUTING.md")
 lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
-path.write_text("".join(line for line in lines if "example-musician" not in line), encoding="utf-8")
+path.write_text(
+    "".join(line for line in lines if "example-musician" not in line),
+    encoding="utf-8",
+    newline="\n",
+)
 PY
     track_setup_path "projects/example-musician"
     track_setup_path "ROUTING.md"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -269,8 +269,10 @@ grep -Fq -- '--agent auto|claude|codex|hermes|cursor|openclaw|none' <<<"$help_ou
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"
 fi
-test "$(grep -Fc '    newline="\n",' scripts/setup.sh)" -eq 2 \
-  || fail "both setup Python rewrites must explicitly preserve LF line endings"
+setup_write_count=$(grep -Fc 'path.write_text(' scripts/setup.sh)
+setup_lf_count=$(grep -Fc 'newline="\n",' scripts/setup.sh)
+test "$setup_write_count" -eq "$setup_lf_count" \
+  || fail "every setup Python rewrite must explicitly preserve LF line endings"
 
 make_setup_fixture() {
   local destination="$1"
@@ -279,7 +281,8 @@ make_setup_fixture() {
   git -C "$destination" init -q
   git -C "$destination" config user.name "Portability Test"
   git -C "$destination" config user.email "portability@example.invalid"
-  git -C "$destination" -c core.autocrlf=false add -A
+  git -C "$destination" config core.autocrlf false
+  git -C "$destination" add -A
   git -C "$destination" commit -qm baseline
   git -C "$destination" remote add origin https://example.invalid/context.git
 }

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -269,6 +269,8 @@ grep -Fq -- '--agent auto|claude|codex|hermes|cursor|openclaw|none' <<<"$help_ou
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"
 fi
+test "$(grep -Fc '    newline="\n",' scripts/setup.sh)" -eq 2 \
+  || fail "both setup Python rewrites must explicitly preserve LF line endings"
 
 make_setup_fixture() {
   local destination="$1"
@@ -281,6 +283,30 @@ make_setup_fixture() {
   git -C "$destination" commit -qm baseline
   git -C "$destination" remote add origin https://example.invalid/context.git
 }
+
+# Both inline Python rewrites must preserve an LF checkout on Windows. Without
+# newline="\n", TextIO converts every line to CRLF and turns the reviewed setup
+# diff into a whole-file rewrite under core.autocrlf=false.
+line_endings_fixture="$portability_tmp/lf-preservation"
+make_setup_fixture "$line_endings_fixture"
+"$CONTEXTOS_PYTHON_CMD" - "$line_endings_fixture/CLAUDE.md" "$line_endings_fixture/ROUTING.md" <<'PY'
+from pathlib import Path
+import sys
+
+for raw_path in sys.argv[1:]:
+    path = Path(raw_path)
+    path.write_text(path.read_text(encoding="utf-8"), encoding="utf-8", newline="\n")
+PY
+git -C "$line_endings_fixture" add CLAUDE.md ROUTING.md
+git -C "$line_endings_fixture" commit --amend --no-edit -q
+printf 'y\nAda\ny\nn\nn\nn\n' | (cd "$line_endings_fixture" && bash scripts/setup.sh --agent none) >/dev/null
+test "$(git -C "$line_endings_fixture" diff --numstat -- CLAUDE.md)" = $'1\t1\tCLAUDE.md' \
+  || fail "setup name replacement rewrote more than one CLAUDE.md line"
+git -C "$line_endings_fixture" diff --quiet -- ROUTING.md \
+  || fail "setup sample-route cleanup rewrote ROUTING.md despite no matching route"
+if LC_ALL=C grep -q $'\r' "$line_endings_fixture/CLAUDE.md" "$line_endings_fixture/ROUTING.md"; then
+  fail "setup rewrites converted an LF checkout to CRLF"
+fi
 
 setup_fixture="$portability_tmp/repo with spaces"
 make_setup_fixture "$setup_fixture"


### PR DESCRIPTION
## What is in this PR

Preserves LF line endings in both inline Python rewrites used by `scripts/setup.sh`, preventing Windows from turning narrow setup edits into whole-file diffs under `core.autocrlf=false`.

Adds a portability regression that:

- normalizes fixture inputs to LF;
- asserts the name replacement changes exactly one line;
- asserts the no-op sample-route cleanup leaves `ROUTING.md` unchanged;
- rejects CRLF output; and
- explicitly requires both setup rewrites to declare the LF contract.

Closes #58.

## Verification

- Known-bad mutation: removing both `newline=\n` arguments makes `tests/test-portability.sh` fail with `both setup Python rewrites must explicitly preserve LF line endings`.
- Restored implementation: `tests/test-portability.sh` passes on Windows Git Bash.
- `bash scripts/validate-all.sh`: 178 tests passed, 11 expected skips; portability, hooks, links, document reachability, integration catalog, and JSON checks passed.

## Checklist

### Skills & commands

- [x] Not applicable: no skills or commands added or changed.

### Repo hygiene

- [x] No sensitive data committed.
- [x] `CHANGELOG.md` updated.
- [x] Local aggregate validation passes; CI pending.