### PR TITLE
Runtime registry, manifest schema v2, and capability authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- A discoverable schema-v2 runtime registry with surface-specific capabilities,
+  probes, instruction and skill precedence, typed evidence, generated JSON Schema
+  and README support claims, plus strict maintainer and conformance checks.
 - `CONTRIBUTING.md` — prerequisites, the validator as the one gate, which files are generated, how to add a catalog entry, skill/adapter structure, and the enforced size limits.
 - `SECURITY.md` — private reporting path, what is in and out of scope, and the design boundaries most likely to be misread (validation is not a publication guarantee; `verified` is a metadata claim; nothing here sandboxes an agent).
 - Issue templates for integration proposals and bug reports, plus contact links routing security reports away from public issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- Runtime descriptors move from schema v1 to the discoverable, incompatible
+  schema v2 with surface-specific capabilities, resolution-only probes,
+  instruction and skill precedence, typed evidence, generated JSON Schema and
+  README support claims, plus strict maintainer and conformance checks.
+
 ### Added
-- A discoverable schema-v2 runtime registry with surface-specific capabilities,
-  probes, instruction and skill precedence, typed evidence, generated JSON Schema
-  and README support claims, plus strict maintainer and conformance checks.
 - `CONTRIBUTING.md` — prerequisites, the validator as the one gate, which files are generated, how to add a catalog entry, skill/adapter structure, and the enforced size limits.
 - `SECURITY.md` — private reporting path, what is in and out of scope, and the design boundaries most likely to be misread (validation is not a publication guarantee; `verified` is a metadata claim; nothing here sandboxes an agent).
 - Issue templates for integration proposals and bug reports, plus contact links routing security reports away from public issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,28 @@ Run it locally rather than discovering a failure in CI. It takes about a minute.
 
 ## Generated files — do not hand-edit
 
-Two files are produced by scripts. Editing them directly means your change is
+Four artifacts are produced by scripts. Editing them directly means your change is
 silently reverted on the next regeneration.
 
 | File | Source of truth | Regenerate with |
 |---|---|---|
 | `references/integrations.md` | `integrations/catalog.json` | `scripts/integrations.py render` |
 | `REPO_MAP.md` | the repository itself | `scripts/generate-repo-map.sh` (gitignored — never commit it) |
+| `runtimes/schema.json` | `contextos/runtime_schema.py` | `scripts/runtime-manifests.py generate` |
+| README registered-host table | validated `runtimes/*.json` descriptors | `scripts/runtime-manifests.py generate` |
+
+## Adding a runtime descriptor
+
+Add `runtimes/<runtime-id>.json`; the lowercase filename stem is the stable ID.
+Copy a current descriptor, declare each host surface independently, and cite
+official evidence for native behavior plus the named local conformance test for
+adapter or advisory behavior. Unknown keys, capability values, evidence claims,
+future dates, missing repository references, and generated-artifact drift all
+fail validation. `generic` is reserved for apply receipts and cannot be a host.
+
+Run `scripts/runtime-manifests.py generate`, add or extend a must-work conformance
+control, then run the full validator. Do not add compatibility-only hosts to the
+generated registered-host block; a shipped descriptor is a support claim.
 
 ## Adding an integration to the catalog
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,18 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 
 ## Host support
 
-| Host | Support level |
+<!-- runtime-support:start -->
+| Host | Tier | Support |
+|---|---|---|
+| Claude Code | first-class | Shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation |
+| Codex | first-class | Shared lifecycle, native skills, project instructions, hooks, and reviewed proposal/apply writes |
+| Hermes Agent | first-class | Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory |
+<!-- runtime-support:end -->
+
+Compatibility paths that are not registered runtime adapters:
+
+| Host | Compatibility path |
 |---|---|
-| Claude Code | Full experience: shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation |
-| Codex | First-class lifecycle, repository skills, trusted project hooks, and the shared deterministic kernel; native memory remains outside the contract |
-| Hermes Agent | `AGENTS.md`, portable skills, the shared kernel, and optional hook adapter; copied skills and native memory remain explicit host boundaries |
 | Gemini CLI / Antigravity CLI | Migration tooling plus portable-skill discovery for continuing enterprise/API-key Gemini CLI; no complete workspace adapter, and no Antigravity discovery or permission parity is claimed |
 | Cursor / OpenClaw | Read `AGENTS.md` from the repository root; portable skills usable where their Agent Skills support allows |
 | claude.ai | Manual consumer of selected knowledge files; no repository writes, hooks, or slash-command parity |

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -16,6 +16,8 @@ from .kernel import (
     install_runtime,
     parse_now,
     read_json,
+    runtime_hook_payload,
+    runtime_manifest,
     start_report,
 )
 
@@ -37,17 +39,20 @@ def parser() -> argparse.ArgumentParser:
     apply = commands.add_parser("apply", help="Apply one exact host-confirmed proposal")
     apply.add_argument("proposal", type=Path)
     apply.add_argument("--confirm", required=True, help="Exact proposal digest printed by propose")
-    apply.add_argument("--runtime", choices=("claude", "codex", "hermes", "generic"), required=True)
+    apply.add_argument("--runtime", metavar="RUNTIME", required=True)
 
     install = commands.add_parser("install", help="Record the selected runtime and print host setup steps")
-    install.add_argument("--runtime", choices=("claude", "codex", "hermes"), required=True)
+    install.add_argument("--runtime", metavar="RUNTIME", required=True)
 
     diagnose = commands.add_parser("doctor", help="Check kernel, state, manifests, locks, and runtime")
-    diagnose.add_argument("--runtime", choices=("claude", "codex", "hermes"))
+    diagnose_selection = diagnose.add_mutually_exclusive_group()
+    diagnose_selection.add_argument("--runtime", metavar="RUNTIME")
+    diagnose_selection.add_argument("--all", action="store_true", help="Validate every shipped runtime descriptor")
 
     hook = commands.add_parser("hook", help="Run a normalized read-only lifecycle hook check")
     hook.add_argument("event", choices=("session-start", "pre-write"))
-    hook.add_argument("--runtime", choices=("claude", "codex", "hermes"), required=True)
+    hook.add_argument("--runtime", metavar="RUNTIME", required=True)
+    hook.add_argument("--surface", metavar="SURFACE")
     return result
 
 
@@ -77,22 +82,24 @@ def main(argv: list[str] | None = None) -> int:
             path, manifest = install_runtime(root, args.runtime)
             emit({"runtime_file": path.relative_to(root).as_posix(), **manifest})
         elif args.command == "doctor":
-            report = doctor(root, args.runtime)
+            report = doctor(root, args.runtime, all_runtimes=args.all)
             emit(report)
             return 1 if report["status"] == "fail" else 0
         elif args.command == "hook":
+            manifest = runtime_manifest(root, args.runtime)
             raw = sys.stdin.read().strip()
             payload = json.loads(raw) if raw else {}
             if not isinstance(payload, dict):
                 raise ContextOSError("hook input must be a JSON object")
             report = hook_report(root, args.event, payload)
             messages = [item["message"] for item in report["findings"]]
-            if args.runtime in {"claude", "codex"}:
-                if messages:
-                    emit({"systemMessage": "\n".join(messages)})
-            else:
-                emit({"action": "allow", "message": "\n".join(messages)})
+            rendered = runtime_hook_payload(manifest, messages, args.surface)
+            if rendered is not None:
+                emit(rendered)
         return 0
     except (ContextOSError, json.JSONDecodeError, OSError, UnicodeError) as exc:
+        if getattr(args, "command", None) == "hook":
+            emit({"systemMessage": f"Context OS advisory hook could not run: {exc}"})
+            return 0
         print(f"context-os: {exc}", file=sys.stderr)
         return 2

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -63,9 +63,7 @@ def emit(value: object) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
-    hook_manifest: dict | None = None
     hook_output: str | None = None
-    hook_output_resolved = False
     try:
         root = discover_root(args.root)
         if args.command == "start":
@@ -97,7 +95,6 @@ def main(argv: list[str] | None = None) -> int:
             }
             if len(surface_outputs) == 1:
                 hook_output = next(iter(surface_outputs))
-            hook_output_resolved = True
             hook_output = runtime_surface(hook_manifest, args.surface).get("hook_output")
             raw = sys.stdin.read().strip()
             payload = json.loads(raw) if raw else {}
@@ -112,10 +109,9 @@ def main(argv: list[str] | None = None) -> int:
     except (ContextOSError, json.JSONDecodeError, OSError, UnicodeError) as exc:
         if getattr(args, "command", None) == "hook":
             message = f"Context OS advisory hook could not run: {exc}"
-            rendered = (
-                render_hook_payload(hook_output, [message])
-                if hook_output_resolved else {"systemMessage": message}
-            )
+            # If no validated descriptor established a host protocol, silence
+            # is safer than emitting another runtime's incompatible envelope.
+            rendered = render_hook_payload(hook_output, [message])
             if rendered is not None:
                 emit(rendered)
             return 0

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -91,8 +91,14 @@ def main(argv: list[str] | None = None) -> int:
             return 1 if report["status"] == "fail" else 0
         elif args.command == "hook":
             hook_manifest = runtime_manifest(root, args.runtime, check_paths=False)
-            hook_output = runtime_surface(hook_manifest, args.surface).get("hook_output")
+            surface_outputs = {
+                surface.get("hook_output")
+                for surface in hook_manifest["surfaces"].values()
+            }
+            if len(surface_outputs) == 1:
+                hook_output = next(iter(surface_outputs))
             hook_output_resolved = True
+            hook_output = runtime_surface(hook_manifest, args.surface).get("hook_output")
             raw = sys.stdin.read().strip()
             payload = json.loads(raw) if raw else {}
             if not isinstance(payload, dict):

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -16,8 +16,9 @@ from .kernel import (
     install_runtime,
     parse_now,
     read_json,
-    runtime_hook_payload,
+    render_hook_payload,
     runtime_manifest,
+    runtime_surface,
     start_report,
 )
 
@@ -62,6 +63,9 @@ def emit(value: object) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
+    hook_manifest: dict | None = None
+    hook_output: str | None = None
+    hook_output_resolved = False
     try:
         root = discover_root(args.root)
         if args.command == "start":
@@ -86,20 +90,28 @@ def main(argv: list[str] | None = None) -> int:
             emit(report)
             return 1 if report["status"] == "fail" else 0
         elif args.command == "hook":
-            manifest = runtime_manifest(root, args.runtime)
+            hook_manifest = runtime_manifest(root, args.runtime, check_paths=False)
+            hook_output = runtime_surface(hook_manifest, args.surface).get("hook_output")
+            hook_output_resolved = True
             raw = sys.stdin.read().strip()
             payload = json.loads(raw) if raw else {}
             if not isinstance(payload, dict):
                 raise ContextOSError("hook input must be a JSON object")
             report = hook_report(root, args.event, payload)
             messages = [item["message"] for item in report["findings"]]
-            rendered = runtime_hook_payload(manifest, messages, args.surface)
+            rendered = render_hook_payload(hook_output, messages)
             if rendered is not None:
                 emit(rendered)
         return 0
     except (ContextOSError, json.JSONDecodeError, OSError, UnicodeError) as exc:
         if getattr(args, "command", None) == "hook":
-            emit({"systemMessage": f"Context OS advisory hook could not run: {exc}"})
+            message = f"Context OS advisory hook could not run: {exc}"
+            rendered = (
+                render_hook_payload(hook_output, [message])
+                if hook_output_resolved else {"systemMessage": message}
+            )
+            if rendered is not None:
+                emit(rendered)
             return 0
         print(f"context-os: {exc}", file=sys.stderr)
         return 2

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -14,6 +14,12 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
+from .runtime_schema import (
+    RUNTIME_ID_RE,
+    RuntimeManifestError,
+    validate_runtime_manifest,
+)
+
 
 SCHEMA_VERSION = 1
 PLACEHOLDER_DATE = "[DATE]"
@@ -27,14 +33,6 @@ SETUP_NEXT_ACTION = (
     "Run the explicit setup workflow (bash scripts/setup.sh, then the $context-setup "
     "skill) before starting a session."
 )
-RUNTIME_NAMES = {"claude", "codex", "hermes"}
-CAPABILITY_VALUES = {"native", "adapter", "advisory", "unsupported"}
-CAPABILITY_KEYS = {
-    "agent_skills", "explicit_invocation", "project_hooks",
-    "blocking_pre_tool_hook", "mcp", "native_memory", "proposal_apply",
-}
-
-
 class ContextOSError(RuntimeError):
     pass
 
@@ -511,7 +509,7 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
     expected_digest = validate_proposal(document)
     if confirmation != expected_digest:
         raise ContextOSError("--confirm must exactly match the proposal_digest")
-    runtime_manifest(root, runtime)
+    validate_execution_runtime(root, runtime)
     with transaction_lock(root):
         for change in document.get("changes", []):
             path = safe_repo_path(root, ensure_text(change.get("path"), "change.path"))
@@ -589,39 +587,64 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
         return receipt_path, receipt
 
 
+def runtime_ids(root: Path) -> list[str]:
+    runtimes_dir = root / "runtimes"
+    if not runtimes_dir.is_dir():
+        return []
+    identifiers = sorted(
+        path.stem for path in runtimes_dir.glob("*.json")
+        if path.name != "schema.json" and path.is_file()
+    )
+    if len(identifiers) != len({identifier.casefold() for identifier in identifiers}):
+        raise ContextOSError("runtime manifest filenames collide when case-folded")
+    return identifiers
+
+
 def runtime_manifest(root: Path, runtime: str) -> dict[str, Any]:
-    if runtime not in RUNTIME_NAMES | {"generic"}:
-        raise ContextOSError(f"unsupported runtime: {runtime}")
+    if not isinstance(runtime, str) or runtime == "generic" or not RUNTIME_ID_RE.fullmatch(runtime):
+        raise ContextOSError(f"invalid runtime id: {runtime}")
     manifest_path = root / "runtimes" / f"{runtime}.json"
     if not manifest_path.exists():
-        if runtime == "generic":
-            return {"runtime": "generic", "capabilities": {}}
         raise ContextOSError(f"missing runtime manifest: {manifest_path}")
     manifest = read_json(manifest_path)
-    required = {"schema_version", "runtime", "instruction_file", "invocation", "capabilities", "install"}
-    invocation = manifest.get("invocation")
-    capabilities = manifest.get("capabilities")
-    install = manifest.get("install")
-    valid = (
-        set(manifest) == required
-        and manifest.get("runtime") == runtime
-        and manifest.get("schema_version") == SCHEMA_VERSION
-        and isinstance(manifest.get("instruction_file"), str)
-        and isinstance(invocation, dict)
-        and set(invocation) == {"setup", "start", "update", "end"}
-        and all(isinstance(value, str) and value for value in invocation.values())
-        and isinstance(capabilities, dict)
-        and set(capabilities) == CAPABILITY_KEYS
-        and set(capabilities.values()) <= CAPABILITY_VALUES
-        and isinstance(install, dict)
-        and set(install) == {"mode", "next_steps"}
-        and isinstance(install.get("mode"), str)
-        and isinstance(install.get("next_steps"), list)
-        and all(isinstance(item, str) and item for item in install["next_steps"])
-    )
-    if not valid:
-        raise ContextOSError(f"invalid runtime manifest: {manifest_path}")
+    try:
+        validate_runtime_manifest(manifest, runtime_id=runtime, root=root)
+    except RuntimeManifestError as exc:
+        raise ContextOSError(f"invalid runtime manifest: {manifest_path} ({exc})") from exc
     return manifest
+
+
+def validate_execution_runtime(root: Path, runtime: str) -> None:
+    if runtime != "generic":
+        runtime_manifest(root, runtime)
+
+
+def runtime_registry(root: Path) -> dict[str, dict[str, Any]]:
+    return {runtime: runtime_manifest(root, runtime) for runtime in runtime_ids(root)}
+
+
+def runtime_surface(manifest: dict[str, Any], surface_id: str | None = None) -> dict[str, Any]:
+    surfaces = manifest.get("surfaces", {})
+    selected = surface_id or ("cli" if "cli" in surfaces else None)
+    if selected is None and len(surfaces) == 1:
+        selected = next(iter(surfaces))
+    if selected not in surfaces:
+        raise ContextOSError(
+            f"runtime {manifest.get('runtime', 'unknown')} has no unambiguous surface"
+        )
+    return surfaces[selected]
+
+
+def runtime_hook_payload(
+    manifest: dict[str, Any], messages: list[str], surface_id: str | None = None
+) -> dict[str, str] | None:
+    message = "\n".join(messages)
+    hook_output = runtime_surface(manifest, surface_id).get("hook_output")
+    if hook_output is None:
+        return None
+    if hook_output == "system-message":
+        return {"systemMessage": message} if message else None
+    return {"action": "allow", "message": message}
 
 
 def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
@@ -719,7 +742,9 @@ def install_runtime(root: Path, runtime: str) -> tuple[Path, dict[str, Any]]:
     return target, local
 
 
-def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
+def doctor(
+    root: Path, runtime: str | None = None, *, all_runtimes: bool = False
+) -> dict[str, Any]:
     checks: list[dict[str, str]] = []
 
     def add(name: str, status: str, detail: str) -> None:
@@ -758,7 +783,7 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
     local_runtime = root / ".context-os" / "runtime.json"
     if selected is None and local_runtime.exists():
         selected = read_json(local_runtime).get("runtime")
-    hosts = [selected] if selected else sorted(RUNTIME_NAMES)
+    hosts = runtime_ids(root) if all_runtimes or not selected else [selected]
     for host in hosts:
         try:
             manifest = runtime_manifest(root, host)
@@ -778,6 +803,7 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
         f"{len(old_artifacts)} artifacts older than 30 days" if old_artifacts else "none older than 30 days",
     )
     if selected:
+        selected_manifest: dict[str, Any] | None = None
         try:
             selected_manifest = runtime_manifest(root, selected)
             expected_source = sha256_text(canonical_json(selected_manifest))
@@ -790,10 +816,35 @@ def doctor(root: Path, runtime: str | None = None) -> dict[str, Any]:
                 )
         except ContextOSError as exc:
             add("runtime-manifest-drift", "fail", str(exc))
-        binary = {"claude": "claude", "codex": "codex", "hermes": "hermes"}.get(selected)
-        if binary:
-            location = shutil.which(binary)
-            add(f"runtime:{selected}", "pass" if location else "warn", location or "not installed")
+        if selected_manifest:
+            for surface_id, surface in selected_manifest["surfaces"].items():
+                for probe in surface["binary_probes"]:
+                    locations = {
+                        candidate: shutil.which(candidate) for candidate in probe["candidates"]
+                    }
+                    executable = next((location for location in locations.values() if location), None)
+                    check_name = f"runtime:{selected}:{surface_id}:{probe['purpose']}"
+                    if probe["purpose"] == "availability" or executable is None:
+                        detail = ", ".join(
+                            f"{candidate}={location or 'not installed'}"
+                            for candidate, location in locations.items()
+                        )
+                        add(check_name, "pass" if executable else "warn", detail)
+                        continue
+                    try:
+                        completed = subprocess.run(
+                            [executable, *probe["args"]], text=True, capture_output=True,
+                            timeout=10, check=False,
+                        )
+                        output = (completed.stdout or completed.stderr).strip().splitlines()
+                        detail = output[0][:240] if output else f"exit {completed.returncode}"
+                        add(
+                            check_name,
+                            "pass" if completed.returncode in probe["success_exit_codes"] else "warn",
+                            detail,
+                        )
+                    except (OSError, subprocess.SubprocessError) as exc:
+                        add(check_name, "warn", str(exc))
     status = "fail" if any(item["status"] == "fail" for item in checks) else "warn" if any(item["status"] == "warn" for item in checks) else "pass"
     return {"schema_version": SCHEMA_VERSION, "status": status, "checks": checks}
 

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -600,7 +600,9 @@ def runtime_ids(root: Path) -> list[str]:
     return identifiers
 
 
-def runtime_manifest(root: Path, runtime: str) -> dict[str, Any]:
+def runtime_manifest(
+    root: Path, runtime: str, *, check_paths: bool = True
+) -> dict[str, Any]:
     if not isinstance(runtime, str) or runtime == "generic" or not RUNTIME_ID_RE.fullmatch(runtime):
         raise ContextOSError(f"invalid runtime id: {runtime}")
     manifest_path = root / "runtimes" / f"{runtime}.json"
@@ -608,7 +610,9 @@ def runtime_manifest(root: Path, runtime: str) -> dict[str, Any]:
         raise ContextOSError(f"missing runtime manifest: {manifest_path}")
     manifest = read_json(manifest_path)
     try:
-        validate_runtime_manifest(manifest, runtime_id=runtime, root=root)
+        validate_runtime_manifest(
+            manifest, runtime_id=runtime, root=root, check_paths=check_paths
+        )
     except RuntimeManifestError as exc:
         raise ContextOSError(f"invalid runtime manifest: {manifest_path} ({exc})") from exc
     return manifest
@@ -616,7 +620,7 @@ def runtime_manifest(root: Path, runtime: str) -> dict[str, Any]:
 
 def validate_execution_runtime(root: Path, runtime: str) -> None:
     if runtime != "generic":
-        runtime_manifest(root, runtime)
+        runtime_manifest(root, runtime, check_paths=False)
 
 
 def runtime_registry(root: Path) -> dict[str, dict[str, Any]]:
@@ -625,12 +629,16 @@ def runtime_registry(root: Path) -> dict[str, dict[str, Any]]:
 
 def runtime_surface(manifest: dict[str, Any], surface_id: str | None = None) -> dict[str, Any]:
     surfaces = manifest.get("surfaces", {})
+    if surface_id is not None and surface_id not in surfaces:
+        raise ContextOSError(
+            f"runtime {manifest.get('runtime', 'unknown')} has no surface {surface_id!r}"
+        )
     selected = surface_id or ("cli" if "cli" in surfaces else None)
     if selected is None and len(surfaces) == 1:
         selected = next(iter(surfaces))
     if selected not in surfaces:
         raise ContextOSError(
-            f"runtime {manifest.get('runtime', 'unknown')} has no unambiguous surface"
+            f"runtime {manifest.get('runtime', 'unknown')} requires an explicit surface"
         )
     return surfaces[selected]
 
@@ -638,8 +646,14 @@ def runtime_surface(manifest: dict[str, Any], surface_id: str | None = None) -> 
 def runtime_hook_payload(
     manifest: dict[str, Any], messages: list[str], surface_id: str | None = None
 ) -> dict[str, str] | None:
-    message = "\n".join(messages)
     hook_output = runtime_surface(manifest, surface_id).get("hook_output")
+    return render_hook_payload(hook_output, messages)
+
+
+def render_hook_payload(
+    hook_output: str | None, messages: list[str]
+) -> dict[str, str] | None:
+    message = "\n".join(messages)
     if hook_output is None:
         return None
     if hook_output == "system-message":
@@ -784,6 +798,8 @@ def doctor(
     if selected is None and local_runtime.exists():
         selected = read_json(local_runtime).get("runtime")
     hosts = runtime_ids(root) if all_runtimes or not selected else [selected]
+    if not hosts:
+        add("manifest-registry", "fail", "no runtime descriptors found")
     for host in hosts:
         try:
             manifest = runtime_manifest(root, host)
@@ -824,27 +840,11 @@ def doctor(
                     }
                     executable = next((location for location in locations.values() if location), None)
                     check_name = f"runtime:{selected}:{surface_id}:{probe['purpose']}"
-                    if probe["purpose"] == "availability" or executable is None:
-                        detail = ", ".join(
-                            f"{candidate}={location or 'not installed'}"
-                            for candidate, location in locations.items()
-                        )
-                        add(check_name, "pass" if executable else "warn", detail)
-                        continue
-                    try:
-                        completed = subprocess.run(
-                            [executable, *probe["args"]], text=True, capture_output=True,
-                            timeout=10, check=False,
-                        )
-                        output = (completed.stdout or completed.stderr).strip().splitlines()
-                        detail = output[0][:240] if output else f"exit {completed.returncode}"
-                        add(
-                            check_name,
-                            "pass" if completed.returncode in probe["success_exit_codes"] else "warn",
-                            detail,
-                        )
-                    except (OSError, subprocess.SubprocessError) as exc:
-                        add(check_name, "warn", str(exc))
+                    detail = ", ".join(
+                        f"{candidate}={location or 'not installed'}"
+                        for candidate, location in locations.items()
+                    )
+                    add(check_name, "pass" if executable else "warn", detail)
     status = "fail" if any(item["status"] == "fail" for item in checks) else "warn" if any(item["status"] == "warn" for item in checks) else "pass"
     return {"schema_version": SCHEMA_VERSION, "status": status, "checks": checks}
 

--- a/contextos/runtime_schema.py
+++ b/contextos/runtime_schema.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+RUNTIME_DESCRIPTOR_SCHEMA_VERSION = 2
+RUNTIME_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+COMPONENT_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+EXECUTABLE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
+SAFE_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+CAPABILITY_VALUES = {"native", "adapter", "advisory", "unsupported"}
+CAPABILITY_KEYS = {
+    "agent_skills",
+    "explicit_invocation",
+    "project_hooks",
+    "blocking_pre_tool_hook",
+    "mcp",
+    "native_memory",
+    "proposal_apply",
+    "skill_allowlists",
+    "execution_authorization",
+}
+SUPPORT_TIERS = {"first-class", "experimental", "compatibility", "deprecated"}
+SURFACE_KINDS = {"cli", "ide", "cloud", "review", "gateway", "messaging", "environment"}
+HOOK_OUTPUT_MODES = {"system-message", "allow-message"}
+PROBE_PURPOSES = {"availability", "version", "native-doctor"}
+INVOCATION_KEYS = {"setup", "start", "update", "end"}
+TOP_LEVEL_KEYS = {
+    "schema_version", "runtime", "display_name", "support_tier", "support_summary",
+    "components", "install", "onboarding_doc", "surfaces", "evidence",
+}
+SURFACE_KEYS = {
+    "kind", "support_tier", "instruction_sources", "skill_sources", "invocation",
+    "capabilities", "hook_output", "binary_probes", "conformance_test", "evidence",
+}
+POSITIVE_CAPABILITIES = CAPABILITY_VALUES - {"unsupported"}
+EVIDENCE_CLAIMS = CAPABILITY_KEYS | {
+    "hook_output", "instruction_sources", "invocation", "skill_sources", "support"
+}
+SOURCE_SCOPES = {"repository", "workspace", "user", "runtime"}
+SOURCE_ROLES = {"canonical", "additive", "memory", "persona", "skills"}
+SOURCE_KEYS = {"scope", "role", "path", "precedence"}
+EVIDENCE_SOURCE_KEYS = {"id", "type", "location", "claims"}
+EVIDENCE_SOURCE_TYPES = {"official", "conformance"}
+
+
+class RuntimeManifestError(ValueError):
+    pass
+
+
+def _fail(field: str, message: str) -> None:
+    raise RuntimeManifestError(f"{field}: {message}")
+
+
+def _exact_keys(value: Any, expected: set[str], field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _fail(field, "must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        details = []
+        if missing:
+            details.append(f"missing {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown {', '.join(unknown)}")
+        _fail(field, "; ".join(details))
+    return value
+
+
+def _string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail(field, "must be a non-empty string without surrounding whitespace")
+    if any(ord(character) < 32 for character in value):
+        _fail(field, "must not contain control characters")
+    return value
+
+
+def _nullable_string(value: Any, field: str) -> str | None:
+    return None if value is None else _string(value, field)
+
+
+def _enum(value: Any, allowed: set[str], field: str) -> str:
+    result = _string(value, field)
+    if result not in allowed:
+        _fail(field, f"unsupported value {result!r}")
+    return result
+
+
+def _unique_strings(value: Any, field: str, *, minimum: int = 0) -> list[str]:
+    if not isinstance(value, list):
+        _fail(field, "must be an array")
+    result = [_string(item, f"{field}[{index}]") for index, item in enumerate(value)]
+    if len(result) < minimum:
+        _fail(field, f"must contain at least {minimum} item(s)")
+    if len(result) != len(set(result)):
+        _fail(field, "must not contain duplicates")
+    return result
+
+
+def _repo_path(root: Path, value: Any, field: str) -> str:
+    raw = _string(value, field)
+    if "\\" in raw:
+        _fail(field, "must use repository-relative POSIX separators")
+    relative = Path(raw)
+    if relative.is_absolute():
+        _fail(field, "must be repository-relative")
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError:
+        _fail(field, "must not escape the repository")
+    if not resolved.exists():
+        _fail(field, f"path does not exist: {raw}")
+    return raw
+
+
+def _source_reference(root: Path, value: Any, field: str) -> None:
+    source = _exact_keys(value, SOURCE_KEYS, field)
+    scope = _enum(source.get("scope"), SOURCE_SCOPES, f"{field}.scope")
+    _enum(source.get("role"), SOURCE_ROLES, f"{field}.role")
+    path = _string(source.get("path"), f"{field}.path")
+    precedence = source.get("precedence")
+    if type(precedence) is not int or precedence < 0:
+        _fail(f"{field}.precedence", "must be a non-negative integer")
+    if scope == "repository":
+        _repo_path(root, path, f"{field}.path")
+    elif Path(path).is_absolute() or "\\" in path or ".." in Path(path).parts:
+        _fail(f"{field}.path", "must be a safe logical relative path")
+
+
+def _schema_string() -> dict[str, Any]:
+    return {"type": "string", "minLength": 1, "pattern": r"^(?!\s)(?:[^\x00-\x1f]*\S)$"}
+
+
+def validate_runtime_manifest(
+    manifest: Any, *, runtime_id: str, root: Path, today: date | None = None
+) -> dict[str, Any]:
+    if runtime_id == "generic" or not RUNTIME_ID_RE.fullmatch(runtime_id):
+        _fail("runtime", f"invalid or reserved runtime id {runtime_id!r}")
+    document = _exact_keys(manifest, TOP_LEVEL_KEYS, "manifest")
+    if document.get("schema_version") != RUNTIME_DESCRIPTOR_SCHEMA_VERSION:
+        _fail("schema_version", f"must equal {RUNTIME_DESCRIPTOR_SCHEMA_VERSION}")
+    if document.get("runtime") != runtime_id:
+        _fail("runtime", f"must match filename stem {runtime_id!r}")
+
+    _string(document.get("display_name"), "display_name")
+    _enum(document.get("support_tier"), SUPPORT_TIERS, "support_tier")
+    _string(document.get("support_summary"), "support_summary")
+    components = _unique_strings(document.get("components"), "components", minimum=1)
+    for index, component in enumerate(components):
+        if not COMPONENT_ID_RE.fullmatch(component):
+            _fail(f"components[{index}]", f"invalid component id {component!r}")
+
+    install = _exact_keys(document.get("install"), {"mode", "next_steps"}, "install")
+    _string(install.get("mode"), "install.mode")
+    _unique_strings(install.get("next_steps"), "install.next_steps", minimum=1)
+    _repo_path(root, document.get("onboarding_doc"), "onboarding_doc")
+
+    evidence = _exact_keys(
+        document.get("evidence"), {"checked_on", "tested_versions", "sources"}, "evidence"
+    )
+    checked_on = _string(evidence.get("checked_on"), "evidence.checked_on")
+    try:
+        checked_date = date.fromisoformat(checked_on)
+    except ValueError:
+        _fail("evidence.checked_on", "must be an ISO-8601 date")
+    if checked_date > (today or date.today()):
+        _fail("evidence.checked_on", "must not be in the future")
+
+    sources = evidence.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _fail("evidence.sources", "must be a non-empty array")
+    source_claims: dict[str, tuple[str, set[str], str]] = {}
+    for index, source in enumerate(sources):
+        field = f"evidence.sources[{index}]"
+        item = _exact_keys(source, EVIDENCE_SOURCE_KEYS, field)
+        source_id = _string(item.get("id"), f"{field}.id")
+        if not SAFE_ID_RE.fullmatch(source_id):
+            _fail(f"{field}.id", f"invalid evidence id {source_id!r}")
+        if source_id in source_claims:
+            _fail("evidence.sources", f"duplicate evidence id {source_id!r}")
+        source_type = _enum(item.get("type"), EVIDENCE_SOURCE_TYPES, f"{field}.type")
+        location = _string(item.get("location"), f"{field}.location")
+        if source_type == "official":
+            parsed = urlparse(location)
+            if parsed.scheme != "https" or not parsed.netloc:
+                _fail(f"{field}.location", "official evidence must be an absolute HTTPS URL")
+        else:
+            _repo_path(root, location, f"{field}.location")
+        claims = _unique_strings(item.get("claims"), f"{field}.claims", minimum=1)
+        for claim_index, claim in enumerate(claims):
+            _enum(claim, EVIDENCE_CLAIMS, f"{field}.claims[{claim_index}]")
+        source_claims[source_id] = (source_type, set(claims), location)
+
+    surfaces = document.get("surfaces")
+    if not isinstance(surfaces, dict) or not surfaces:
+        _fail("surfaces", "must be a non-empty object")
+    if len(surfaces) != len({key.casefold() for key in surfaces}):
+        _fail("surfaces", "surface ids must be unique when case-folded")
+
+    parsed_surfaces: dict[str, dict[str, Any]] = {}
+    for surface_id, raw_surface in surfaces.items():
+        field = f"surfaces.{surface_id}"
+        if not isinstance(surface_id, str) or not SAFE_ID_RE.fullmatch(surface_id):
+            _fail("surfaces", f"invalid surface id {surface_id!r}")
+        surface = _exact_keys(raw_surface, SURFACE_KEYS, field)
+        _enum(surface.get("kind"), SURFACE_KINDS, f"{field}.kind")
+        tier = _enum(surface.get("support_tier"), SUPPORT_TIERS, f"{field}.support_tier")
+        for source_field in ("instruction_sources", "skill_sources"):
+            references = surface.get(source_field)
+            if not isinstance(references, list):
+                _fail(f"{field}.{source_field}", "must be an array")
+            seen_references: set[tuple[str, str]] = set()
+            seen_precedence: set[int] = set()
+            for index, reference in enumerate(references):
+                reference_field = f"{field}.{source_field}[{index}]"
+                _source_reference(root, reference, reference_field)
+                identity = (reference["scope"], reference["path"])
+                if identity in seen_references:
+                    _fail(f"{field}.{source_field}", f"duplicate source {identity!r}")
+                seen_references.add(identity)
+                if reference["precedence"] in seen_precedence:
+                    _fail(
+                        f"{field}.{source_field}",
+                        f"duplicate precedence {reference['precedence']}",
+                    )
+                seen_precedence.add(reference["precedence"])
+        invocation = _exact_keys(surface.get("invocation"), INVOCATION_KEYS, f"{field}.invocation")
+        for key, value in invocation.items():
+            _nullable_string(value, f"{field}.invocation.{key}")
+        capabilities = _exact_keys(surface.get("capabilities"), CAPABILITY_KEYS, f"{field}.capabilities")
+        for key, value in capabilities.items():
+            _enum(value, CAPABILITY_VALUES, f"{field}.capabilities.{key}")
+        hook_output = surface.get("hook_output")
+        if hook_output is not None:
+            _enum(hook_output, HOOK_OUTPUT_MODES, f"{field}.hook_output")
+
+        probes = surface.get("binary_probes")
+        if not isinstance(probes, list):
+            _fail(f"{field}.binary_probes", "must be an array")
+        probe_purposes: set[str] = set()
+        for index, probe in enumerate(probes):
+            probe_field = f"{field}.binary_probes[{index}]"
+            item = _exact_keys(
+                probe, {"purpose", "candidates", "args", "success_exit_codes"}, probe_field
+            )
+            purpose = _enum(item.get("purpose"), PROBE_PURPOSES, f"{probe_field}.purpose")
+            if purpose in probe_purposes:
+                _fail(f"{field}.binary_probes", f"duplicate purpose {purpose!r}")
+            probe_purposes.add(purpose)
+            candidates = _unique_strings(item.get("candidates"), f"{probe_field}.candidates", minimum=1)
+            for candidate_index, candidate in enumerate(candidates):
+                if not EXECUTABLE_RE.fullmatch(candidate):
+                    _fail(f"{probe_field}.candidates[{candidate_index}]", "invalid executable name")
+            _unique_strings(item.get("args"), f"{probe_field}.args")
+            codes = item.get("success_exit_codes")
+            if not isinstance(codes, list) or not codes or any(type(code) is not int for code in codes):
+                _fail(f"{probe_field}.success_exit_codes", "must be a non-empty array of integers")
+            if len(codes) != len(set(codes)):
+                _fail(f"{probe_field}.success_exit_codes", "must not contain duplicates")
+
+        _repo_path(root, surface.get("conformance_test"), f"{field}.conformance_test")
+        conformance_test = surface["conformance_test"]
+        evidence_ids = _unique_strings(surface.get("evidence"), f"{field}.evidence", minimum=1)
+        unknown_evidence = sorted(set(evidence_ids) - set(source_claims))
+        if unknown_evidence:
+            _fail(f"{field}.evidence", f"unknown evidence ids: {', '.join(unknown_evidence)}")
+        covered = set().union(*(source_claims[item][1] for item in evidence_ids))
+        required_claims = {
+            key for key, value in capabilities.items() if value in POSITIVE_CAPABILITIES
+        }
+        required_claims.add("support")
+        if surface["instruction_sources"]:
+            required_claims.add("instruction_sources")
+        if surface["skill_sources"]:
+            required_claims.add("skill_sources")
+        if any(value is not None for value in invocation.values()):
+            required_claims.add("invocation")
+        if hook_output is not None:
+            required_claims.add("hook_output")
+        missing_claims = sorted(required_claims - covered)
+        if missing_claims:
+            _fail(f"{field}.evidence", f"does not cover claims: {', '.join(missing_claims)}")
+        for capability, value in capabilities.items():
+            if value not in POSITIVE_CAPABILITIES:
+                continue
+            required_type = "official" if value == "native" else "conformance"
+            if not any(
+                source_claims[evidence_id][0] == required_type
+                and capability in source_claims[evidence_id][1]
+                and (
+                    required_type != "conformance"
+                    or source_claims[evidence_id][2] == conformance_test
+                )
+                for evidence_id in evidence_ids
+            ):
+                _fail(
+                    f"{field}.evidence",
+                    f"{capability}={value} requires {required_type} evidence",
+                )
+        parsed_surfaces[surface_id] = {"tier": tier}
+
+        if tier == "first-class" and any(value is None for value in invocation.values()):
+            _fail(f"{field}.invocation", "first-class surfaces require all lifecycle invocations")
+
+    tested_versions = evidence.get("tested_versions")
+    if not isinstance(tested_versions, list):
+        _fail("evidence.tested_versions", "must be an array")
+    tested_surface_ids: set[str] = set()
+    for index, tested in enumerate(tested_versions):
+        field = f"evidence.tested_versions[{index}]"
+        item = _exact_keys(tested, {"surface", "version"}, field)
+        surface_id = _string(item.get("surface"), f"{field}.surface")
+        if surface_id not in parsed_surfaces:
+            _fail(f"{field}.surface", f"unknown surface {surface_id!r}")
+        if surface_id in tested_surface_ids:
+            _fail("evidence.tested_versions", f"duplicate surface {surface_id!r}")
+        tested_surface_ids.add(surface_id)
+        _string(item.get("version"), f"{field}.version")
+    first_class = {
+        surface_id for surface_id, item in parsed_surfaces.items() if item["tier"] == "first-class"
+    }
+    if missing := sorted(first_class - tested_surface_ids):
+        _fail("evidence.tested_versions", f"missing first-class surfaces: {', '.join(missing)}")
+    if document["support_tier"] == "first-class" and not first_class:
+        _fail("support_tier", "first-class runtimes require a first-class surface")
+    tier_rank = {"first-class": 0, "experimental": 1, "compatibility": 2, "deprecated": 3}
+    strongest_surface_tier = min(
+        (item["tier"] for item in parsed_surfaces.values()), key=tier_rank.__getitem__
+    )
+    if document["support_tier"] != strongest_surface_tier:
+        _fail("support_tier", f"must match strongest surface tier {strongest_surface_tier!r}")
+    return document
+
+
+def runtime_schema_document() -> dict[str, Any]:
+    text = _schema_string()
+    nullable_text = {"oneOf": [text, {"type": "null"}]}
+    capability_properties = {
+        key: {"enum": sorted(CAPABILITY_VALUES)} for key in sorted(CAPABILITY_KEYS)
+    }
+    source_reference = {
+        "type": "object", "additionalProperties": False, "required": sorted(SOURCE_KEYS),
+        "properties": {
+            "scope": {"enum": sorted(SOURCE_SCOPES)},
+            "role": {"enum": sorted(SOURCE_ROLES)},
+            "path": text,
+            "precedence": {"type": "integer", "minimum": 0},
+        },
+    }
+    surface = {
+        "type": "object", "additionalProperties": False, "required": sorted(SURFACE_KEYS),
+        "properties": {
+            "kind": {"enum": sorted(SURFACE_KINDS)},
+            "support_tier": {"enum": sorted(SUPPORT_TIERS)},
+            "instruction_sources": {"type": "array", "uniqueItems": True, "items": source_reference},
+            "skill_sources": {"type": "array", "uniqueItems": True, "items": source_reference},
+            "invocation": {"type": "object", "additionalProperties": False,
+                "required": sorted(INVOCATION_KEYS),
+                "properties": {key: nullable_text for key in sorted(INVOCATION_KEYS)}},
+            "capabilities": {"type": "object", "additionalProperties": False,
+                "required": sorted(CAPABILITY_KEYS), "properties": capability_properties},
+            "hook_output": {"oneOf": [{"enum": sorted(HOOK_OUTPUT_MODES)}, {"type": "null"}]},
+            "binary_probes": {"type": "array", "items": {"type": "object",
+                "additionalProperties": False,
+                "required": ["args", "candidates", "purpose", "success_exit_codes"],
+                "properties": {
+                    "purpose": {"enum": sorted(PROBE_PURPOSES)},
+                    "candidates": {"type": "array", "minItems": 1, "uniqueItems": True,
+                        "items": {"type": "string", "pattern": EXECUTABLE_RE.pattern}},
+                    "args": {"type": "array", "uniqueItems": True, "items": text},
+                    "success_exit_codes": {"type": "array", "minItems": 1, "uniqueItems": True,
+                        "items": {"type": "integer"}},
+                }}},
+            "conformance_test": text,
+            "evidence": {"type": "array", "minItems": 1, "uniqueItems": True, "items": text},
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$comment": (
+            "Generated structural subset. contextos.runtime_schema is authoritative for "
+            "repository paths, evidence coverage, dates, reserved IDs, and cross-field rules."
+        ),
+        "title": "Context OS runtime descriptor", "type": "object",
+        "additionalProperties": False, "required": sorted(TOP_LEVEL_KEYS),
+        "properties": {
+            "schema_version": {"const": RUNTIME_DESCRIPTOR_SCHEMA_VERSION},
+            "runtime": {"type": "string", "pattern": r"^(?!generic$)[a-z][a-z0-9-]*$"},
+            "display_name": text,
+            "support_tier": {"enum": sorted(SUPPORT_TIERS)},
+            "support_summary": text,
+            "components": {"type": "array", "minItems": 1, "uniqueItems": True,
+                "items": {"type": "string", "pattern": COMPONENT_ID_RE.pattern}},
+            "install": {"type": "object", "additionalProperties": False,
+                "required": ["mode", "next_steps"],
+                "properties": {"mode": text, "next_steps": {"type": "array", "minItems": 1,
+                    "uniqueItems": True, "items": text}}},
+            "onboarding_doc": text,
+            "surfaces": {"type": "object", "minProperties": 1,
+                "propertyNames": {"pattern": SAFE_ID_RE.pattern}, "additionalProperties": surface},
+            "evidence": {"type": "object", "additionalProperties": False,
+                "required": ["checked_on", "sources", "tested_versions"],
+                "properties": {
+                    "checked_on": {"type": "string", "format": "date"},
+                    "tested_versions": {"type": "array", "items": {"type": "object",
+                        "additionalProperties": False, "required": ["surface", "version"],
+                        "properties": {"surface": text, "version": text}}},
+                    "sources": {"type": "array", "minItems": 1, "items": {"type": "object",
+                        "additionalProperties": False, "required": sorted(EVIDENCE_SOURCE_KEYS),
+                        "properties": {"id": {"type": "string", "pattern": SAFE_ID_RE.pattern},
+                            "type": {"enum": sorted(EVIDENCE_SOURCE_TYPES)},
+                            "location": text,
+                            "claims": {"type": "array", "minItems": 1, "uniqueItems": True,
+                                "items": {"enum": sorted(EVIDENCE_CLAIMS)}}}}},
+                }},
+        },
+    }

--- a/contextos/runtime_schema.py
+++ b/contextos/runtime_schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import date
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 from urllib.parse import urlparse
 
@@ -36,7 +36,7 @@ TOP_LEVEL_KEYS = {
 }
 SURFACE_KEYS = {
     "kind", "support_tier", "instruction_sources", "skill_sources", "invocation",
-    "capabilities", "hook_output", "binary_probes", "conformance_test", "evidence",
+    "capabilities", "hook_output", "binary_probes", "conformance_tests", "evidence",
 }
 POSITIVE_CAPABILITIES = CAPABILITY_VALUES - {"unsupported"}
 EVIDENCE_CLAIMS = CAPABILITY_KEYS | {
@@ -103,7 +103,7 @@ def _unique_strings(value: Any, field: str, *, minimum: int = 0) -> list[str]:
     return result
 
 
-def _repo_path(root: Path, value: Any, field: str) -> str:
+def _repo_path(root: Path, value: Any, field: str, *, must_exist: bool = True) -> str:
     raw = _string(value, field)
     if "\\" in raw:
         _fail(field, "must use repository-relative POSIX separators")
@@ -115,12 +115,14 @@ def _repo_path(root: Path, value: Any, field: str) -> str:
         resolved.relative_to(root.resolve())
     except ValueError:
         _fail(field, "must not escape the repository")
-    if not resolved.exists():
+    if must_exist and not resolved.exists():
         _fail(field, f"path does not exist: {raw}")
     return raw
 
 
-def _source_reference(root: Path, value: Any, field: str) -> None:
+def _source_reference(
+    root: Path, value: Any, field: str, *, check_paths: bool
+) -> None:
     source = _exact_keys(value, SOURCE_KEYS, field)
     scope = _enum(source.get("scope"), SOURCE_SCOPES, f"{field}.scope")
     _enum(source.get("role"), SOURCE_ROLES, f"{field}.role")
@@ -129,8 +131,13 @@ def _source_reference(root: Path, value: Any, field: str) -> None:
     if type(precedence) is not int or precedence < 0:
         _fail(f"{field}.precedence", "must be a non-negative integer")
     if scope == "repository":
-        _repo_path(root, path, f"{field}.path")
-    elif Path(path).is_absolute() or "\\" in path or ".." in Path(path).parts:
+        _repo_path(root, path, f"{field}.path", must_exist=check_paths)
+    elif (
+        PurePosixPath(path).is_absolute()
+        or PureWindowsPath(path).is_absolute()
+        or "\\" in path
+        or ".." in PurePosixPath(path).parts
+    ):
         _fail(f"{field}.path", "must be a safe logical relative path")
 
 
@@ -139,7 +146,8 @@ def _schema_string() -> dict[str, Any]:
 
 
 def validate_runtime_manifest(
-    manifest: Any, *, runtime_id: str, root: Path, today: date | None = None
+    manifest: Any, *, runtime_id: str, root: Path, today: date | None = None,
+    check_paths: bool = True,
 ) -> dict[str, Any]:
     if runtime_id == "generic" or not RUNTIME_ID_RE.fullmatch(runtime_id):
         _fail("runtime", f"invalid or reserved runtime id {runtime_id!r}")
@@ -160,17 +168,21 @@ def validate_runtime_manifest(
     install = _exact_keys(document.get("install"), {"mode", "next_steps"}, "install")
     _string(install.get("mode"), "install.mode")
     _unique_strings(install.get("next_steps"), "install.next_steps", minimum=1)
-    _repo_path(root, document.get("onboarding_doc"), "onboarding_doc")
+    _repo_path(
+        root, document.get("onboarding_doc"), "onboarding_doc", must_exist=check_paths
+    )
 
     evidence = _exact_keys(
         document.get("evidence"), {"checked_on", "tested_versions", "sources"}, "evidence"
     )
     checked_on = _string(evidence.get("checked_on"), "evidence.checked_on")
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", checked_on):
+        _fail("evidence.checked_on", "must use YYYY-MM-DD format")
     try:
         checked_date = date.fromisoformat(checked_on)
     except ValueError:
         _fail("evidence.checked_on", "must be an ISO-8601 date")
-    if checked_date > (today or date.today()):
+    if check_paths and checked_date > (today or date.today()):
         _fail("evidence.checked_on", "must not be in the future")
 
     sources = evidence.get("sources")
@@ -192,7 +204,7 @@ def validate_runtime_manifest(
             if parsed.scheme != "https" or not parsed.netloc:
                 _fail(f"{field}.location", "official evidence must be an absolute HTTPS URL")
         else:
-            _repo_path(root, location, f"{field}.location")
+            _repo_path(root, location, f"{field}.location", must_exist=check_paths)
         claims = _unique_strings(item.get("claims"), f"{field}.claims", minimum=1)
         for claim_index, claim in enumerate(claims):
             _enum(claim, EVIDENCE_CLAIMS, f"{field}.claims[{claim_index}]")
@@ -220,7 +232,7 @@ def validate_runtime_manifest(
             seen_precedence: set[int] = set()
             for index, reference in enumerate(references):
                 reference_field = f"{field}.{source_field}[{index}]"
-                _source_reference(root, reference, reference_field)
+                _source_reference(root, reference, reference_field, check_paths=check_paths)
                 identity = (reference["scope"], reference["path"])
                 if identity in seen_references:
                     _fail(f"{field}.{source_field}", f"duplicate source {identity!r}")
@@ -247,9 +259,7 @@ def validate_runtime_manifest(
         probe_purposes: set[str] = set()
         for index, probe in enumerate(probes):
             probe_field = f"{field}.binary_probes[{index}]"
-            item = _exact_keys(
-                probe, {"purpose", "candidates", "args", "success_exit_codes"}, probe_field
-            )
+            item = _exact_keys(probe, {"purpose", "candidates"}, probe_field)
             purpose = _enum(item.get("purpose"), PROBE_PURPOSES, f"{probe_field}.purpose")
             if purpose in probe_purposes:
                 _fail(f"{field}.binary_probes", f"duplicate purpose {purpose!r}")
@@ -258,15 +268,15 @@ def validate_runtime_manifest(
             for candidate_index, candidate in enumerate(candidates):
                 if not EXECUTABLE_RE.fullmatch(candidate):
                     _fail(f"{probe_field}.candidates[{candidate_index}]", "invalid executable name")
-            _unique_strings(item.get("args"), f"{probe_field}.args")
-            codes = item.get("success_exit_codes")
-            if not isinstance(codes, list) or not codes or any(type(code) is not int for code in codes):
-                _fail(f"{probe_field}.success_exit_codes", "must be a non-empty array of integers")
-            if len(codes) != len(set(codes)):
-                _fail(f"{probe_field}.success_exit_codes", "must not contain duplicates")
 
-        _repo_path(root, surface.get("conformance_test"), f"{field}.conformance_test")
-        conformance_test = surface["conformance_test"]
+        conformance_tests = _unique_strings(
+            surface.get("conformance_tests"), f"{field}.conformance_tests", minimum=1
+        )
+        for index, conformance_test in enumerate(conformance_tests):
+            _repo_path(
+                root, conformance_test, f"{field}.conformance_tests[{index}]",
+                must_exist=check_paths,
+            )
         evidence_ids = _unique_strings(surface.get("evidence"), f"{field}.evidence", minimum=1)
         unknown_evidence = sorted(set(evidence_ids) - set(source_claims))
         if unknown_evidence:
@@ -296,7 +306,7 @@ def validate_runtime_manifest(
                 and capability in source_claims[evidence_id][1]
                 and (
                     required_type != "conformance"
-                    or source_claims[evidence_id][2] == conformance_test
+                    or source_claims[evidence_id][2] in conformance_tests
                 )
                 for evidence_id in evidence_ids
             ):
@@ -369,16 +379,15 @@ def runtime_schema_document() -> dict[str, Any]:
             "hook_output": {"oneOf": [{"enum": sorted(HOOK_OUTPUT_MODES)}, {"type": "null"}]},
             "binary_probes": {"type": "array", "items": {"type": "object",
                 "additionalProperties": False,
-                "required": ["args", "candidates", "purpose", "success_exit_codes"],
+                "required": ["candidates", "purpose"],
                 "properties": {
                     "purpose": {"enum": sorted(PROBE_PURPOSES)},
                     "candidates": {"type": "array", "minItems": 1, "uniqueItems": True,
                         "items": {"type": "string", "pattern": EXECUTABLE_RE.pattern}},
-                    "args": {"type": "array", "uniqueItems": True, "items": text},
-                    "success_exit_codes": {"type": "array", "minItems": 1, "uniqueItems": True,
-                        "items": {"type": "integer"}},
                 }}},
-            "conformance_test": text,
+            "conformance_tests": {
+                "type": "array", "minItems": 1, "uniqueItems": True, "items": text
+            },
             "evidence": {"type": "array", "minItems": 1, "uniqueItems": True, "items": text},
         },
     }

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -12,8 +12,9 @@ models, tool names, or native memory.
    judgment without owning mutation mechanics.
 3. **Deterministic kernel:** `bash scripts/contextos.sh` owns paths, rendering,
    invariants, proposals, locks, optimistic hashes, applies, and receipts.
-4. **Runtime adapters:** `.claude/`, `.codex/`, and `adapters/hermes/` map host
-   discovery and hooks to the portable layers.
+4. **Runtime adapters:** discoverable schema-v2 descriptors in `runtimes/` map
+   each host surface to instructions, skills, lifecycle invocations, probes,
+   capabilities, and evidence. Provider files remain in their adapter directories.
 5. **Conformance:** dependency-light tests assert exact state transitions;
    opt-in launch tests exercise installed host discovery without hiding skips.
 
@@ -22,9 +23,9 @@ models, tool names, or native memory.
 ```text
 bash scripts/contextos.sh start [--now ISO_TIMESTAMP]
 bash scripts/contextos.sh propose setup|update|end --input payload.json [--now ISO_TIMESTAMP]
-bash scripts/contextos.sh apply proposal.json --confirm SHA256 --runtime claude|codex|hermes
-bash scripts/contextos.sh install --runtime claude|codex|hermes
-bash scripts/contextos.sh doctor [--runtime claude|codex|hermes]
+bash scripts/contextos.sh apply proposal.json --confirm SHA256 --runtime RUNTIME
+bash scripts/contextos.sh install --runtime RUNTIME
+bash scripts/contextos.sh doctor [--runtime RUNTIME | --all]
 ```
 
 `--now` exists for deterministic fixtures. Production calls use local time.
@@ -60,10 +61,14 @@ memory. Those actions remain separate approval boundaries.
 
 ## Capabilities and degradation
 
-`runtimes/*.json` declares host capabilities as `native`, `adapter`,
-`advisory`, or `unsupported`. Adapters may improve presentation or catch errors
-earlier, but unsupported hooks never weaken kernel enforcement. Hermes copied
-skills can drift, so installation and `doctor` report that boundary explicitly.
+`runtimes/*.json` declares capabilities per host surface as `native`, `adapter`,
+`advisory`, or `unsupported`. `contextos/runtime_schema.py` is the authoritative
+contract and deterministically generates `runtimes/schema.json`; validation
+fails if the generated schema or README support table drifts. `generic` is a
+reserved apply-receipt identity, never a discoverable or installable runtime.
+Adapters may improve presentation or catch errors earlier, but unsupported hooks
+never weaken kernel enforcement. Hermes copied skills can drift, so installation
+and `doctor` report that boundary explicitly.
 
 ## Conformance policy
 

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -70,6 +70,11 @@ Adapters may improve presentation or catch errors earlier, but unsupported hooks
 never weaken kernel enforcement. Hermes copied skills can drift, so installation
 and `doctor` report that boundary explicitly.
 
+Binary probes are declarative, resolution-only checks. `doctor` may resolve the
+listed executable candidates with `PATH`, but runtime descriptors cannot supply
+arguments or cause a process to execute. Native diagnostic execution requires a
+separate code-owned trust policy.
+
 ## Conformance policy
 
 Every lifecycle mutation needs:

--- a/runtimes/claude.json
+++ b/runtimes/claude.json
@@ -38,11 +38,15 @@
       },
       "hook_output": "system-message",
       "binary_probes": [
-        {"purpose": "availability", "candidates": ["claude"], "args": [], "success_exit_codes": [0]},
-        {"purpose": "version", "candidates": ["claude"], "args": ["--version"], "success_exit_codes": [0]}
+        {"purpose": "availability", "candidates": ["claude"]},
+        {"purpose": "version", "candidates": ["claude"]}
       ],
-      "conformance_test": "tests/test_runtime_conformance.py",
-      "evidence": ["claude-settings", "claude-hooks", "claude-conformance"]
+      "conformance_tests": [
+        "tests/test_contextos_kernel.py",
+        "tests/test_cross_runtime_hooks.py",
+        "tests/test_runtime_conformance.py"
+      ],
+      "evidence": ["claude-settings", "claude-hooks", "claude-kernel", "claude-conformance"]
     }
   },
   "evidence": {
@@ -62,10 +66,16 @@
         "claims": ["project_hooks", "blocking_pre_tool_hook", "hook_output"]
       },
       {
+        "id": "claude-kernel",
+        "type": "conformance",
+        "location": "tests/test_contextos_kernel.py",
+        "claims": ["proposal_apply"]
+      },
+      {
         "id": "claude-conformance",
         "type": "conformance",
         "location": "tests/test_runtime_conformance.py",
-        "claims": ["proposal_apply", "support"]
+        "claims": ["support"]
       }
     ]
   }

--- a/runtimes/claude.json
+++ b/runtimes/claude.json
@@ -1,27 +1,72 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "runtime": "claude",
-  "instruction_file": "CLAUDE.md",
-  "invocation": {
-    "setup": "/setup",
-    "start": "/start",
-    "update": "/update",
-    "end": "/end"
-  },
-  "capabilities": {
-    "agent_skills": "native",
-    "explicit_invocation": "native",
-    "project_hooks": "native",
-    "blocking_pre_tool_hook": "native",
-    "mcp": "native",
-    "native_memory": "native",
-    "proposal_apply": "adapter"
-  },
+  "display_name": "Claude Code",
+  "support_tier": "first-class",
+  "support_summary": "Shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation",
+  "components": ["core", "portable-skills", "claude-adapter"],
   "install": {
     "mode": "repository-native",
     "next_steps": [
       "Launch Claude Code from the repository root.",
       "Review project hook trust, then run /setup or /start."
+    ]
+  },
+  "onboarding_doc": "docs/getting-started.md",
+  "surfaces": {
+    "cli": {
+      "kind": "cli",
+      "support_tier": "first-class",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "CLAUDE.md", "precedence": 100}
+      ],
+      "skill_sources": [
+        {"scope": "repository", "role": "skills", "path": ".agents/skills", "precedence": 100},
+        {"scope": "repository", "role": "additive", "path": ".claude/commands", "precedence": 90}
+      ],
+      "invocation": {"setup": "/setup", "start": "/start", "update": "/update", "end": "/end"},
+      "capabilities": {
+        "agent_skills": "native",
+        "explicit_invocation": "native",
+        "project_hooks": "native",
+        "blocking_pre_tool_hook": "native",
+        "mcp": "native",
+        "native_memory": "native",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "native",
+        "execution_authorization": "native"
+      },
+      "hook_output": "system-message",
+      "binary_probes": [
+        {"purpose": "availability", "candidates": ["claude"], "args": [], "success_exit_codes": [0]},
+        {"purpose": "version", "candidates": ["claude"], "args": ["--version"], "success_exit_codes": [0]}
+      ],
+      "conformance_test": "tests/test_runtime_conformance.py",
+      "evidence": ["claude-settings", "claude-hooks", "claude-conformance"]
+    }
+  },
+  "evidence": {
+    "checked_on": "2026-08-24",
+    "tested_versions": [{"surface": "cli", "version": "2.1.245"}],
+    "sources": [
+      {
+        "id": "claude-settings",
+        "type": "official",
+        "location": "https://code.claude.com/docs/en/settings",
+        "claims": ["agent_skills", "explicit_invocation", "mcp", "native_memory", "skill_allowlists", "execution_authorization", "invocation", "instruction_sources", "skill_sources"]
+      },
+      {
+        "id": "claude-hooks",
+        "type": "official",
+        "location": "https://code.claude.com/docs/en/hooks",
+        "claims": ["project_hooks", "blocking_pre_tool_hook", "hook_output"]
+      },
+      {
+        "id": "claude-conformance",
+        "type": "conformance",
+        "location": "tests/test_runtime_conformance.py",
+        "claims": ["proposal_apply", "support"]
+      }
     ]
   }
 }

--- a/runtimes/codex.json
+++ b/runtimes/codex.json
@@ -1,27 +1,71 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "runtime": "codex",
-  "instruction_file": "AGENTS.md",
-  "invocation": {
-    "setup": "$setup",
-    "start": "$start",
-    "update": "$update",
-    "end": "$end"
-  },
-  "capabilities": {
-    "agent_skills": "native",
-    "explicit_invocation": "native",
-    "project_hooks": "native",
-    "blocking_pre_tool_hook": "native",
-    "mcp": "native",
-    "native_memory": "unsupported",
-    "proposal_apply": "adapter"
-  },
+  "display_name": "Codex",
+  "support_tier": "first-class",
+  "support_summary": "Shared lifecycle, native skills, project instructions, hooks, and reviewed proposal/apply writes",
+  "components": ["core", "portable-skills", "agents-instructions", "codex-adapter"],
   "install": {
     "mode": "repository-native",
     "next_steps": [
       "Launch Codex from the repository root.",
       "Review the trusted .codex layer and project hooks, then run $setup or $start."
+    ]
+  },
+  "onboarding_doc": "docs/codex-onboarding.md",
+  "surfaces": {
+    "cli": {
+      "kind": "cli",
+      "support_tier": "first-class",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+      ],
+      "skill_sources": [
+        {"scope": "repository", "role": "skills", "path": ".agents/skills", "precedence": 100}
+      ],
+      "invocation": {"setup": "$setup", "start": "$start", "update": "$update", "end": "$end"},
+      "capabilities": {
+        "agent_skills": "native",
+        "explicit_invocation": "native",
+        "project_hooks": "native",
+        "blocking_pre_tool_hook": "native",
+        "mcp": "native",
+        "native_memory": "unsupported",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "unsupported",
+        "execution_authorization": "unsupported"
+      },
+      "hook_output": "system-message",
+      "binary_probes": [
+        {"purpose": "availability", "candidates": ["codex"], "args": [], "success_exit_codes": [0]},
+        {"purpose": "version", "candidates": ["codex"], "args": ["--version"], "success_exit_codes": [0]}
+      ],
+      "conformance_test": "tests/test_runtime_conformance.py",
+      "evidence": ["codex-agents", "codex-commands", "codex-conformance"]
+    }
+  },
+  "evidence": {
+    "checked_on": "2026-08-24",
+    "tested_versions": [{"surface": "cli", "version": "Codex managed session (2026-08-24)"}],
+    "sources": [
+      {
+        "id": "codex-agents",
+        "type": "official",
+        "location": "https://learn.chatgpt.com/docs/agent-configuration/agents-md",
+        "claims": ["agent_skills", "project_hooks", "blocking_pre_tool_hook", "mcp", "hook_output", "instruction_sources", "skill_sources"]
+      },
+      {
+        "id": "codex-commands",
+        "type": "official",
+        "location": "https://learn.chatgpt.com/docs/developer-commands?surface=cli",
+        "claims": ["explicit_invocation", "invocation"]
+      },
+      {
+        "id": "codex-conformance",
+        "type": "conformance",
+        "location": "tests/test_runtime_conformance.py",
+        "claims": ["proposal_apply", "support"]
+      }
     ]
   }
 }

--- a/runtimes/codex.json
+++ b/runtimes/codex.json
@@ -37,11 +37,15 @@
       },
       "hook_output": "system-message",
       "binary_probes": [
-        {"purpose": "availability", "candidates": ["codex"], "args": [], "success_exit_codes": [0]},
-        {"purpose": "version", "candidates": ["codex"], "args": ["--version"], "success_exit_codes": [0]}
+        {"purpose": "availability", "candidates": ["codex"]},
+        {"purpose": "version", "candidates": ["codex"]}
       ],
-      "conformance_test": "tests/test_runtime_conformance.py",
-      "evidence": ["codex-agents", "codex-commands", "codex-conformance"]
+      "conformance_tests": [
+        "tests/test_contextos_kernel.py",
+        "tests/test_cross_runtime_hooks.py",
+        "tests/test_runtime_conformance.py"
+      ],
+      "evidence": ["codex-agents", "codex-commands", "codex-kernel", "codex-conformance"]
     }
   },
   "evidence": {
@@ -61,10 +65,16 @@
         "claims": ["explicit_invocation", "invocation"]
       },
       {
+        "id": "codex-kernel",
+        "type": "conformance",
+        "location": "tests/test_contextos_kernel.py",
+        "claims": ["proposal_apply"]
+      },
+      {
         "id": "codex-conformance",
         "type": "conformance",
         "location": "tests/test_runtime_conformance.py",
-        "claims": ["proposal_apply", "support"]
+        "claims": ["support"]
       }
     ]
   }

--- a/runtimes/hermes.json
+++ b/runtimes/hermes.json
@@ -39,11 +39,18 @@
       },
       "hook_output": "allow-message",
       "binary_probes": [
-        {"purpose": "availability", "candidates": ["hermes"], "args": [], "success_exit_codes": [0]},
-        {"purpose": "version", "candidates": ["hermes"], "args": ["--version"], "success_exit_codes": [0]}
+        {"purpose": "availability", "candidates": ["hermes"]},
+        {"purpose": "version", "candidates": ["hermes"]}
       ],
-      "conformance_test": "tests/test_runtime_conformance.py",
-      "evidence": ["hermes-overview", "hermes-hooks", "hermes-conformance"]
+      "conformance_tests": [
+        "tests/test_contextos_kernel.py",
+        "tests/test_cross_runtime_hooks.py",
+        "tests/test_runtime_conformance.py"
+      ],
+      "evidence": [
+        "hermes-overview", "hermes-hooks", "hermes-kernel",
+        "hermes-hook-conformance", "hermes-conformance"
+      ]
     }
   },
   "evidence": {
@@ -63,10 +70,22 @@
         "claims": ["hook_output"]
       },
       {
+        "id": "hermes-kernel",
+        "type": "conformance",
+        "location": "tests/test_contextos_kernel.py",
+        "claims": ["proposal_apply"]
+      },
+      {
+        "id": "hermes-hook-conformance",
+        "type": "conformance",
+        "location": "tests/test_cross_runtime_hooks.py",
+        "claims": ["project_hooks", "blocking_pre_tool_hook"]
+      },
+      {
         "id": "hermes-conformance",
         "type": "conformance",
         "location": "tests/test_runtime_conformance.py",
-        "claims": ["agent_skills", "explicit_invocation", "project_hooks", "blocking_pre_tool_hook", "proposal_apply", "support"]
+        "claims": ["agent_skills", "explicit_invocation", "support"]
       }
     ]
   }

--- a/runtimes/hermes.json
+++ b/runtimes/hermes.json
@@ -1,28 +1,73 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "runtime": "hermes",
-  "instruction_file": "AGENTS.md",
-  "invocation": {
-    "setup": "/setup",
-    "start": "/start",
-    "update": "/update",
-    "end": "/end"
-  },
-  "capabilities": {
-    "agent_skills": "adapter",
-    "explicit_invocation": "advisory",
-    "project_hooks": "adapter",
-    "blocking_pre_tool_hook": "advisory",
-    "mcp": "native",
-    "native_memory": "native",
-    "proposal_apply": "adapter"
-  },
+  "display_name": "Hermes Agent",
+  "support_tier": "first-class",
+  "support_summary": "Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory",
+  "components": ["core", "portable-skills", "agents-instructions", "hermes-adapter"],
   "install": {
     "mode": "skill-copy-or-external-directory",
     "next_steps": [
       "Expose this repository's .agents/skills directory to Hermes or install all four short aliases and their context-* cores.",
       "Start a new Hermes session so the installed skill catalog refreshes.",
       "Keep Hermes MEMORY.md and USER.md separate from repository state."
+    ]
+  },
+  "onboarding_doc": "adapters/hermes/README.md",
+  "surfaces": {
+    "cli": {
+      "kind": "cli",
+      "support_tier": "first-class",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+      ],
+      "skill_sources": [
+        {"scope": "repository", "role": "skills", "path": ".agents/skills", "precedence": 100},
+        {"scope": "repository", "role": "additive", "path": "adapters/hermes", "precedence": 90}
+      ],
+      "invocation": {"setup": "/setup", "start": "/start", "update": "/update", "end": "/end"},
+      "capabilities": {
+        "agent_skills": "adapter",
+        "explicit_invocation": "advisory",
+        "project_hooks": "adapter",
+        "blocking_pre_tool_hook": "advisory",
+        "mcp": "native",
+        "native_memory": "native",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "unsupported",
+        "execution_authorization": "unsupported"
+      },
+      "hook_output": "allow-message",
+      "binary_probes": [
+        {"purpose": "availability", "candidates": ["hermes"], "args": [], "success_exit_codes": [0]},
+        {"purpose": "version", "candidates": ["hermes"], "args": ["--version"], "success_exit_codes": [0]}
+      ],
+      "conformance_test": "tests/test_runtime_conformance.py",
+      "evidence": ["hermes-overview", "hermes-hooks", "hermes-conformance"]
+    }
+  },
+  "evidence": {
+    "checked_on": "2026-08-24",
+    "tested_versions": [{"surface": "cli", "version": "0.20.5"}],
+    "sources": [
+      {
+        "id": "hermes-overview",
+        "type": "official",
+        "location": "https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/overview.md",
+        "claims": ["mcp", "native_memory", "invocation", "instruction_sources", "skill_sources"]
+      },
+      {
+        "id": "hermes-hooks",
+        "type": "official",
+        "location": "https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/hooks.md",
+        "claims": ["hook_output"]
+      },
+      {
+        "id": "hermes-conformance",
+        "type": "conformance",
+        "location": "tests/test_runtime_conformance.py",
+        "claims": ["agent_skills", "explicit_invocation", "project_hooks", "blocking_pre_tool_hook", "proposal_apply", "support"]
+      }
     ]
   }
 }

--- a/runtimes/schema.json
+++ b/runtimes/schema.json
@@ -1,28 +1,529 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Context OS runtime capability manifest",
+  "$comment": "Generated structural subset. contextos.runtime_schema is authoritative for repository paths, evidence coverage, dates, reserved IDs, and cross-field rules.",
+  "title": "Context OS runtime descriptor",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "runtime", "instruction_file", "invocation", "capabilities", "install"],
+  "required": [
+    "components",
+    "display_name",
+    "evidence",
+    "install",
+    "onboarding_doc",
+    "runtime",
+    "schema_version",
+    "support_summary",
+    "support_tier",
+    "surfaces"
+  ],
   "properties": {
-    "schema_version": {"const": 1},
-    "runtime": {"enum": ["claude", "codex", "hermes"]},
-    "instruction_file": {"type": "string"},
-    "invocation": {
-      "type": "object",
-      "additionalProperties": {"type": "string"},
-      "required": ["setup", "start", "update", "end"]
+    "schema_version": {
+      "const": 2
     },
-    "capabilities": {
-      "type": "object",
-      "additionalProperties": {"enum": ["native", "adapter", "advisory", "unsupported"]}
+    "runtime": {
+      "type": "string",
+      "pattern": "^(?!generic$)[a-z][a-z0-9-]*$"
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+    },
+    "support_tier": {
+      "enum": [
+        "compatibility",
+        "deprecated",
+        "experimental",
+        "first-class"
+      ]
+    },
+    "support_summary": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      }
     },
     "install": {
       "type": "object",
-      "required": ["mode", "next_steps"],
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "next_steps"
+      ],
       "properties": {
-        "mode": {"type": "string"},
-        "next_steps": {"type": "array", "items": {"type": "string"}}
+        "mode": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+        },
+        "next_steps": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+          }
+        }
+      }
+    },
+    "onboarding_doc": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+    },
+    "surfaces": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "binary_probes",
+          "capabilities",
+          "conformance_test",
+          "evidence",
+          "hook_output",
+          "instruction_sources",
+          "invocation",
+          "kind",
+          "skill_sources",
+          "support_tier"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "cli",
+              "cloud",
+              "environment",
+              "gateway",
+              "ide",
+              "messaging",
+              "review"
+            ]
+          },
+          "support_tier": {
+            "enum": [
+              "compatibility",
+              "deprecated",
+              "experimental",
+              "first-class"
+            ]
+          },
+          "instruction_sources": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path",
+                "precedence",
+                "role",
+                "scope"
+              ],
+              "properties": {
+                "scope": {
+                  "enum": [
+                    "repository",
+                    "runtime",
+                    "user",
+                    "workspace"
+                  ]
+                },
+                "role": {
+                  "enum": [
+                    "additive",
+                    "canonical",
+                    "memory",
+                    "persona",
+                    "skills"
+                  ]
+                },
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                },
+                "precedence": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "skill_sources": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path",
+                "precedence",
+                "role",
+                "scope"
+              ],
+              "properties": {
+                "scope": {
+                  "enum": [
+                    "repository",
+                    "runtime",
+                    "user",
+                    "workspace"
+                  ]
+                },
+                "role": {
+                  "enum": [
+                    "additive",
+                    "canonical",
+                    "memory",
+                    "persona",
+                    "skills"
+                  ]
+                },
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                },
+                "precedence": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "invocation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "end",
+              "setup",
+              "start",
+              "update"
+            ],
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "setup": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "update": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "agent_skills",
+              "blocking_pre_tool_hook",
+              "execution_authorization",
+              "explicit_invocation",
+              "mcp",
+              "native_memory",
+              "project_hooks",
+              "proposal_apply",
+              "skill_allowlists"
+            ],
+            "properties": {
+              "agent_skills": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "blocking_pre_tool_hook": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "execution_authorization": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "explicit_invocation": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "mcp": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "native_memory": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "project_hooks": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "proposal_apply": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              },
+              "skill_allowlists": {
+                "enum": [
+                  "adapter",
+                  "advisory",
+                  "native",
+                  "unsupported"
+                ]
+              }
+            }
+          },
+          "hook_output": {
+            "oneOf": [
+              {
+                "enum": [
+                  "allow-message",
+                  "system-message"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "binary_probes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "args",
+                "candidates",
+                "purpose",
+                "success_exit_codes"
+              ],
+              "properties": {
+                "purpose": {
+                  "enum": [
+                    "availability",
+                    "native-doctor",
+                    "version"
+                  ]
+                },
+                "candidates": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+                  }
+                },
+                "args": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+                  }
+                },
+                "success_exit_codes": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "conformance_test": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "checked_on",
+        "sources",
+        "tested_versions"
+      ],
+      "properties": {
+        "checked_on": {
+          "type": "string",
+          "format": "date"
+        },
+        "tested_versions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "surface",
+              "version"
+            ],
+            "properties": {
+              "surface": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+              },
+              "version": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+              }
+            }
+          }
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "claims",
+              "id",
+              "location",
+              "type"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]*$"
+              },
+              "type": {
+                "enum": [
+                  "conformance",
+                  "official"
+                ]
+              },
+              "location": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+              },
+              "claims": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "enum": [
+                    "agent_skills",
+                    "blocking_pre_tool_hook",
+                    "execution_authorization",
+                    "explicit_invocation",
+                    "hook_output",
+                    "instruction_sources",
+                    "invocation",
+                    "mcp",
+                    "native_memory",
+                    "project_hooks",
+                    "proposal_apply",
+                    "skill_allowlists",
+                    "skill_sources",
+                    "support"
+                  ]
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/runtimes/schema.json
+++ b/runtimes/schema.json
@@ -93,7 +93,7 @@
         "required": [
           "binary_probes",
           "capabilities",
-          "conformance_test",
+          "conformance_tests",
           "evidence",
           "hook_output",
           "instruction_sources",
@@ -374,10 +374,8 @@
               "type": "object",
               "additionalProperties": false,
               "required": [
-                "args",
                 "candidates",
-                "purpose",
-                "success_exit_codes"
+                "purpose"
               ],
               "properties": {
                 "purpose": {
@@ -395,31 +393,19 @@
                     "type": "string",
                     "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
                   }
-                },
-                "args": {
-                  "type": "array",
-                  "uniqueItems": true,
-                  "items": {
-                    "type": "string",
-                    "minLength": 1,
-                    "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
-                  }
-                },
-                "success_exit_codes": {
-                  "type": "array",
-                  "minItems": 1,
-                  "uniqueItems": true,
-                  "items": {
-                    "type": "integer"
-                  }
                 }
               }
             }
           },
-          "conformance_test": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+          "conformance_tests": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+            }
           },
           "evidence": {
             "type": "array",

--- a/scripts/context-os-hook.py
+++ b/scripts/context-os-hook.py
@@ -28,7 +28,7 @@ def main() -> int:
     surface_id = sys.argv[3] if len(sys.argv) == 4 else None
     hook_output: str | None = "system-message"
     try:
-        manifest = runtime_manifest(ROOT, runtime)
+        manifest = runtime_manifest(ROOT, runtime, check_paths=False)
         hook_output = runtime_surface(manifest, surface_id).get("hook_output")
         raw = sys.stdin.read().strip()
         payload = json.loads(raw) if raw else {}

--- a/scripts/context-os-hook.py
+++ b/scripts/context-os-hook.py
@@ -11,32 +11,42 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from contextos.kernel import ContextOSError, hook_report  # noqa: E402
+from contextos.kernel import (  # noqa: E402
+    ContextOSError,
+    hook_report,
+    runtime_hook_payload,
+    runtime_manifest,
+    runtime_surface,
+)
 
 
 def main() -> int:
-    if len(sys.argv) != 3 or sys.argv[1] not in {"claude", "codex", "hermes"}:
-        print("usage: context-os-hook.py claude|codex|hermes session-start|pre-write", file=sys.stderr)
+    if len(sys.argv) not in (3, 4):
+        print("usage: context-os-hook.py RUNTIME session-start|pre-write [SURFACE]", file=sys.stderr)
         return 2
-    runtime, event = sys.argv[1:]
+    runtime, event = sys.argv[1:3]
+    surface_id = sys.argv[3] if len(sys.argv) == 4 else None
+    hook_output: str | None = "system-message"
     try:
+        manifest = runtime_manifest(ROOT, runtime)
+        hook_output = runtime_surface(manifest, surface_id).get("hook_output")
         raw = sys.stdin.read().strip()
         payload = json.loads(raw) if raw else {}
         if not isinstance(payload, dict):
             raise ContextOSError("hook input must be an object")
         report = hook_report(ROOT, event, payload)
         messages = [item["message"] for item in report["findings"]]
-        if runtime in {"claude", "codex"}:
-            if messages:
-                print(json.dumps({"systemMessage": "\n".join(messages)}))
-        else:
-            print(json.dumps({"action": "allow", "message": "\n".join(messages)}))
+        rendered = runtime_hook_payload(manifest, messages, surface_id)
+        if rendered is not None:
+            print(json.dumps(rendered))
         return 0
     except (ContextOSError, json.JSONDecodeError, OSError, UnicodeError) as exc:
         # These hooks are advisory. Surface malformed input instead of silently
         # passing, but do not create a second mutation-enforcement path.
         message = f"Context OS advisory hook could not run: {exc}"
-        if runtime in {"claude", "codex"}:
+        if hook_output is None:
+            return 0
+        if hook_output == "system-message":
             print(json.dumps({"systemMessage": message}))
         else:
             print(json.dumps({"action": "allow", "message": message}))

--- a/scripts/runtime-manifests.py
+++ b/scripts/runtime-manifests.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Generate or verify runtime-registry artifacts from the Python contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from contextos.kernel import ContextOSError, runtime_registry  # noqa: E402
+from contextos.runtime_schema import runtime_schema_document  # noqa: E402
+
+
+README_START = "<!-- runtime-support:start -->"
+README_END = "<!-- runtime-support:end -->"
+
+
+def schema_text() -> str:
+    return json.dumps(runtime_schema_document(), indent=2, ensure_ascii=False) + "\n"
+
+
+def support_block(registry: dict[str, dict[str, object]]) -> str:
+    def cell(value: object) -> str:
+        return str(value).replace("\\", "\\\\").replace("|", "\\|")
+
+    lines = [
+        README_START,
+        "| Host | Tier | Support |",
+        "|---|---|---|",
+    ]
+    for manifest in registry.values():
+        lines.append(
+            f"| {cell(manifest['display_name'])} | {cell(manifest['support_tier'])} | "
+            f"{cell(manifest['support_summary'])} |"
+        )
+    lines.append(README_END)
+    return "\n".join(lines)
+
+
+def replace_block(readme: str, block: str) -> str:
+    if readme.count(README_START) != 1 or readme.count(README_END) != 1:
+        raise ContextOSError("README runtime support markers must each appear exactly once")
+    before, remainder = readme.split(README_START, 1)
+    _, after = remainder.split(README_END, 1)
+    return before + block + after
+
+
+def generated() -> tuple[str, str]:
+    registry = runtime_registry(ROOT)
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    return schema_text(), replace_block(readme, support_block(registry))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("generate", "check"))
+    args = parser.parse_args()
+    try:
+        wanted_schema, wanted_readme = generated()
+        targets = {
+            ROOT / "runtimes" / "schema.json": wanted_schema,
+            ROOT / "README.md": wanted_readme,
+        }
+        if args.command == "generate":
+            for path, content in targets.items():
+                path.write_text(content, encoding="utf-8", newline="\n")
+            print("Generated runtime schema and README support table")
+            return 0
+        stale = [path.relative_to(ROOT).as_posix() for path, content in targets.items()
+                 if not path.exists() or path.read_text(encoding="utf-8") != content]
+        if stale:
+            print(
+                "runtime registry artifacts are stale: " + ", ".join(stale)
+                + "; run scripts/runtime-manifests.py generate",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Runtime registry checks passed ({len(runtime_registry(ROOT))} descriptors)")
+        return 0
+    except (ContextOSError, OSError, UnicodeError, ValueError) as exc:
+        print(f"runtime-manifests: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime-manifests.py
+++ b/scripts/runtime-manifests.py
@@ -34,6 +34,8 @@ def support_block(registry: dict[str, dict[str, object]]) -> str:
         "|---|---|---|",
     ]
     for manifest in registry.values():
+        if manifest["support_tier"] not in {"first-class", "experimental"}:
+            continue
         lines.append(
             f"| {cell(manifest['display_name'])} | {cell(manifest['support_tier'])} | "
             f"{cell(manifest['support_summary'])} |"

--- a/scripts/validate-all.sh
+++ b/scripts/validate-all.sh
@@ -18,6 +18,7 @@ done < <(find .claude/hooks scripts tests -name '*.sh' -print0)
 
 "$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_*.py'
 "$CONTEXTOS_PYTHON_CMD" scripts/integrations.py check
+"$CONTEXTOS_PYTHON_CMD" scripts/runtime-manifests.py check
 
 "$CONTEXTOS_PYTHON_CMD" - <<'PY'
 import json
@@ -31,11 +32,8 @@ paths = [
     Path("docs/templates/update-payload.json"),
     Path("docs/templates/end-payload.json"),
     Path("integrations/catalog.json"),
-    Path("runtimes/schema.json"),
-    Path("runtimes/claude.json"),
-    Path("runtimes/codex.json"),
-    Path("runtimes/hermes.json"),
 ]
+paths.extend(sorted(Path("runtimes").glob("*.json")))
 for path in paths:
     with path.open(encoding="utf-8") as handle:
         json.load(handle)

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -59,9 +59,7 @@ cp "$ROOT/.claude/hooks/session-start.sh" "$SESSION_REPO/.claude/hooks/session-s
 cp "$ROOT/scripts/context-os-hook.py" "$ROOT/scripts/context-os-hook.sh" \
   "$ROOT/scripts/python-env.sh" "$SESSION_REPO/scripts/"
 cp -R "$ROOT/contextos" "$SESSION_REPO/contextos"
-cp -R "$ROOT/runtimes" "$ROOT/docs" "$ROOT/adapters" "$ROOT/tests" \
-  "$ROOT/.agents" "$SESSION_REPO/"
-cp -R "$ROOT/.claude/commands" "$SESSION_REPO/.claude/commands"
+cp -R "$ROOT/runtimes" "$SESSION_REPO/"
 printf '# Test workspace\n' > "$SESSION_REPO/AGENTS.md"
 printf '# Test workspace\n' > "$SESSION_REPO/CLAUDE.md"
 git -C "$SESSION_REPO" init -q -b main

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -59,7 +59,11 @@ cp "$ROOT/.claude/hooks/session-start.sh" "$SESSION_REPO/.claude/hooks/session-s
 cp "$ROOT/scripts/context-os-hook.py" "$ROOT/scripts/context-os-hook.sh" \
   "$ROOT/scripts/python-env.sh" "$SESSION_REPO/scripts/"
 cp -R "$ROOT/contextos" "$SESSION_REPO/contextos"
+cp -R "$ROOT/runtimes" "$ROOT/docs" "$ROOT/adapters" "$ROOT/tests" \
+  "$ROOT/.agents" "$SESSION_REPO/"
+cp -R "$ROOT/.claude/commands" "$SESSION_REPO/.claude/commands"
 printf '# Test workspace\n' > "$SESSION_REPO/AGENTS.md"
+printf '# Test workspace\n' > "$SESSION_REPO/CLAUDE.md"
 git -C "$SESSION_REPO" init -q -b main
 
 printf '# Current State\n\n**Last Updated:** [DATE]\n' > "$SESSION_REPO/state/current.md"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -17,6 +17,7 @@ from contextos.kernel import (
     hook_report,
     install_runtime,
     read_json,
+    runtime_manifest,
     canonical_json,
     sha256_text,
     start_report,
@@ -444,6 +445,12 @@ class KernelTest(unittest.TestCase):
         check = next(item for item in report["checks"] if item["name"] == "manifest:claude")
         self.assertEqual("fail", check["status"])
 
+    def test_bare_doctor_fails_when_registry_is_empty(self) -> None:
+        shutil.rmtree(self.root / "runtimes")
+        report = doctor(self.root)
+        check = next(item for item in report["checks"] if item["name"] == "manifest-registry")
+        self.assertEqual("fail", check["status"])
+
     def test_doctor_handles_runtime_without_a_cli_surface(self) -> None:
         path = self.root / "runtimes/hermes.json"
         manifest = json.loads(path.read_text(encoding="utf-8"))
@@ -467,11 +474,31 @@ class KernelTest(unittest.TestCase):
             any(item["name"].startswith("runtime:hermes:cloud:") for item in report["checks"])
         )
 
+    def test_doctor_never_executes_descriptor_probe_commands(self) -> None:
+        with mock.patch("contextos.kernel.shutil.which", return_value="resolved-command"), mock.patch(
+            "contextos.kernel.subprocess.run",
+            side_effect=AssertionError("descriptor probe executed a process"),
+        ) as run:
+            report = doctor(self.root, "hermes")
+        run.assert_not_called()
+        self.assertTrue(
+            any(item["name"] == "runtime:hermes:cli:version" for item in report["checks"])
+        )
+
     def test_runtime_manifest_is_required_for_receipt_claim(self) -> None:
         proposal_path, proposal = self._propose("update", {"progress": ["One"]})
         os.remove(self.root / "runtimes/codex.json")
         with self.assertRaisesRegex(ContextOSError, "missing runtime manifest"):
             self._apply(proposal_path, proposal)
+
+    def test_apply_does_not_require_maintainer_docs_or_tests(self) -> None:
+        proposal_path, proposal = self._propose("update", {"progress": ["One"]})
+        for directory in ("docs", "tests", ".agents"):
+            shutil.rmtree(self.root / directory)
+        receipt_path, _ = self._apply(proposal_path, proposal)
+        self.assertTrue(receipt_path.is_file())
+        with self.assertRaisesRegex(ContextOSError, "path does not exist"):
+            runtime_manifest(self.root, "codex")
 
     def test_hook_must_fire_and_must_not_fire_controls(self) -> None:
         must_fire = hook_report(

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from unittest import mock
@@ -34,6 +35,7 @@ class KernelTest(unittest.TestCase):
         (self.root / "sessions").mkdir()
         (self.root / "runtimes").mkdir()
         (self.root / "AGENTS.md").write_text("# Test workspace\n", encoding="utf-8")
+        (self.root / "CLAUDE.md").write_text("# Test workspace\n", encoding="utf-8")
         (self.root / "TODO.md").write_text("# Tasks\n", encoding="utf-8")
         (self.root / "state" / "current.md").write_text(
             "# Current State\n\n**Last Updated:** 2026-08-20\n\n## Active priorities\n\n- Old\n",
@@ -55,6 +57,8 @@ class KernelTest(unittest.TestCase):
         for runtime in ("claude", "codex", "hermes"):
             source = ROOT / "runtimes" / f"{runtime}.json"
             (self.root / "runtimes" / f"{runtime}.json").write_bytes(source.read_bytes())
+        for directory in (".agents", ".claude", "adapters", "docs", "tests"):
+            shutil.copytree(ROOT / directory, self.root / directory)
 
     def tearDown(self) -> None:
         self.temp.cleanup()
@@ -417,7 +421,7 @@ class KernelTest(unittest.TestCase):
         self.assertIn(report["status"], {"pass", "warn"})
         self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
         manifest = json.loads((self.root / "runtimes/hermes.json").read_text())
-        manifest["capabilities"]["mcp"] = "advisory"
+        manifest["support_summary"] += " (updated)"
         (self.root / "runtimes/hermes.json").write_text(json.dumps(manifest), encoding="utf-8")
         drift = doctor(self.root, "hermes")
         drift_check = next(item for item in drift["checks"] if item["name"] == "runtime-manifest-drift")
@@ -431,6 +435,37 @@ class KernelTest(unittest.TestCase):
         report = doctor(self.root, "hermes")
         self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
         self.assertTrue(any(item["name"] == "file:custom-state/current.md" for item in report["checks"]))
+
+    def test_bare_doctor_validates_all_manifests_during_setup(self) -> None:
+        manifest = json.loads((self.root / "runtimes/claude.json").read_text(encoding="utf-8"))
+        manifest["unknown"] = True
+        (self.root / "runtimes/claude.json").write_text(json.dumps(manifest), encoding="utf-8")
+        report = doctor(self.root)
+        check = next(item for item in report["checks"] if item["name"] == "manifest:claude")
+        self.assertEqual("fail", check["status"])
+
+    def test_doctor_handles_runtime_without_a_cli_surface(self) -> None:
+        path = self.root / "runtimes/hermes.json"
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        cloud = manifest["surfaces"].pop("cli")
+        cloud["kind"] = "cloud"
+        review = json.loads(json.dumps(cloud))
+        review["kind"] = "review"
+        manifest["surfaces"] = {"cloud": cloud, "review": review}
+        manifest["evidence"]["tested_versions"] = [
+            {"surface": "cloud", "version": "fixture"},
+            {"surface": "review", "version": "fixture"},
+        ]
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        with mock.patch(
+            "contextos.kernel.shutil.which",
+            side_effect=lambda command: "git-path" if command == "git" else None,
+        ):
+            report = doctor(self.root, "hermes")
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]), report)
+        self.assertTrue(
+            any(item["name"].startswith("runtime:hermes:cloud:") for item in report["checks"])
+        )
 
     def test_runtime_manifest_is_required_for_receipt_claim(self) -> None:
         proposal_path, proposal = self._propose("update", {"progress": ["One"]})

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -236,7 +236,9 @@ class CrossRuntimeHookTest(unittest.TestCase):
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("no surface 'bogus'", json.loads(result.stdout)["systemMessage"])
+        output = json.loads(result.stdout)
+        self.assertEqual("allow", output["action"])
+        self.assertIn("no surface 'bogus'", output["message"])
 
 
 if __name__ == "__main__":

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -206,6 +206,38 @@ class CrossRuntimeHookTest(unittest.TestCase):
         self.assertEqual(0, result.returncode)
         self.assertIn("could not run", json.loads(result.stdout)["systemMessage"])
 
+    def test_cli_malformed_hermes_input_preserves_allow_envelope(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "contextos", "--root", str(ROOT), "hook",
+                "pre-write", "--runtime", "hermes",
+            ],
+            cwd=ROOT,
+            input="not-json",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual("allow", output["action"])
+        self.assertIn("could not run", output["message"])
+
+    def test_cli_invalid_surface_remains_advisory(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "contextos", "--root", str(ROOT), "hook",
+                "pre-write", "--runtime", "hermes", "--surface", "bogus",
+            ],
+            cwd=ROOT,
+            input="not-json",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("no surface 'bogus'", json.loads(result.stdout)["systemMessage"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_conformance.py
+++ b/tests/test_runtime_conformance.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from contextos.kernel import runtime_hook_payload, runtime_registry, runtime_surface
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RuntimeConformanceTest(unittest.TestCase):
+    """Must-work adapter controls; authenticated host launches remain opt-in."""
+
+    def test_first_class_surfaces_expose_complete_lifecycle(self) -> None:
+        for runtime, manifest in runtime_registry(ROOT).items():
+            for surface_id, surface in manifest["surfaces"].items():
+                with self.subTest(runtime=runtime, surface=surface_id):
+                    if surface["support_tier"] == "first-class":
+                        self.assertTrue(all(surface["invocation"].values()))
+                        self.assertEqual("adapter", surface["capabilities"]["proposal_apply"])
+
+    def test_registered_hook_envelopes_are_renderable(self) -> None:
+        registry = runtime_registry(ROOT)
+        self.assertEqual(
+            {"systemMessage": "control"},
+            runtime_hook_payload(registry["claude"], ["control"], "cli"),
+        )
+        self.assertEqual(
+            {"systemMessage": "control"},
+            runtime_hook_payload(registry["codex"], ["control"], "cli"),
+        )
+        self.assertEqual(
+            {"action": "allow", "message": "control"},
+            runtime_hook_payload(registry["hermes"], ["control"], "cli"),
+        )
+
+    def test_every_registered_surface_is_explicitly_selectable(self) -> None:
+        for manifest in runtime_registry(ROOT).values():
+            for surface_id, expected in manifest["surfaces"].items():
+                self.assertIs(expected, runtime_surface(manifest, surface_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_conformance.py
+++ b/tests/test_runtime_conformance.py
@@ -60,6 +60,24 @@ class RuntimeConformanceTest(unittest.TestCase):
         self.assertEqual(0, status)
         self.assertEqual("", stdout.getvalue())
 
+    def test_invalid_ambiguous_surface_stays_silent(self) -> None:
+        manifest = {
+            "runtime": "fixture",
+            "surfaces": {
+                "chat": {"hook_output": "system-message"},
+                "cli": {"hook_output": "allow-message"},
+            },
+        }
+        stdout = io.StringIO()
+        with mock.patch("contextos.cli.discover_root", return_value=ROOT), mock.patch(
+            "contextos.cli.runtime_manifest", return_value=manifest
+        ), contextlib.redirect_stdout(stdout):
+            status = cli_main(
+                ["hook", "pre-write", "--runtime", "fixture", "--surface", "bogus"]
+            )
+        self.assertEqual(0, status)
+        self.assertEqual("", stdout.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_conformance.py
+++ b/tests/test_runtime_conformance.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import unittest
 from pathlib import Path
+from unittest import mock
 
+from contextos.cli import main as cli_main
 from contextos.kernel import runtime_hook_payload, runtime_registry, runtime_surface
 
 
@@ -19,6 +23,10 @@ class RuntimeConformanceTest(unittest.TestCase):
                     if surface["support_tier"] == "first-class":
                         self.assertTrue(all(surface["invocation"].values()))
                         self.assertEqual("adapter", surface["capabilities"]["proposal_apply"])
+                        self.assertTrue(surface["conformance_tests"])
+                    for source in surface["skill_sources"]:
+                        if source["scope"] == "repository":
+                            self.assertTrue((ROOT / source["path"]).exists())
 
     def test_registered_hook_envelopes_are_renderable(self) -> None:
         registry = runtime_registry(ROOT)
@@ -39,6 +47,18 @@ class RuntimeConformanceTest(unittest.TestCase):
         for manifest in runtime_registry(ROOT).values():
             for surface_id, expected in manifest["surfaces"].items():
                 self.assertIs(expected, runtime_surface(manifest, surface_id))
+
+    def test_null_hook_surface_stays_silent_on_malformed_input(self) -> None:
+        manifest = {"runtime": "fixture", "surfaces": {"messaging": {"hook_output": None}}}
+        stdout = io.StringIO()
+        with mock.patch("contextos.cli.discover_root", return_value=ROOT), mock.patch(
+            "contextos.cli.runtime_manifest", return_value=manifest
+        ), mock.patch("sys.stdin", io.StringIO("not-json")), contextlib.redirect_stdout(stdout):
+            status = cli_main(
+                ["hook", "pre-write", "--runtime", "fixture", "--surface", "messaging"]
+            )
+        self.assertEqual(0, status)
+        self.assertEqual("", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_conformance.py
+++ b/tests/test_runtime_conformance.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from unittest import mock
 
 from contextos.cli import main as cli_main
-from contextos.kernel import runtime_hook_payload, runtime_registry, runtime_surface
+from contextos.kernel import (
+    ContextOSError,
+    runtime_hook_payload,
+    runtime_registry,
+    runtime_surface,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -75,6 +80,16 @@ class RuntimeConformanceTest(unittest.TestCase):
             status = cli_main(
                 ["hook", "pre-write", "--runtime", "fixture", "--surface", "bogus"]
             )
+        self.assertEqual(0, status)
+        self.assertEqual("", stdout.getvalue())
+
+    def test_manifest_load_failure_stays_silent_without_a_known_protocol(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch("contextos.cli.discover_root", return_value=ROOT), mock.patch(
+            "contextos.cli.runtime_manifest",
+            side_effect=ContextOSError("missing runtime manifest"),
+        ), contextlib.redirect_stdout(stdout):
+            status = cli_main(["hook", "pre-write", "--runtime", "hermes"])
         self.assertEqual(0, status)
         self.assertEqual("", stdout.getvalue())
 

--- a/tests/test_runtime_launch.py
+++ b/tests/test_runtime_launch.py
@@ -21,7 +21,7 @@ class RuntimeLaunchTest(unittest.TestCase):
             self.skipTest(f"{runtime} is not installed")
         prompt = (
             f"Read AGENTS.md and runtimes/{runtime}.json in this public fixture. "
-            f"Do not write files or use external data. If the {runtime} manifest declares "
+            f"Do not write files or use external data. If the {runtime} manifest's cli surface declares "
             "setup, start, update, and end invocations and AGENTS.md requires proposal/apply, "
             f"reply with exactly CONTEXT_OS_RUNTIME={runtime}. Otherwise explain the mismatch."
         )

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -56,6 +56,12 @@ class RuntimeManifestTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeManifestError, "capabilities.mcp"):
             validate_runtime_manifest(manifest, runtime_id="codex", root=ROOT)
 
+    def test_probe_contract_rejects_executable_arguments(self) -> None:
+        manifest = load("codex")
+        manifest["surfaces"]["cli"]["binary_probes"][0]["args"] = ["-c", "do_work()"]
+        with self.assertRaisesRegex(RuntimeManifestError, "unknown args"):
+            validate_runtime_manifest(manifest, runtime_id="codex", root=ROOT)
+
     def test_contract_rejects_unknown_keys_claims_future_and_mismatch(self) -> None:
         manifest = load("codex")
         mutations = []
@@ -65,10 +71,26 @@ class RuntimeManifestTest(unittest.TestCase):
         future = copy.deepcopy(manifest)
         future["evidence"]["checked_on"] = "2999-01-01"
         mutations.append((future, "codex", "future"))
+        compact_date = copy.deepcopy(manifest)
+        compact_date["evidence"]["checked_on"] = "20260824"
+        mutations.append((compact_date, "codex", "YYYY-MM-DD"))
+        week_date = copy.deepcopy(manifest)
+        week_date["evidence"]["checked_on"] = "2026-W35-1"
+        mutations.append((week_date, "codex", "YYYY-MM-DD"))
         uncovered = copy.deepcopy(manifest)
-        for source in uncovered["evidence"]["sources"]:
-            if "support" in source["claims"]:
-                source["claims"].remove("support")
+        support_ids = {
+            source["id"] for source in uncovered["evidence"]["sources"]
+            if "support" in source["claims"]
+        }
+        uncovered["evidence"]["sources"] = [
+            source for source in uncovered["evidence"]["sources"]
+            if source["id"] not in support_ids
+        ]
+        for surface in uncovered["surfaces"].values():
+            surface["evidence"] = [
+                evidence_id for evidence_id in surface["evidence"]
+                if evidence_id not in support_ids
+            ]
         mutations.append((uncovered, "codex", "does not cover claims"))
         unknown_claim = copy.deepcopy(manifest)
         unknown_claim["evidence"]["sources"][0]["claims"].append("magic")
@@ -80,6 +102,27 @@ class RuntimeManifestTest(unittest.TestCase):
             validate_runtime_manifest(manifest, runtime_id="generic", root=ROOT)
         with self.assertRaisesRegex(RuntimeManifestError, "match filename"):
             validate_runtime_manifest(manifest, runtime_id="other", root=ROOT)
+
+    def test_operational_validation_ignores_clock_skew_but_keeps_date_shape(self) -> None:
+        manifest = load("codex")
+        validate_runtime_manifest(
+            manifest, runtime_id="codex", root=ROOT, today=date(2020, 1, 1),
+            check_paths=False,
+        )
+        manifest["evidence"]["checked_on"] = "20260824"
+        with self.assertRaisesRegex(RuntimeManifestError, "YYYY-MM-DD"):
+            validate_runtime_manifest(
+                manifest, runtime_id="codex", root=ROOT, check_paths=False
+            )
+
+    def test_logical_sources_reject_posix_absolute_paths_on_every_platform(self) -> None:
+        manifest = load("codex")
+        manifest["surfaces"]["cli"]["instruction_sources"][0] = {
+            "scope": "workspace", "role": "canonical", "path": "/etc/passwd",
+            "precedence": 100,
+        }
+        with self.assertRaisesRegex(RuntimeManifestError, "safe logical relative path"):
+            validate_runtime_manifest(manifest, runtime_id="codex", root=ROOT)
 
     def test_generic_is_apply_only_not_a_descriptor(self) -> None:
         with self.assertRaisesRegex(ContextOSError, "invalid runtime id"):
@@ -112,7 +155,7 @@ class RuntimeManifestTest(unittest.TestCase):
             manifest["display_name"] = "Future Agent"
             manifest["onboarding_doc"] = "docs/onboarding.md"
             surface = manifest["surfaces"]["cli"]
-            surface["conformance_test"] = "tests/conformance.py"
+            surface["conformance_tests"] = ["tests/conformance.py"]
             for source in manifest["evidence"]["sources"]:
                 if source["type"] == "conformance":
                     source["location"] = "tests/conformance.py"
@@ -151,8 +194,7 @@ class RuntimeManifestTest(unittest.TestCase):
         messaging["kind"] = "messaging"
         messaging["hook_output"] = None
         cli["binary_probes"].append(
-            {"purpose": "native-doctor", "candidates": ["openclaw", "openclaw-agent"],
-             "args": ["doctor"], "success_exit_codes": [0]}
+            {"purpose": "native-doctor", "candidates": ["openclaw", "openclaw-agent"]}
         )
         manifest["surfaces"] = {"cli": cli, "messaging": messaging}
         manifest["evidence"]["tested_versions"] = []

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -1,49 +1,164 @@
 from __future__ import annotations
 
+import copy
 import json
 import tempfile
 import unittest
+from datetime import date
 from pathlib import Path
 
-from contextos.kernel import ContextOSError, runtime_manifest
+from contextos.kernel import (
+    ContextOSError, install_runtime, runtime_hook_payload, runtime_ids,
+    runtime_manifest, runtime_registry,
+)
+from contextos.runtime_schema import (
+    CAPABILITY_KEYS,
+    RUNTIME_DESCRIPTOR_SCHEMA_VERSION,
+    RuntimeManifestError,
+    runtime_schema_document,
+    validate_runtime_manifest,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def load(runtime: str) -> dict:
+    return json.loads((ROOT / "runtimes" / f"{runtime}.json").read_text(encoding="utf-8"))
+
+
 class RuntimeManifestTest(unittest.TestCase):
-    def test_manifests_have_complete_lifecycle_and_capabilities(self) -> None:
-        required_capabilities = {
-            "agent_skills", "explicit_invocation", "project_hooks",
-            "blocking_pre_tool_hook", "mcp", "native_memory", "proposal_apply",
-        }
-        for runtime in ("claude", "codex", "hermes"):
+    def test_registry_discovers_and_validates_every_descriptor(self) -> None:
+        self.assertEqual(["claude", "codex", "hermes"], runtime_ids(ROOT))
+        registry = runtime_registry(ROOT)
+        self.assertEqual({"claude", "codex", "hermes"}, set(registry))
+        self.assertNotIn("generic", registry)
+        for runtime, manifest in registry.items():
             with self.subTest(runtime=runtime):
-                manifest = json.loads((ROOT / "runtimes" / f"{runtime}.json").read_text(encoding="utf-8"))
-                self.assertEqual(1, manifest["schema_version"])
+                self.assertEqual(RUNTIME_DESCRIPTOR_SCHEMA_VERSION, manifest["schema_version"])
                 self.assertEqual(runtime, manifest["runtime"])
-                self.assertEqual({"setup", "start", "update", "end"}, set(manifest["invocation"]))
-                self.assertEqual(required_capabilities, set(manifest["capabilities"]))
-                self.assertTrue(manifest["install"]["next_steps"])
+                for surface in manifest["surfaces"].values():
+                    self.assertEqual(CAPABILITY_KEYS, set(surface["capabilities"]))
 
-    def test_short_aliases_match_runtime_invocations(self) -> None:
-        claude = json.loads((ROOT / "runtimes/claude.json").read_text())
-        codex = json.loads((ROOT / "runtimes/codex.json").read_text())
-        hermes = json.loads((ROOT / "runtimes/hermes.json").read_text())
-        for name in ("setup", "start", "update", "end"):
-            self.assertEqual(f"/{name}", claude["invocation"][name])
-            self.assertEqual(f"${name}", codex["invocation"][name])
-            self.assertEqual(f"/{name}", hermes["invocation"][name])
+    def test_short_aliases_match_cli_surface_invocations(self) -> None:
+        for runtime, prefix in (("claude", "/"), ("codex", "$"), ("hermes", "/")):
+            invocation = load(runtime)["surfaces"]["cli"]["invocation"]
+            for name in ("setup", "start", "update", "end"):
+                self.assertEqual(f"{prefix}{name}", invocation[name])
 
-    def test_kernel_rejects_schema_drift(self) -> None:
+    def test_checked_in_schema_matches_authoritative_contract(self) -> None:
+        actual = json.loads((ROOT / "runtimes/schema.json").read_text(encoding="utf-8"))
+        self.assertEqual(runtime_schema_document(), actual)
+
+    def test_mutation_sentinel_rejects_unknown_capability_value(self) -> None:
+        manifest = load("codex")
+        manifest["surfaces"]["cli"]["capabilities"]["mcp"] = "invented"
+        with self.assertRaisesRegex(RuntimeManifestError, "capabilities.mcp"):
+            validate_runtime_manifest(manifest, runtime_id="codex", root=ROOT)
+
+    def test_contract_rejects_unknown_keys_claims_future_and_mismatch(self) -> None:
+        manifest = load("codex")
+        mutations = []
+        unknown = copy.deepcopy(manifest)
+        unknown["surprise"] = True
+        mutations.append((unknown, "codex", "unknown surprise"))
+        future = copy.deepcopy(manifest)
+        future["evidence"]["checked_on"] = "2999-01-01"
+        mutations.append((future, "codex", "future"))
+        uncovered = copy.deepcopy(manifest)
+        for source in uncovered["evidence"]["sources"]:
+            if "support" in source["claims"]:
+                source["claims"].remove("support")
+        mutations.append((uncovered, "codex", "does not cover claims"))
+        unknown_claim = copy.deepcopy(manifest)
+        unknown_claim["evidence"]["sources"][0]["claims"].append("magic")
+        mutations.append((unknown_claim, "codex", "unsupported value"))
+        for candidate, runtime_id, message in mutations:
+            with self.subTest(message=message), self.assertRaisesRegex(RuntimeManifestError, message):
+                validate_runtime_manifest(candidate, runtime_id=runtime_id, root=ROOT, today=date(2026, 8, 24))
+        with self.assertRaisesRegex(RuntimeManifestError, "reserved"):
+            validate_runtime_manifest(manifest, runtime_id="generic", root=ROOT)
+        with self.assertRaisesRegex(RuntimeManifestError, "match filename"):
+            validate_runtime_manifest(manifest, runtime_id="other", root=ROOT)
+
+    def test_generic_is_apply_only_not_a_descriptor(self) -> None:
+        with self.assertRaisesRegex(ContextOSError, "invalid runtime id"):
+            runtime_manifest(ROOT, "generic")
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with self.assertRaisesRegex(ContextOSError, "invalid runtime id"):
+                install_runtime(root, "generic")
+            self.assertFalse((root / ".context-os/runtime.json").exists())
+
+    def test_hook_envelopes_come_from_surface_descriptors(self) -> None:
+        self.assertEqual(
+            {"systemMessage": "notice"}, runtime_hook_payload(load("claude"), ["notice"])
+        )
+        self.assertEqual(
+            {"action": "allow", "message": "notice"},
+            runtime_hook_payload(load("hermes"), ["notice"]),
+        )
+
+    def test_new_descriptor_is_discovered_without_code_change(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "runtimes").mkdir()
-            manifest = json.loads((ROOT / "runtimes/codex.json").read_text(encoding="utf-8"))
-            manifest["capabilities"]["mcp"] = "invented"
-            (root / "runtimes/codex.json").write_text(json.dumps(manifest), encoding="utf-8")
-            with self.assertRaisesRegex(ContextOSError, "invalid runtime manifest"):
-                runtime_manifest(root, "codex")
+            (root / "docs").mkdir()
+            (root / "tests").mkdir()
+            (root / "docs/onboarding.md").write_text("# Onboarding\n", encoding="utf-8")
+            (root / "tests/conformance.py").write_text("# fixture\n", encoding="utf-8")
+            manifest = load("codex")
+            manifest["runtime"] = "future-agent"
+            manifest["display_name"] = "Future Agent"
+            manifest["onboarding_doc"] = "docs/onboarding.md"
+            surface = manifest["surfaces"]["cli"]
+            surface["conformance_test"] = "tests/conformance.py"
+            for source in manifest["evidence"]["sources"]:
+                if source["type"] == "conformance":
+                    source["location"] = "tests/conformance.py"
+            surface["instruction_sources"] = [
+                {"scope": "workspace", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+            ]
+            surface["skill_sources"] = [
+                {"scope": "workspace", "role": "skills", "path": "skills", "precedence": 100}
+            ]
+            (root / "runtimes/future-agent.json").write_text(json.dumps(manifest), encoding="utf-8")
+            self.assertEqual(["future-agent"], runtime_ids(root))
+            self.assertEqual("Future Agent", runtime_registry(root)["future-agent"]["display_name"])
+            target, installed = install_runtime(root, "future-agent")
+            self.assertTrue(target.is_file())
+            self.assertEqual("future-agent", installed["runtime"])
+            self.assertEqual({"systemMessage": "notice"}, runtime_hook_payload(manifest, ["notice"]))
+
+    def test_openclaw_spike_supports_precedence_and_multiple_surfaces(self) -> None:
+        manifest = load("hermes")
+        manifest["runtime"] = "openclaw-spike"
+        manifest["display_name"] = "OpenClaw Spike"
+        manifest["support_tier"] = "experimental"
+        cli = manifest["surfaces"].pop("cli")
+        cli["support_tier"] = "experimental"
+        cli["instruction_sources"] = [
+            {"scope": "workspace", "role": "canonical", "path": "AGENTS.md", "precedence": 100},
+            {"scope": "user", "role": "persona", "path": "SOUL.md", "precedence": 80},
+            {"scope": "user", "role": "persona", "path": "USER.md", "precedence": 75},
+            {"scope": "user", "role": "memory", "path": "MEMORY.md", "precedence": 70},
+        ]
+        cli["skill_sources"] = [
+            {"scope": "workspace", "role": "skills", "path": ".agents/skills", "precedence": 100},
+            {"scope": "user", "role": "skills", "path": "skills", "precedence": 50},
+        ]
+        messaging = copy.deepcopy(cli)
+        messaging["kind"] = "messaging"
+        messaging["hook_output"] = None
+        cli["binary_probes"].append(
+            {"purpose": "native-doctor", "candidates": ["openclaw", "openclaw-agent"],
+             "args": ["doctor"], "success_exit_codes": [0]}
+        )
+        manifest["surfaces"] = {"cli": cli, "messaging": messaging}
+        manifest["evidence"]["tested_versions"] = []
+        validate_runtime_manifest(manifest, runtime_id="openclaw-spike", root=ROOT)
+        self.assertIn("skill_allowlists", cli["capabilities"])
+        self.assertIn("execution_authorization", cli["capabilities"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #61

## Summary

- replace hardcoded runtime enums with discoverable, strictly validated schema-v2 descriptors
- model capabilities, instructions, skills, hook envelopes, binary probes, conformance, and evidence per runtime surface
- generate and drift-check the JSON Schema plus README registered-host table from the Python authority
- preserve generic as an apply-only receipt identity and add maintainer-wide doctor validation
- migrate Claude, Codex, and Hermes descriptors and add an undiscovered OpenClaw multi-surface spike control

## Verification

- 189 Python tests pass; 11 authenticated runtime-launch tests skip explicitly
- portability controls: 29 + 9 tests pass
- hook integration controls pass
- runtime registry generation/check and git diff --check pass
- full Bash validation reaches the Python suite; WSL cannot resolve this Windows linked-worktree gitdir, while the same 189-test suite passes under native Windows Python

## Review

- Claude Opus reviewed the full diff; its high-severity findings around multi-surface doctor behavior, setup-time validation, advisory hook exits, conformance evidence, and generated docs were fixed with regression controls
- Hermes free-model review completed; stealth/ox-alpha also reviewed the schema architecture before implementation, with its final retry rate-limited