### PR TITLE
docs: catalog MarkItDown MCP integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
 - `CONTRIBUTING.md` — prerequisites, the validator as the one gate, which files are generated, how to add a catalog entry, skill/adapter structure, and the enforced size limits.
 - `SECURITY.md` — private reporting path, what is in and out of scope, and the design boundaries most likely to be misread (validation is not a publication guarantee; `verified` is a metadata claim; nothing here sandboxes an agent).
 - Issue templates for integration proposals and bug reports, plus contact links routing security reports away from public issues.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The [optional integrations catalog](references/integrations.md) is generated fro
 
 Start with the task-based [integration chooser](docs/integrations-guide.md), add at most one new trust boundary at a time, then read the selected generated entry in full.
 
-The current catalog includes portable skill collections and creator tools, plus reviewed paths for Tolaria MCP, Obsidian CLI, Beads for Gemini CLI, Granola MCP, Google Workspace CLI, Notion MCP, and Substack MCP. `listed` and `experimental` entries are leads, not endorsements. Setup never installs, authenticates, or activates them.
+The current catalog includes portable skill collections and creator tools, plus reviewed paths for MarkItDown MCP, Tolaria MCP, Obsidian CLI, Beads for Gemini CLI, Granola MCP, Google Workspace CLI, Notion MCP, and Substack MCP. `listed` and `experimental` entries are leads, not endorsements. Setup never installs, authenticates, or activates them.
 
 ## Repository layout
 

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -21,6 +21,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Let an agent work with an Obsidian vault | [Obsidian CLI](../references/integrations.md#obsidian-cli) | Broad command/eval surface and implicit vault/file targeting |
 | Manage Substack drafts or publish Notes | [Substack MCP](../references/integrations.md#substack-mcp) | Session credentials, sensitive analytics, and immediate public Notes |
 | Read or update a mounted Markdown vault | [Tolaria MCP](../references/integrations.md#tolaria-mcp) | Sensitive vault reads and full-note overwrite |
+| Convert an explicitly selected document or URI to Markdown | [MarkItDown MCP](../references/integrations.md#markitdown-mcp) | Local-file and network reads through an unauthenticated server process |
 
 The obsolete checked-in `gws mcp` configuration was removed. The current Google Workspace path uses the reviewed CLI setup in [`references/google-workspace-cli-setup.md`](../references/google-workspace-cli-setup.md); it is still opt-in and is not pre-approved by the command adapters.
 

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -583,7 +583,7 @@
       "installation": {
         "automatic": false,
         "scope": "project_or_user",
-        "prerequisites": ["Python with pip or Docker", "An MCP-compatible client", "Explicitly bounded file and network access for the server process"]
+        "prerequisites": ["Python with pip or Docker", "An MCP-compatible client", "Explicitly bounded file and network access for the server process", "Third-party plugins disabled by leaving MARKITDOWN_ENABLE_PLUGINS unset or false"]
       },
       "data_boundary": {
         "credentials": [],
@@ -601,7 +601,7 @@
         "arbitrary_execution": false,
         "oauth": false,
         "destructive": false,
-        "details": ["The convert_to_markdown tool accepts file, HTTP, HTTPS, and data URIs, so every call must be treated as an explicit sensitive-read boundary", "The server has no authentication and runs with the privileges and network reachability of its process", "Keep HTTP or SSE bound to localhost and prefer a sandbox or container with narrow mounts when converting untrusted content"]
+        "details": ["The convert_to_markdown tool accepts file, HTTP, HTTPS, and data URIs, so every call must be treated as an explicit sensitive-read boundary", "The server has no authentication and runs with the privileges and network reachability of its process", "Keep HTTP or SSE bound to localhost and prefer a sandbox or container with narrow mounts when converting untrusted content", "This reviewed profile excludes third-party plugins; keep MARKITDOWN_ENABLE_PLUGINS unset or false because enabled plugins widen the process execution boundary"]
       },
       "confirmation": {
         "required_for": ["external_install", "read_sensitive"],
@@ -609,8 +609,8 @@
       },
       "risk_tags": ["local-data", "sensitive-read", "network-capable", "open-world", "no-authentication", "prompt-injection"],
       "maturity": "verified",
-      "last_verified": "2026-08-25",
-      "evidence": ["https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md", "https://github.com/microsoft/markitdown/releases/tag/v0.1.7"],
+      "last_verified": "2026-08-24",
+      "evidence": ["https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md", "https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/src/markitdown_mcp/__main__.py", "https://github.com/microsoft/markitdown/releases/tag/v0.1.7"],
       "health_check": "Run the stdio server in a sandbox, list its single convert_to_markdown tool, then convert one non-sensitive local fixture from an explicitly allowed directory.",
       "uninstall": {
         "instructions": "Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested.",

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -610,7 +610,7 @@
       "risk_tags": ["local-data", "sensitive-read", "network-capable", "open-world", "no-authentication", "prompt-injection"],
       "maturity": "verified",
       "last_verified": "2026-08-24",
-      "evidence": ["https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md", "https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/src/markitdown_mcp/__main__.py", "https://github.com/microsoft/markitdown/releases/tag/v0.1.7"],
+      "evidence": ["https://github.com/microsoft/markitdown/blob/fd239d5d2be43d9b68329730206b9312c7d5a388/packages/markitdown-mcp/README.md", "https://github.com/microsoft/markitdown/blob/fd239d5d2be43d9b68329730206b9312c7d5a388/packages/markitdown-mcp/src/markitdown_mcp/__main__.py", "https://github.com/microsoft/markitdown/releases/tag/v0.1.7"],
       "health_check": "Run the stdio server in a sandbox, list its single convert_to_markdown tool, then convert one non-sensitive local fixture from an explicitly allowed directory.",
       "uninstall": {
         "instructions": "Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested.",

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -572,6 +572,50 @@
         "instructions": "Remove the Tolaria MCP entry from each configured client; preserve the Tolaria application and every vault unless separate removal is requested.",
         "removes_user_data": false
       }
+    },
+    {
+      "id": "markitdown-mcp",
+      "name": "MarkItDown MCP",
+      "summary": "Microsoft's local MCP server converts explicitly supplied file, HTTP, HTTPS, and data URIs to Markdown through one read-only tool.",
+      "source_url": "https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp",
+      "kind": "mcp_server",
+      "supported_agents": ["claude_code", "codex", "gemini_cli", "cursor", "opencode", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["Python with pip or Docker", "An MCP-compatible client", "Explicitly bounded file and network access for the server process"]
+      },
+      "data_boundary": {
+        "credentials": [],
+        "reads": ["Any local file readable by the server account when given a file URI", "Any HTTP or HTTPS resource reachable from the server process, plus caller-supplied data URIs"],
+        "writes": []
+      },
+      "capabilities": {
+        "read": true,
+        "sensitive_read": true,
+        "write": false,
+        "remote_write": false,
+        "publish": false,
+        "overwrite": false,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": false,
+        "destructive": false,
+        "details": ["The convert_to_markdown tool accepts file, HTTP, HTTPS, and data URIs, so every call must be treated as an explicit sensitive-read boundary", "The server has no authentication and runs with the privileges and network reachability of its process", "Keep HTTP or SSE bound to localhost and prefer a sandbox or container with narrow mounts when converting untrusted content"]
+      },
+      "confirmation": {
+        "required_for": ["external_install", "read_sensitive"],
+        "notes": "Confirm installation and the exact URI before each conversion; reject broad local paths, private-network targets, or untrusted remote content unless their read boundary is explicitly approved."
+      },
+      "risk_tags": ["local-data", "sensitive-read", "network-capable", "open-world", "no-authentication", "prompt-injection"],
+      "maturity": "verified",
+      "last_verified": "2026-08-25",
+      "evidence": ["https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md", "https://github.com/microsoft/markitdown/releases/tag/v0.1.7"],
+      "health_check": "Run the stdio server in a sandbox, list its single convert_to_markdown tool, then convert one non-sensitive local fixture from an explicitly allowed directory.",
+      "uninstall": {
+        "instructions": "Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested.",
+        "removes_user_data": false
+      }
     }
   ]
 }

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -13,6 +13,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Google Workspace CLI](https://github.com/googleworkspace/cli) | `connector` | verified | Yes | Yes | No | Yes | Yes | 2026-08-15 |
 | [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-15 |
 | [Linear MCP](https://linear.app/docs/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
+| [MarkItDown MCP](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-25 |
 | [Notion MCP](https://developers.notion.com/guides/mcp/get-started-with-mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-15 |
 | [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-15 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
@@ -215,6 +216,30 @@ Capabilities and limits:
 - Use https://mcp.linear.app/mcp/readonly or request only the read OAuth scope for session briefings and investigation
 - The default https://mcp.linear.app/mcp endpoint is read-write and can create or update issues, projects, and comments
 - Before turning notes or repository state into Linear work, show the proposed project, milestones, issues, relationships, and exact comments and do not invent dependencies
+
+## MarkItDown MCP
+
+Microsoft's local MCP server converts explicitly supplied file, HTTP, HTTPS, and data URIs to Markdown through one read-only tool.
+
+- **Supported agents:** `claude_code`, `codex`, `gemini_cli`, `cursor`, `opencode`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** Python with pip or Docker; An MCP-compatible client; Explicitly bounded file and network access for the server process
+- **Credentials:** None
+- **Reads:** Any local file readable by the server account when given a file URI; Any HTTP or HTTPS resource reachable from the server process, plus caller-supplied data URIs
+- **Writes / external effects:** None
+- **Typed safety signals:** sensitive read
+- **Required confirmation gates:** `external_install`, `read_sensitive`
+- **Confirmation:** Confirm installation and the exact URI before each conversion; reject broad local paths, private-network targets, or untrusted remote content unless their read boundary is explicitly approved.
+- **Risk tags:** `local-data`, `sensitive-read`, `network-capable`, `open-world`, `no-authentication`, `prompt-injection`
+- **Evidence:** [1](https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md); [2](https://github.com/microsoft/markitdown/releases/tag/v0.1.7)
+- **Health check:** Run the stdio server in a sandbox, list its single convert\_to\_markdown tool, then convert one non-sensitive local fixture from an explicitly allowed directory.
+- **Uninstall:** Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested. (removes user data: No)
+
+Capabilities and limits:
+
+- The convert\_to\_markdown tool accepts file, HTTP, HTTPS, and data URIs, so every call must be treated as an explicit sensitive-read boundary
+- The server has no authentication and runs with the privileges and network reachability of its process
+- Keep HTTP or SSE bound to localhost and prefer a sandbox or container with narrow mounts when converting untrusted content
 
 ## Notion MCP
 

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -231,7 +231,7 @@ Microsoft's local MCP server converts explicitly supplied file, HTTP, HTTPS, and
 - **Required confirmation gates:** `external_install`, `read_sensitive`
 - **Confirmation:** Confirm installation and the exact URI before each conversion; reject broad local paths, private-network targets, or untrusted remote content unless their read boundary is explicitly approved.
 - **Risk tags:** `local-data`, `sensitive-read`, `network-capable`, `open-world`, `no-authentication`, `prompt-injection`
-- **Evidence:** [1](https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md); [2](https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/src/markitdown_mcp/__main__.py); [3](https://github.com/microsoft/markitdown/releases/tag/v0.1.7)
+- **Evidence:** [1](https://github.com/microsoft/markitdown/blob/fd239d5d2be43d9b68329730206b9312c7d5a388/packages/markitdown-mcp/README.md); [2](https://github.com/microsoft/markitdown/blob/fd239d5d2be43d9b68329730206b9312c7d5a388/packages/markitdown-mcp/src/markitdown_mcp/__main__.py); [3](https://github.com/microsoft/markitdown/releases/tag/v0.1.7)
 - **Health check:** Run the stdio server in a sandbox, list its single convert\_to\_markdown tool, then convert one non-sensitive local fixture from an explicitly allowed directory.
 - **Uninstall:** Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested. (removes user data: No)
 

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -13,7 +13,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Google Workspace CLI](https://github.com/googleworkspace/cli) | `connector` | verified | Yes | Yes | No | Yes | Yes | 2026-08-15 |
 | [Granola MCP](https://docs.granola.ai/help-center/sharing/integrations/mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-15 |
 | [Linear MCP](https://linear.app/docs/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
-| [MarkItDown MCP](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-25 |
+| [MarkItDown MCP](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-24 |
 | [Notion MCP](https://developers.notion.com/guides/mcp/get-started-with-mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-15 |
 | [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-15 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
@@ -223,7 +223,7 @@ Microsoft's local MCP server converts explicitly supplied file, HTTP, HTTPS, and
 
 - **Supported agents:** `claude_code`, `codex`, `gemini_cli`, `cursor`, `opencode`, `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** Python with pip or Docker; An MCP-compatible client; Explicitly bounded file and network access for the server process
+- **Prerequisites:** Python with pip or Docker; An MCP-compatible client; Explicitly bounded file and network access for the server process; Third-party plugins disabled by leaving MARKITDOWN\_ENABLE\_PLUGINS unset or false
 - **Credentials:** None
 - **Reads:** Any local file readable by the server account when given a file URI; Any HTTP or HTTPS resource reachable from the server process, plus caller-supplied data URIs
 - **Writes / external effects:** None
@@ -231,7 +231,7 @@ Microsoft's local MCP server converts explicitly supplied file, HTTP, HTTPS, and
 - **Required confirmation gates:** `external_install`, `read_sensitive`
 - **Confirmation:** Confirm installation and the exact URI before each conversion; reject broad local paths, private-network targets, or untrusted remote content unless their read boundary is explicitly approved.
 - **Risk tags:** `local-data`, `sensitive-read`, `network-capable`, `open-world`, `no-authentication`, `prompt-injection`
-- **Evidence:** [1](https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md); [2](https://github.com/microsoft/markitdown/releases/tag/v0.1.7)
+- **Evidence:** [1](https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/README.md); [2](https://github.com/microsoft/markitdown/blob/9dc0d6579b8739c9d0671ff205e071e3053c7df1/packages/markitdown-mcp/src/markitdown_mcp/__main__.py); [3](https://github.com/microsoft/markitdown/releases/tag/v0.1.7)
 - **Health check:** Run the stdio server in a sandbox, list its single convert\_to\_markdown tool, then convert one non-sensitive local fixture from an explicitly allowed directory.
 - **Uninstall:** Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested. (removes user data: No)
 
@@ -240,6 +240,7 @@ Capabilities and limits:
 - The convert\_to\_markdown tool accepts file, HTTP, HTTPS, and data URIs, so every call must be treated as an explicit sensitive-read boundary
 - The server has no authentication and runs with the privileges and network reachability of its process
 - Keep HTTP or SSE bound to localhost and prefer a sandbox or container with narrow mounts when converting untrusted content
+- This reviewed profile excludes third-party plugins; keep MARKITDOWN\_ENABLE\_PLUGINS unset or false because enabled plugins widen the process execution boundary
 
 ## Notion MCP
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -27,12 +27,13 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
         self.assertEqual(self.catalog["schema_version"], 2)
-        self.assertEqual(len(self.catalog["integrations"]), 13)
+        self.assertEqual(len(self.catalog["integrations"]), 14)
         self.assertTrue(
             {
                 "github-mcp",
                 "google-workspace-cli",
                 "linear-mcp",
+                "markitdown-mcp",
                 "notion-mcp",
                 "readwise-mcp",
             }.issubset(
@@ -46,6 +47,14 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assertIn("immediate public publish action", rendered)
         self.assertTrue(rendered.endswith("\n"))
         self.assertFalse(rendered.endswith("\n\n"))
+
+    def test_markitdown_mcp_is_read_only_but_open_world(self) -> None:
+        item = self.entry("markitdown-mcp")
+        self.assertTrue(item["capabilities"]["read"])
+        self.assertTrue(item["capabilities"]["sensitive_read"])
+        self.assertFalse(item["capabilities"]["write"])
+        self.assertIn("network-capable", item["risk_tags"])
+        self.assertIn("read_sensitive", item["confirmation"]["required_for"])
 
     def test_issue_22_connectors_have_typed_sensitive_and_mutating_gates(self) -> None:
         for integration_id in ("google-workspace-cli", "notion-mcp"):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -53,8 +53,16 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assertTrue(item["capabilities"]["read"])
         self.assertTrue(item["capabilities"]["sensitive_read"])
         self.assertFalse(item["capabilities"]["write"])
+        self.assertFalse(item["capabilities"]["arbitrary_execution"])
         self.assertIn("network-capable", item["risk_tags"])
         self.assertIn("read_sensitive", item["confirmation"]["required_for"])
+        prerequisites = " ".join(item["installation"]["prerequisites"])
+        details = " ".join(item["capabilities"]["details"])
+        self.assertIn("MARKITDOWN_ENABLE_PLUGINS", prerequisites)
+        self.assertIn("excludes third-party plugins", details)
+        self.assertTrue(
+            any(url.endswith("/packages/markitdown-mcp/src/markitdown_mcp/__main__.py") for url in item["evidence"])
+        )
 
     def test_issue_22_connectors_have_typed_sensitive_and_mutating_gates(self) -> None:
         for integration_id in ("google-workspace-cli", "notion-mcp"):


### PR DESCRIPTION
## Summary
- add Microsoft MarkItDown MCP to the integration catalog
- document conservative local and network trust boundaries
- regenerate the reference and add catalog safety coverage

## Validation
- python scripts/integrations.py check
- python -m unittest tests.test_integrations -v (20 passed)

Closes #53