### PR TITLE
[Multi-agent] Define component ownership and dependency graph

### DIFF
--- a/.agents/skills/context-setup/SKILL.md
+++ b/.agents/skills/context-setup/SKILL.md
@@ -62,5 +62,5 @@ bash scripts/contextos.sh apply <proposal> --confirm <digest> --runtime <active-
 The kernel must refuse path escapes, writes outside context paths, unapproved
 populated replacements, changed targets, or concurrent applies.
 
-Run `bash scripts/validate-all.sh`, report the receipt and result, and offer a
+Run `bash scripts/validate-all.sh --workspace`, report the receipt and result, and offer a
 commit only after final diff review. Suggest `$start` next and `$end` to close.

--- a/.agents/skills/mine-gemini-workflows/SKILL.md
+++ b/.agents/skills/mine-gemini-workflows/SKILL.md
@@ -59,7 +59,8 @@ For each approved candidate:
 - record provenance using session IDs, immutable recording digests, and evidence counts, not transcript content,
 - separate provider-neutral steps from Gemini-, Claude-, or Codex-specific tool adapters.
 
-Show the draft and parity case before writing. Then run `bash scripts/validate-all.sh`.
+Show the draft and parity case before writing. Then run
+`bash scripts/validate-all.sh --workspace`.
 
 ### 6. Report limitations
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -31,7 +31,9 @@ For a security problem, do not use this template. See SECURITY.md.
 ## Validator output
 
 <!--
-Paste the relevant output of `bash scripts/validate-all.sh`, if you ran it.
+Paste the relevant output of `bash scripts/validate-all.sh --workspace`, if you
+ran it in a personalized workspace. Product contributors should use the strict
+form without `--workspace`.
 If it passes while the bug reproduces, say that explicitly — a green validator
 on broken behavior is itself worth knowing about.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,5 +65,7 @@ remain supported.
 
 ## Validation
 
-Run `bash scripts/validate-all.sh` after changing instructions, skills,
-commands, hooks, scripts, manifests, or generated references.
+Run `bash scripts/validate-all.sh --workspace` after changing personal context
+or adding workspace-owned skills and commands. Product contributors and CI run
+the strict form without `--workspace` after changing instructions, hooks,
+scripts, manifests, or generated references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Added
 - A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
+- An authoritative component inventory with dependency resolution, exact
+  tracked-file ownership, managed/seed/development policies, runtime-reference
+  validation, and documented prerequisites for future clean composition.
 - `CONTRIBUTING.md` — prerequisites, the validator as the one gate, which files are generated, how to add a catalog entry, skill/adapter structure, and the enforced size limits.
 - `SECURITY.md` — private reporting path, what is in and out of scope, and the design boundaries most likely to be misread (validation is not a publication guarantee; `verified` is a metadata claim; nothing here sandboxes an agent).
 - Issue templates for integration proposals and bug reports, plus contact links routing security reports away from public issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - An authoritative component inventory with dependency resolution, exact
   tracked-file ownership, managed/seed/development policies, runtime-reference
   validation, and documented prerequisites for future clean composition.
+- Workspace-aware validation that preserves strict maintainer coverage while
+  allowing declared user extensions and intentionally removed seed content.
 - `CONTRIBUTING.md` — prerequisites, the validator as the one gate, which files are generated, how to add a catalog entry, skill/adapter structure, and the enforced size limits.
 - `SECURITY.md` — private reporting path, what is in and out of scope, and the design boundaries most likely to be misread (validation is not a publication guarantee; `verified` is a metadata claim; nothing here sandboxes an agent).
 - Issue templates for integration proposals and bug reports, plus contact links routing security reports away from public issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Run it locally rather than discovering a failure in CI. It takes about a minute.
 
 ## Generated files — do not hand-edit
 
-Four artifacts are produced by scripts. Editing them directly means your change is
+Five artifacts are produced by scripts. Editing them directly means your change is
 silently reverted on the next regeneration.
 
 | File | Source of truth | Regenerate with |
@@ -46,6 +46,7 @@ silently reverted on the next regeneration.
 | `REPO_MAP.md` | the repository itself | `scripts/generate-repo-map.sh` (gitignored — never commit it) |
 | `runtimes/schema.json` | `contextos/runtime_schema.py` | `scripts/runtime-manifests.py generate` |
 | README registered-host table | validated `runtimes/*.json` descriptors | `scripts/runtime-manifests.py generate` |
+| `components/schema.json` | `contextos/component_schema.py` | `scripts/component-manifests.py generate` |
 
 ## Adding a runtime descriptor
 
@@ -59,6 +60,14 @@ fail validation. `generic` is reserved for apply receipts and cannot be a host.
 Run `scripts/runtime-manifests.py generate`, add or extend a must-work conformance
 control, then run the full validator. Do not add compatibility-only hosts to the
 generated registered-host block; a shipped descriptor is a support claim.
+
+Every runtime component ID must also exist in `components/manifest.json`. When
+adding or moving a checked-in file, give it exactly one component owner and an
+explicit `managed`, `seed`, or `development` policy. New user files below the
+catalog's extensible roots are workspace-owned, but the maintainer check is
+strict over this repository's tracked source set; do not add personal context to
+a product contribution. See [the component model](docs/component-model.md) for
+the dependency and clean-composition boundaries.
 
 ## Adding an integration to the catalog
 

--- a/README.md
+++ b/README.md
@@ -180,13 +180,19 @@ Claude Code auto-memory is a separate, host-specific layer. The repository inclu
 - Use one git worktree per concurrent agent session.
 - Follow [`docs/safety-contract.md`](docs/safety-contract.md) before external writes, destructive actions, or permission changes.
 
-Run the full local check after changing instructions, skills, scripts, adapters, or generated references:
+Run the full local check after changing instructions, skills, scripts, adapters,
+generated references, or tracked personal context:
 
 ```bash
-bash scripts/validate-all.sh
+bash scripts/validate-all.sh --workspace
 ```
 
-CI runs the same aggregate validator. It checks structure, adapter mappings, links, shell syntax, hook behavior, JSON, tests, and generated integration documentation. It cannot prove the behavior of an installed agent version or an external service.
+The workspace mode permits new tracked files only below the component catalog's
+declared extensible roots. CI and product contributors run the strict form
+without `--workspace`, so every tracked template file still requires an owner.
+Both forms check structure, adapter mappings, links, shell syntax, hook behavior,
+JSON, tests, and generated integration documentation. They cannot prove the
+behavior of an installed agent version or an external service.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ contextos/                 Deterministic lifecycle kernel
 .codex/hooks.json          Codex lifecycle advisory adapter
 adapters/hermes/           Hermes installation and optional hook adapter
 runtimes/                  Machine-readable capability manifests
+components/                Component ownership and dependency manifest
 integrations/              Machine-checked opt-in integration catalog
 references/                Generated catalog and integration setup notes
 scripts/                   Setup, validation, migration, and maintenance tools
@@ -197,6 +198,7 @@ CI runs the same aggregate validator. It checks structure, adapter mappings, lin
 | Use the repository in Hermes Agent | [Memory across agents](docs/memory-across-agents.md) and the Hermes section of [AGENTS.md](AGENTS.md) |
 | Keep claude.ai projects aligned | [Claude projects sync](docs/claude-projects-sync.md) |
 | See every command and portable skill | [Commands and skills](docs/commands-and-skills.md) |
+| Understand component ownership and future clean composition | [Component model](docs/component-model.md) |
 | Choose an optional add-on | [Integration chooser](docs/integrations-guide.md) and [catalog](references/integrations.md) |
 | Understand product language and boundaries | [Positioning](docs/positioning.md) |
 | Keep context files small and cheap to load | [Optimizing context files](docs/optimizing-context.md) |

--- a/ROUTING.md
+++ b/ROUTING.md
@@ -32,7 +32,8 @@ For tasks without a slash command, use this table to determine which files to lo
 - Creating a portable skill → use `.agents/skills/<name>/SKILL.md` and keep host adapters thin
 - Creating a Claude-only skill → read `docs/agent-template.md` for the scaffold and checklist
 - Treating `projects/<project>/skills/` as native discovery → do not; those files are ordinary context unless routed or adapted
-- Validating skill structure → run `scripts/validate-all.sh`
+- Validating skill structure in a personalized workspace → run
+  `scripts/validate-all.sh --workspace`
 
 ## Agent migration
 - Importing selected context from an assistant, project, memory export, or account export → read `docs/migration-guide.md`, then use Claude Code `/setup` or portable `$context-setup`

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -1,12 +1,18 @@
 {
     "schema_version": 1,
+    "extensible_paths": [
+        "contextos.workspace.json",
+        "workspace.yaml"
+    ],
     "extensible_roots": [
         ".agents/skills",
+        ".claude/agents",
         ".claude/commands",
         "content",
         "identity",
         "inbox",
         "projects",
+        "references",
         "sessions",
         "state",
         "writing"

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -1,12 +1,10 @@
 {
     "schema_version": 1,
     "extensible_paths": [
-        "contextos.workspace.json",
         "workspace.yaml"
     ],
     "extensible_roots": [
         ".agents/skills",
-        ".claude/agents",
         ".claude/commands",
         "content",
         "identity",

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -1,6 +1,8 @@
 {
     "schema_version": 1,
     "extensible_roots": [
+        ".agents/skills",
+        ".claude/commands",
         "content",
         "identity",
         "inbox",

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -1,0 +1,759 @@
+{
+    "schema_version": 1,
+    "extensible_roots": [
+        "content",
+        "identity",
+        "inbox",
+        "projects",
+        "sessions",
+        "state",
+        "writing"
+    ],
+    "components": [
+        {
+            "id": "core",
+            "description": "Provider-neutral kernel, shared documentation, repository scaffolding, and user-owned seed files.",
+            "depends_on": [],
+            "paths": [
+                {
+                    "path": ".gitattributes",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".github/FUNDING.yml",
+                    "policy": "development"
+                },
+                {
+                    "path": ".github/ISSUE_TEMPLATE/bug-report.md",
+                    "policy": "development"
+                },
+                {
+                    "path": ".github/ISSUE_TEMPLATE/config.yml",
+                    "policy": "development"
+                },
+                {
+                    "path": ".github/ISSUE_TEMPLATE/integration-proposal.md",
+                    "policy": "development"
+                },
+                {
+                    "path": ".github/PULL_REQUEST_TEMPLATE.md",
+                    "policy": "development"
+                },
+                {
+                    "path": ".github/workflows/validate.yml",
+                    "policy": "development"
+                },
+                {
+                    "path": ".gitignore",
+                    "policy": "managed"
+                },
+                {
+                    "path": "CHANGELOG.md",
+                    "policy": "development"
+                },
+                {
+                    "path": "components/manifest.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "components/schema.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "content/log.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "contextos/__init__.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/__main__.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/cli.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/component_schema.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/kernel.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/runtime_schema.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "CONTRIBUTING.md",
+                    "policy": "development"
+                },
+                {
+                    "path": "docs/agent-template.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/assets/og-image.png",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/assets/og-image.svg",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/commands-and-skills.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/component-model.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/cross-runtime-architecture.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/first-skill.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/gemini-migration.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/getting-started.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/integrations-guide.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/launch-copy.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/maintenance.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/mcp-efficiency.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/memory-across-agents.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/migration-guide.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/optimizing-context.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/positioning.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/repo-maintenance.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/safety-contract.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/social-preview.png",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/templates/end-payload.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/templates/setup-payload.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/templates/update-payload.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/templates/workflow-parity.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "identity/professional-background.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "identity/who-i-am.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "inbox/.gitkeep",
+                    "policy": "seed"
+                },
+                {
+                    "path": "integrations/catalog.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "LICENSE",
+                    "policy": "managed"
+                },
+                {
+                    "path": "projects/README.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "references/ai-data-extraction.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "references/google-workspace-cli-setup.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "references/integrations.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "references/notion-mcp-setup.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "ROUTING.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "runtimes/schema.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/check-doc-reachability.sh",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/check-links.sh",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/component-manifests.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/contextos.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/context-os-hook.ps1",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/context-os-hook.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/context-os-hook.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/generate-repo-map.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/integrations.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/mine-gemini-workflows.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/pre-commit-hook.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/python-env.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/runtime-manifests.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/setup.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/validate-all.sh",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/validate-skills.sh",
+                    "policy": "development"
+                },
+                {
+                    "path": "SECURITY.md",
+                    "policy": "development"
+                },
+                {
+                    "path": "sessions/.gitkeep",
+                    "policy": "seed"
+                },
+                {
+                    "path": "sessions/README.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/blockers.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/current.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/current-log.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/decisions.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/gws-references.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/heartbeat-log.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "state/weekly-priorities.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "tests/test_component_manifests.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_contextos_kernel.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_cross_runtime_hooks.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_docs_positioning.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_integrations.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_mine_gemini_workflows.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_runtime_conformance.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_runtime_launch.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_runtime_manifests.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test-hooks.sh",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test-portability.sh",
+                    "policy": "development"
+                },
+                {
+                    "path": "TODO.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "writing/skills/avoid-ai-writing/SKILL.md",
+                    "policy": "seed"
+                }
+            ]
+        },
+        {
+            "id": "portable-skills",
+            "description": "Provider-neutral lifecycle and migration skill bodies.",
+            "depends_on": [
+                "core"
+            ],
+            "paths": [
+                {
+                    "path": ".agents/skills/context-end/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/context-setup/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/context-start/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/context-update/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/end/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/migrate-gemini/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/mine-gemini-workflows/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/setup/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/start/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/update/SKILL.md",
+                    "policy": "managed"
+                }
+            ]
+        },
+        {
+            "id": "openai-skill-metadata",
+            "description": "OpenAI skill discovery metadata kept separate from portable skill bodies.",
+            "depends_on": [
+                "portable-skills"
+            ],
+            "paths": [
+                {
+                    "path": ".agents/skills/context-end/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/context-setup/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/context-start/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/context-update/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/end/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/setup/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/start/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".agents/skills/update/agents/openai.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": "tests/validate-openai-metadata.py",
+                    "policy": "development"
+                }
+            ]
+        },
+        {
+            "id": "agents-instructions",
+            "description": "Shared AGENTS.md instruction bridge for runtimes that consume it.",
+            "depends_on": [
+                "core",
+                "portable-skills"
+            ],
+            "paths": [
+                {
+                    "path": "AGENTS.md",
+                    "policy": "managed"
+                }
+            ]
+        },
+        {
+            "id": "claude-adapter",
+            "description": "Claude Code instructions, commands, hooks, memory tooling, and runtime descriptor.",
+            "depends_on": [
+                "core",
+                "portable-skills"
+            ],
+            "paths": [
+                {
+                    "path": ".claude/commands/capture.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/clean-ai-writing.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/content-shipped.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/dream.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/dream-apply.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/end.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/find-context.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/migrate-gemini.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/mine-gemini-workflows.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/reconcile.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/recover.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/setup.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/start.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/today.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/commands/update.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/hooks/branch-hygiene.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/hooks/guarded-repos.txt",
+                    "policy": "seed"
+                },
+                {
+                    "path": ".claude/hooks/README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/hooks/session-start.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/hooks/ssot-guard.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/hooks/worktree-guard.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/settings.json",
+                    "policy": "seed"
+                },
+                {
+                    "path": ".claude/skills/skill-creator/references/claude-code-frontmatter.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": ".claude/skills/skill-creator/SKILL.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "CLAUDE.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "docs/auto-memory.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/claude-projects-sync.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/assets/start-demo.gif",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/demo/start-session.sh",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/dream-architecture.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/memory-template.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/start-demo.tape",
+                    "policy": "managed"
+                },
+                {
+                    "path": "runtimes/claude.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/dream/prompts/lint.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/dream/prompts/merge.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/dream/prompts/rot.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/dream/prompts/split.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/dream/README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "scripts/dream/validate-memory.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "SETUP-PROMPTS.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "tests/test_dream_paths.py",
+                    "policy": "development"
+                }
+            ]
+        },
+        {
+            "id": "codex-adapter",
+            "description": "Codex hooks, onboarding, skill metadata, and runtime descriptor.",
+            "depends_on": [
+                "core",
+                "portable-skills",
+                "agents-instructions",
+                "openai-skill-metadata"
+            ],
+            "paths": [
+                {
+                    "path": ".codex/hooks.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/codex-onboarding.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "runtimes/codex.json",
+                    "policy": "managed"
+                }
+            ]
+        },
+        {
+            "id": "hermes-adapter",
+            "description": "Hermes installation guidance, optional hooks, and runtime descriptor.",
+            "depends_on": [
+                "core",
+                "portable-skills",
+                "agents-instructions"
+            ],
+            "paths": [
+                {
+                    "path": "adapters/hermes/hooks.example.yaml",
+                    "policy": "managed"
+                },
+                {
+                    "path": "adapters/hermes/README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "runtimes/hermes.json",
+                    "policy": "managed"
+                }
+            ]
+        },
+        {
+            "id": "example-project",
+            "description": "Optional removable example project and workflow seeds.",
+            "depends_on": [
+                "core"
+            ],
+            "paths": [
+                {
+                    "path": "projects/example-musician/artist-context.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "projects/example-musician/promotion-strategy.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "projects/example-musician/README.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "projects/example-musician/workflow-examples/press-outreach/SKILL.md",
+                    "policy": "seed"
+                },
+                {
+                    "path": "projects/example-musician/workflow-examples/social-post/SKILL.md",
+                    "policy": "seed"
+                }
+            ]
+        }
+    ]
+}

--- a/components/schema.json
+++ b/components/schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Generated structural subset. contextos.component_schema is authoritative for lexical path safety, portable Unicode identity, filesystem checks, dependency graph rules, and tracked-file coverage.",
+  "title": "Context OS component manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "components",
+    "extensible_roots",
+    "schema_version"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "extensible_roots": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!\\s)(?:[^\\u0000-\\u001f\\u007f]*\\S)$"
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "depends_on",
+          "description",
+          "id",
+          "paths"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!\\s)(?:[^\\u0000-\\u001f\\u007f]*\\S)$"
+          },
+          "depends_on": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^(?!\\s)(?:[^\\u0000-\\u001f\\u007f]*\\S)$"
+            }
+          },
+          "paths": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "path",
+                "policy"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^(?!\\s)(?:[^\\u0000-\\u001f\\u007f]*\\S)$"
+                },
+                "policy": {
+                  "enum": [
+                    "development",
+                    "managed",
+                    "seed"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/schema.json
+++ b/components/schema.json
@@ -6,12 +6,22 @@
   "additionalProperties": false,
   "required": [
     "components",
+    "extensible_paths",
     "extensible_roots",
     "schema_version"
   ],
   "properties": {
     "schema_version": {
       "const": 1
+    },
+    "extensible_paths": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!\\s)(?:[^\\u0000-\\u001f\\u007f]*\\S)$"
+      }
     },
     "extensible_roots": {
       "type": "array",

--- a/contextos/component_schema.py
+++ b/contextos/component_schema.py
@@ -263,14 +263,6 @@ def validate_component_manifest(
             policy = _text(path_entry.get("policy"), f"{path_field}.policy")
             if policy not in PATH_POLICIES:
                 _fail(f"{path_field}.policy", f"unsupported value {policy!r}")
-            path_parts = tuple(_identity(path).split("/"))
-            root_parts = [tuple(_identity(item).split("/")) for item in extensible_roots]
-            if (any(path_parts[:len(prefix)] == prefix for prefix in root_parts)
-                    and policy != "seed"):
-                _fail(
-                    f"{path_field}.policy",
-                    "paths below extensible roots must use the user-owned seed policy",
-                )
             all_paths.append((path, f"{path_field}.path"))
             if check_paths:
                 _check_regular_file(root, path, f"{path_field}.path")

--- a/contextos/component_schema.py
+++ b/contextos/component_schema.py
@@ -94,7 +94,6 @@ def _safe_posix_path(value: Any, field: str) -> str:
 def _ownership_path(value: Any, field: str) -> str:
     raw = _safe_posix_path(value, field)
     parts = PurePosixPath(raw).parts
-    portable = _identity(raw)
     portable_parts = tuple(_identity(part) for part in parts)
     if any(
         part.endswith((".", " "))
@@ -103,6 +102,13 @@ def _ownership_path(value: Any, field: str) -> str:
         for part in portable_parts
     ):
         _fail(field, "must not use a Windows-aliased or illegal path segment")
+    return _reserved_ownership_path(raw, field)
+
+
+def _reserved_ownership_path(raw: str, field: str) -> str:
+    """Reject secret and generated-state names without enforcing host portability."""
+    portable = _identity(raw)
+    portable_parts = tuple(_identity(part) for part in PurePosixPath(raw).parts)
     if (portable in RESERVED_OWNERSHIP_PATHS
             or portable.endswith("/.ds_store") or portable == ".ds_store"
             or portable.endswith("/.lsoverride") or portable == ".lsoverride"
@@ -529,6 +535,7 @@ def unclassified_tracked_paths(
             key in extensible_paths
             or any(parts[:len(prefix)] == prefix for prefix in extensible)
         ):
+            _reserved_ownership_path(path, f"tracked_paths[{index}]")
             continue
         _ownership_path(path, f"tracked_paths[{index}]")
         missing.append(path)

--- a/contextos/component_schema.py
+++ b/contextos/component_schema.py
@@ -474,7 +474,7 @@ def unclassified_tracked_paths(
     seen: dict[str, str] = {}
     missing: list[str] = []
     for index, value in enumerate(tracked_paths):
-        path = _safe_posix_path(value, f"tracked_paths[{index}]")
+        path = _ownership_path(value, f"tracked_paths[{index}]")
         key = _identity(path)
         if key in seen:
             _fail("tracked_paths", f"portable path collision: {seen[key]!r} and {path!r}")

--- a/contextos/component_schema.py
+++ b/contextos/component_schema.py
@@ -15,7 +15,9 @@ from typing import Any, Iterable, Sequence
 COMPONENT_MANIFEST_SCHEMA_VERSION = 1
 COMPONENT_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 PATH_POLICIES = {"managed", "seed", "development"}
-TOP_LEVEL_KEYS = {"schema_version", "extensible_roots", "components"}
+TOP_LEVEL_KEYS = {
+    "schema_version", "extensible_paths", "extensible_roots", "components",
+}
 COMPONENT_KEYS = {"id", "description", "depends_on", "paths"}
 PATH_KEYS = {"path", "policy"}
 RESERVED_OWNERSHIP_PATHS = {
@@ -140,7 +142,9 @@ def _reject_prefix_conflicts(paths: Sequence[tuple[str, str]], field: str) -> No
             _fail(field, f"prefix conflict between {left_path!r} and {right_path!r}")
 
 
-def _check_regular_file(root: Path, relative: str, field: str) -> None:
+def _check_regular_file(
+    root: Path, relative: str, field: str, *, allow_missing: bool = False,
+) -> None:
     root_resolved = root.resolve()
     candidate = root / Path(*PurePosixPath(relative).parts)
     current = root
@@ -150,6 +154,10 @@ def _check_regular_file(root: Path, relative: str, field: str) -> None:
             _fail(field, f"must not be a symlink or traverse one: {relative}")
     try:
         resolved = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        if allow_missing:
+            return
+        _fail(field, f"path does not exist: {relative}")
     except OSError:
         _fail(field, f"path does not exist: {relative}")
     try:
@@ -204,6 +212,7 @@ def write_generated_file(path: Path, content: str, *, root: Path) -> None:
 
 def validate_component_manifest(
     manifest: Any, *, root: Path, check_paths: bool = True,
+    allow_missing_seed: bool = False,
 ) -> dict[str, Any]:
     """Validate and return a component manifest.
 
@@ -230,6 +239,22 @@ def validate_component_manifest(
     _reject_prefix_conflicts(
         [(path, f"extensible_roots[{index}]") for index, path in enumerate(extensible_roots)],
         "extensible_roots",
+    )
+
+    paths_value = document.get("extensible_paths")
+    if not isinstance(paths_value, list):
+        _fail("extensible_paths", "must be an array")
+    extensible_paths = [
+        _ownership_path(item, f"extensible_paths[{index}]")
+        for index, item in enumerate(paths_value)
+    ]
+    _reject_normalized_duplicates(
+        ((path, f"extensible_paths[{index}]") for index, path in enumerate(extensible_paths)),
+        "extensible_paths",
+    )
+    _reject_prefix_conflicts(
+        [(path, f"extensible_paths[{index}]") for index, path in enumerate(extensible_paths)],
+        "extensible_paths",
     )
 
     raw_components = document.get("components")
@@ -265,13 +290,25 @@ def validate_component_manifest(
                 _fail(f"{path_field}.policy", f"unsupported value {policy!r}")
             all_paths.append((path, f"{path_field}.path"))
             if check_paths:
-                _check_regular_file(root, path, f"{path_field}.path")
+                _check_regular_file(
+                    root, path, f"{path_field}.path",
+                    allow_missing=allow_missing_seed and policy == "seed",
+                )
         component_ids.append((component_id, f"{field}.id"))
         parsed_components.append(component)
 
     _reject_normalized_duplicates(component_ids, "components")
     _reject_normalized_duplicates(all_paths, "components.paths")
     _reject_prefix_conflicts(all_paths, "components.paths")
+    owned_identities = {_identity(path) for path, _ in all_paths}
+    overlapping_extensions = sorted(
+        path for path in extensible_paths if _identity(path) in owned_identities
+    )
+    if overlapping_extensions:
+        _fail(
+            "extensible_paths",
+            "must not also be component-owned: " + ", ".join(overlapping_extensions),
+        )
 
     ids_by_identity = {_identity(component_id): component_id for component_id, _ in component_ids}
     graph: dict[str, list[str]] = {}
@@ -315,6 +352,7 @@ def validate_component_manifest(
 
 def load_component_manifest(
     path: Path, *, root: Path | None = None, check_paths: bool = True,
+    allow_missing_seed: bool = False,
 ) -> dict[str, Any]:
     try:
         with path.open(encoding="utf-8") as handle:
@@ -330,6 +368,7 @@ def load_component_manifest(
     return validate_component_manifest(
         manifest, root=root if root is not None else path.parent.parent,
         check_paths=check_paths,
+        allow_missing_seed=allow_missing_seed,
     )
 
 
@@ -443,6 +482,9 @@ def component_schema_document() -> dict[str, Any]:
         "required": sorted(TOP_LEVEL_KEYS),
         "properties": {
             "schema_version": {"const": COMPONENT_MANIFEST_SCHEMA_VERSION},
+            "extensible_paths": {
+                "type": "array", "uniqueItems": True, "items": text,
+            },
             "extensible_roots": {
                 "type": "array", "uniqueItems": True, "items": text,
             },
@@ -471,10 +513,11 @@ def unclassified_tracked_paths(
     }
     extensible = [tuple(_identity(path).split("/"))
                   for path in document["extensible_roots"]]
+    extensible_paths = {_identity(path) for path in document["extensible_paths"]}
     seen: dict[str, str] = {}
     missing: list[str] = []
     for index, value in enumerate(tracked_paths):
-        path = _ownership_path(value, f"tracked_paths[{index}]")
+        path = _safe_posix_path(value, f"tracked_paths[{index}]")
         key = _identity(path)
         if key in seen:
             _fail("tracked_paths", f"portable path collision: {seen[key]!r} and {path!r}")
@@ -482,14 +525,19 @@ def unclassified_tracked_paths(
         if key in classified:
             continue
         parts = tuple(key.split("/"))
-        if allow_extensible and any(parts[:len(prefix)] == prefix for prefix in extensible):
+        if allow_extensible and (
+            key in extensible_paths
+            or any(parts[:len(prefix)] == prefix for prefix in extensible)
+        ):
             continue
+        _ownership_path(path, f"tracked_paths[{index}]")
         missing.append(path)
     return sorted(missing, key=_identity)
 
 
 def untracked_owned_paths(
     manifest: Any, tracked_paths: Iterable[str], *, root: Path,
+    allow_missing_seed: bool = False,
 ) -> list[str]:
     """Return owned catalog paths that are absent from the Git source set."""
     document = validate_component_manifest(manifest, root=root, check_paths=False)
@@ -502,6 +550,7 @@ def untracked_owned_paths(
             path_entry["path"]
             for component in document["components"]
             for path_entry in component["paths"]
+            if not (allow_missing_seed and path_entry["policy"] == "seed")
             if _identity(path_entry["path"]) not in tracked
         ),
         key=_identity,

--- a/contextos/component_schema.py
+++ b/contextos/component_schema.py
@@ -1,0 +1,516 @@
+"""Authoritative validation for the repository component inventory."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import tempfile
+import unicodedata
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Iterable, Sequence
+
+
+COMPONENT_MANIFEST_SCHEMA_VERSION = 1
+COMPONENT_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+PATH_POLICIES = {"managed", "seed", "development"}
+TOP_LEVEL_KEYS = {"schema_version", "extensible_roots", "components"}
+COMPONENT_KEYS = {"id", "description", "depends_on", "paths"}
+PATH_KEYS = {"path", "policy"}
+RESERVED_OWNERSHIP_PATHS = {
+    ".claude/settings.local.json", "repo_map.md", ".env", ".env.local",
+}
+RESERVED_OWNERSHIP_ROOTS = {
+    ".git", ".context-os", "__pycache__", ".vscode", ".idea", ".appledouble",
+    "node_modules",
+}
+WINDOWS_DEVICE_NAMES = {
+    "con", "prn", "aux", "nul",
+    *(f"com{index}" for index in range(1, 10)),
+    *(f"lpt{index}" for index in range(1, 10)),
+}
+WINDOWS_ILLEGAL_CHARACTERS = set('<>:"|?*')
+
+
+class ComponentManifestError(ValueError):
+    """Raised when a component manifest violates the repository contract."""
+
+
+def _fail(field: str, message: str) -> None:
+    raise ComponentManifestError(f"{field}: {message}")
+
+
+def _exact_keys(value: Any, expected: set[str], field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _fail(field, "must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        details = []
+        if missing:
+            details.append(f"missing {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown {', '.join(unknown)}")
+        _fail(field, "; ".join(details))
+    return value
+
+
+def _text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail(field, "must be a non-empty string without surrounding whitespace")
+    if any(unicodedata.category(character) in {"Cc", "Cf", "Zl", "Zp"}
+           for character in value):
+        _fail(field, "must not contain control or format characters")
+    return value
+
+
+def _identity(value: str) -> str:
+    """Return the portable identity used for IDs and repository paths."""
+    return unicodedata.normalize("NFC", value).casefold()
+
+
+portable_path_identity = _identity
+
+
+def _safe_posix_path(value: Any, field: str) -> str:
+    raw = _text(value, field)
+    if "\\" in raw:
+        _fail(field, "must use POSIX separators")
+    posix = PurePosixPath(raw)
+    windows = PureWindowsPath(raw)
+    if posix.is_absolute() or windows.is_absolute() or windows.drive:
+        _fail(field, "must be repository-relative")
+    if any(part in {"", ".", ".."} for part in raw.split("/")):
+        _fail(field, "must be a canonical lexical path without empty, '.' or '..' segments")
+    if posix.as_posix() != raw:
+        _fail(field, "must be a canonical lexical POSIX path")
+    return raw
+
+
+def _ownership_path(value: Any, field: str) -> str:
+    raw = _safe_posix_path(value, field)
+    parts = PurePosixPath(raw).parts
+    portable = _identity(raw)
+    portable_parts = tuple(_identity(part) for part in parts)
+    if any(
+        part.endswith((".", " "))
+        or any(character in WINDOWS_ILLEGAL_CHARACTERS for character in part)
+        or part.split(".", 1)[0] in WINDOWS_DEVICE_NAMES
+        for part in portable_parts
+    ):
+        _fail(field, "must not use a Windows-aliased or illegal path segment")
+    if (portable in RESERVED_OWNERSHIP_PATHS
+            or portable.endswith("/.ds_store") or portable == ".ds_store"
+            or portable.endswith("/.lsoverride") or portable == ".lsoverride"
+            or any(part in RESERVED_OWNERSHIP_ROOTS for part in portable_parts)
+            or any(part.startswith(".env") for part in portable_parts)
+            or portable.endswith((
+                ".pyc", ".pyo", ".pyd", ".log", ".pem", ".key", ".swp", ".swo",
+            ))):
+        _fail(field, "must not claim local, generated-on-demand, secret, or ignored state")
+    return raw
+
+
+def _string_array(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list):
+        _fail(field, "must be an array")
+    return [_text(item, f"{field}[{index}]") for index, item in enumerate(value)]
+
+
+def _reject_normalized_duplicates(values: Iterable[tuple[str, str]], field: str) -> None:
+    seen: dict[str, str] = {}
+    for value, location in values:
+        key = _identity(value)
+        if key in seen:
+            _fail(field, f"duplicate values after Unicode NFC case-folding: {seen[key]!r} and {value!r}")
+        seen[key] = value
+
+
+def _reject_prefix_conflicts(paths: Sequence[tuple[str, str]], field: str) -> None:
+    ordered = sorted(
+        ((_identity(path).split("/"), path, location) for path, location in paths),
+        key=lambda item: item[0],
+    )
+    for left, right in zip(ordered, ordered[1:]):
+        left_parts, left_path, _ = left
+        right_parts, right_path, _ = right
+        if len(left_parts) < len(right_parts) and right_parts[:len(left_parts)] == left_parts:
+            _fail(field, f"prefix conflict between {left_path!r} and {right_path!r}")
+
+
+def _check_regular_file(root: Path, relative: str, field: str) -> None:
+    root_resolved = root.resolve()
+    candidate = root / Path(*PurePosixPath(relative).parts)
+    current = root
+    for part in PurePosixPath(relative).parts:
+        current /= part
+        if current.is_symlink():
+            _fail(field, f"must not be a symlink or traverse one: {relative}")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError:
+        _fail(field, f"path does not exist: {relative}")
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        _fail(field, f"must not escape the repository: {relative}")
+    try:
+        mode = candidate.lstat().st_mode
+    except OSError:
+        _fail(field, f"path does not exist: {relative}")
+    if not stat.S_ISREG(mode):
+        _fail(field, f"must name a regular file: {relative}")
+
+
+def write_generated_file(path: Path, content: str, *, root: Path) -> None:
+    """Atomically replace a generated file without following repository symlinks."""
+    root_resolved = root.resolve()
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        _fail("generated_path", f"escapes repository: {path}")
+    current = root
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            _fail("generated_path", f"traverses a symlink: {current.relative_to(root)}")
+    if path.is_symlink():
+        _fail("generated_path", f"must not be a symlink: {relative}")
+    if path.exists() and not path.is_file():
+        _fail("generated_path", f"must be a regular file: {relative}")
+    try:
+        path.parent.resolve().relative_to(root_resolved)
+    except ValueError:
+        _fail("generated_path", "must remain inside repository")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", newline="\n", dir=path.parent,
+            prefix=f".{path.name}.", suffix=".tmp", delete=False,
+        ) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary_name = handle.name
+        os.replace(temporary_name, path)
+        temporary_name = None
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+
+
+def validate_component_manifest(
+    manifest: Any, *, root: Path, check_paths: bool = True,
+) -> dict[str, Any]:
+    """Validate and return a component manifest.
+
+    Path comparison is lexical, Unicode-NFC-normalized, and case-insensitive so
+    a manifest cannot be valid on one supported filesystem and ambiguous on
+    another.
+    """
+    document = _exact_keys(manifest, TOP_LEVEL_KEYS, "manifest")
+    if (type(document.get("schema_version")) is not int
+            or document["schema_version"] != COMPONENT_MANIFEST_SCHEMA_VERSION):
+        _fail("schema_version", f"must equal integer {COMPONENT_MANIFEST_SCHEMA_VERSION}")
+
+    roots_value = document.get("extensible_roots")
+    if not isinstance(roots_value, list):
+        _fail("extensible_roots", "must be an array")
+    extensible_roots = [
+        _ownership_path(item, f"extensible_roots[{index}]")
+        for index, item in enumerate(roots_value)
+    ]
+    _reject_normalized_duplicates(
+        ((path, f"extensible_roots[{index}]") for index, path in enumerate(extensible_roots)),
+        "extensible_roots",
+    )
+    _reject_prefix_conflicts(
+        [(path, f"extensible_roots[{index}]") for index, path in enumerate(extensible_roots)],
+        "extensible_roots",
+    )
+
+    raw_components = document.get("components")
+    if not isinstance(raw_components, list) or not raw_components:
+        _fail("components", "must be a non-empty array")
+
+    component_ids: list[tuple[str, str]] = []
+    all_paths: list[tuple[str, str]] = []
+    parsed_components: list[dict[str, Any]] = []
+    for index, raw_component in enumerate(raw_components):
+        field = f"components[{index}]"
+        component = _exact_keys(raw_component, COMPONENT_KEYS, field)
+        component_id = _text(component.get("id"), f"{field}.id")
+        if not COMPONENT_ID_RE.fullmatch(component_id):
+            _fail(f"{field}.id", "must be a lowercase kebab-case component id")
+        _text(component.get("description"), f"{field}.description")
+        dependencies = _string_array(component.get("depends_on"), f"{field}.depends_on")
+        _reject_normalized_duplicates(
+            ((dependency, f"{field}.depends_on[{dependency_index}]")
+             for dependency_index, dependency in enumerate(dependencies)),
+            f"{field}.depends_on",
+        )
+
+        raw_paths = component.get("paths")
+        if not isinstance(raw_paths, list) or not raw_paths:
+            _fail(f"{field}.paths", "must be a non-empty array")
+        for path_index, raw_path in enumerate(raw_paths):
+            path_field = f"{field}.paths[{path_index}]"
+            path_entry = _exact_keys(raw_path, PATH_KEYS, path_field)
+            path = _ownership_path(path_entry.get("path"), f"{path_field}.path")
+            policy = _text(path_entry.get("policy"), f"{path_field}.policy")
+            if policy not in PATH_POLICIES:
+                _fail(f"{path_field}.policy", f"unsupported value {policy!r}")
+            path_parts = tuple(_identity(path).split("/"))
+            root_parts = [tuple(_identity(item).split("/")) for item in extensible_roots]
+            if (any(path_parts[:len(prefix)] == prefix for prefix in root_parts)
+                    and policy != "seed"):
+                _fail(
+                    f"{path_field}.policy",
+                    "paths below extensible roots must use the user-owned seed policy",
+                )
+            all_paths.append((path, f"{path_field}.path"))
+            if check_paths:
+                _check_regular_file(root, path, f"{path_field}.path")
+        component_ids.append((component_id, f"{field}.id"))
+        parsed_components.append(component)
+
+    _reject_normalized_duplicates(component_ids, "components")
+    _reject_normalized_duplicates(all_paths, "components.paths")
+    _reject_prefix_conflicts(all_paths, "components.paths")
+
+    ids_by_identity = {_identity(component_id): component_id for component_id, _ in component_ids}
+    graph: dict[str, list[str]] = {}
+    for index, component in enumerate(parsed_components):
+        component_id = component["id"]
+        component_key = _identity(component_id)
+        dependencies: list[str] = []
+        for dependency_index, dependency in enumerate(component["depends_on"]):
+            dependency_key = _identity(dependency)
+            dependency_field = f"components[{index}].depends_on[{dependency_index}]"
+            if dependency_key == component_key:
+                _fail(dependency_field, "component must not depend on itself")
+            if dependency_key not in ids_by_identity:
+                _fail(dependency_field, f"unknown component {dependency!r}")
+            dependencies.append(dependency_key)
+        graph[component_key] = dependencies
+
+    state: dict[str, int] = {}
+    stack: list[str] = []
+
+    def visit(component_key: str) -> None:
+        if state.get(component_key) == 2:
+            return
+        if state.get(component_key) == 1:
+            start = stack.index(component_key)
+            cycle = stack[start:] + [component_key]
+            _fail("components.depends_on", "dependency cycle: " + " -> ".join(
+                ids_by_identity[item] for item in cycle
+            ))
+        state[component_key] = 1
+        stack.append(component_key)
+        for dependency_key in sorted(graph[component_key]):
+            visit(dependency_key)
+        stack.pop()
+        state[component_key] = 2
+
+    for component_key in sorted(graph):
+        visit(component_key)
+    return document
+
+
+def load_component_manifest(
+    path: Path, *, root: Path | None = None, check_paths: bool = True,
+) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            manifest = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ComponentManifestError(
+            f"invalid JSON in {path}: line {exc.lineno} column {exc.colno}"
+        ) from exc
+    except OSError as exc:
+        raise ComponentManifestError(
+            f"cannot read component manifest {path}: {exc.strerror or exc}"
+        ) from exc
+    return validate_component_manifest(
+        manifest, root=root if root is not None else path.parent.parent,
+        check_paths=check_paths,
+    )
+
+
+def component_closure(manifest: Any, component_ids: Sequence[str]) -> list[str]:
+    """Return a stable dependency-first closure for the requested components."""
+    document = validate_component_manifest(manifest, root=Path("."), check_paths=False)
+    requested = [_text(item, f"component_ids[{index}]")
+                 for index, item in enumerate(component_ids)]
+    _reject_normalized_duplicates(
+        ((item, f"component_ids[{index}]") for index, item in enumerate(requested)),
+        "component_ids",
+    )
+    components = {_identity(item["id"]): item for item in document["components"]}
+    unknown = sorted(item for item in requested if _identity(item) not in components)
+    if unknown:
+        _fail("component_ids", f"unknown components: {', '.join(unknown)}")
+
+    result: list[str] = []
+    included: set[str] = set()
+
+    def include(component_key: str) -> None:
+        if component_key in included:
+            return
+        component = components[component_key]
+        for dependency in sorted(component["depends_on"], key=_identity):
+            include(_identity(dependency))
+        included.add(component_key)
+        result.append(component["id"])
+
+    for requested_id in sorted(requested, key=_identity):
+        include(_identity(requested_id))
+    return result
+
+
+def component_owners(manifest: Any) -> dict[str, str]:
+    """Return exact repository paths mapped to their single component owner."""
+    document = validate_component_manifest(manifest, root=Path("."), check_paths=False)
+    return {
+        path_entry["path"]: component["id"]
+        for component in document["components"]
+        for path_entry in component["paths"]
+    }
+
+
+def resolved_component_paths(
+    manifest: Any, component_ids: Sequence[str], *, include_development: bool = False,
+) -> list[dict[str, str]]:
+    """Resolve selected components to deterministic, single-owner path records."""
+    document = validate_component_manifest(manifest, root=Path("."), check_paths=False)
+    selected = set(component_closure(document, component_ids))
+    records = [
+        {
+            "owner": component["id"],
+            "path": path_entry["path"],
+            "policy": path_entry["policy"],
+        }
+        for component in document["components"]
+        if component["id"] in selected
+        for path_entry in component["paths"]
+        if include_development or path_entry["policy"] != "development"
+    ]
+    return sorted(records, key=lambda item: _identity(item["path"]))
+
+
+# The short name is convenient to callers resolving install selections.
+dependency_closure = component_closure
+
+
+def component_schema_document() -> dict[str, Any]:
+    """Return the generated JSON Schema structural subset of this contract."""
+    text = {
+        "type": "string",
+        "minLength": 1,
+        "pattern": r"^(?!\s)(?:[^\u0000-\u001f\u007f]*\S)$",
+    }
+    path_entry = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": sorted(PATH_KEYS),
+        "properties": {
+            "path": text,
+            "policy": {"enum": sorted(PATH_POLICIES)},
+        },
+    }
+    component = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": sorted(COMPONENT_KEYS),
+        "properties": {
+            "id": {"type": "string", "pattern": COMPONENT_ID_RE.pattern},
+            "description": text,
+            "depends_on": {
+                "type": "array", "uniqueItems": True, "items": text,
+            },
+            "paths": {
+                "type": "array", "minItems": 1, "uniqueItems": True,
+                "items": path_entry,
+            },
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$comment": (
+            "Generated structural subset. contextos.component_schema is authoritative "
+            "for lexical path safety, portable Unicode identity, filesystem checks, "
+            "dependency graph rules, and tracked-file coverage."
+        ),
+        "title": "Context OS component manifest",
+        "type": "object",
+        "additionalProperties": False,
+        "required": sorted(TOP_LEVEL_KEYS),
+        "properties": {
+            "schema_version": {"const": COMPONENT_MANIFEST_SCHEMA_VERSION},
+            "extensible_roots": {
+                "type": "array", "uniqueItems": True, "items": text,
+            },
+            "components": {
+                "type": "array", "minItems": 1, "uniqueItems": True,
+                "items": component,
+            },
+        },
+    }
+
+
+def unclassified_tracked_paths(
+    manifest: Any, tracked_paths: Iterable[str], *, root: Path,
+    allow_extensible: bool = False,
+) -> list[str]:
+    """Return tracked files without an exact owner.
+
+    Maintainer checks are strict. Operational callers may explicitly allow new
+    user files below extensible roots without weakening the release inventory.
+    """
+    document = validate_component_manifest(manifest, root=root, check_paths=False)
+    classified = {
+        _identity(path_entry["path"])
+        for component in document["components"]
+        for path_entry in component["paths"]
+    }
+    extensible = [tuple(_identity(path).split("/"))
+                  for path in document["extensible_roots"]]
+    seen: dict[str, str] = {}
+    missing: list[str] = []
+    for index, value in enumerate(tracked_paths):
+        path = _safe_posix_path(value, f"tracked_paths[{index}]")
+        key = _identity(path)
+        if key in seen:
+            _fail("tracked_paths", f"portable path collision: {seen[key]!r} and {path!r}")
+        seen[key] = path
+        if key in classified:
+            continue
+        parts = tuple(key.split("/"))
+        if allow_extensible and any(parts[:len(prefix)] == prefix for prefix in extensible):
+            continue
+        missing.append(path)
+    return sorted(missing, key=_identity)
+
+
+def untracked_owned_paths(
+    manifest: Any, tracked_paths: Iterable[str], *, root: Path,
+) -> list[str]:
+    """Return owned catalog paths that are absent from the Git source set."""
+    document = validate_component_manifest(manifest, root=root, check_paths=False)
+    tracked = {
+        _identity(_safe_posix_path(path, f"tracked_paths[{index}]"))
+        for index, path in enumerate(tracked_paths)
+    }
+    return sorted(
+        (
+            path_entry["path"]
+            for component in document["components"]
+            for path_entry in component["paths"]
+            if _identity(path_entry["path"]) not in tracked
+        ),
+        key=_identity,
+    )

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -14,6 +14,13 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
+from .component_schema import (
+    ComponentManifestError,
+    component_closure,
+    component_owners,
+    load_component_manifest,
+    portable_path_identity,
+)
 from .runtime_schema import (
     RUNTIME_ID_RE,
     RuntimeManifestError,
@@ -603,6 +610,12 @@ def runtime_ids(root: Path) -> list[str]:
 def runtime_manifest(
     root: Path, runtime: str, *, check_paths: bool = True
 ) -> dict[str, Any]:
+    """Load a runtime and its required core component contract.
+
+    ``check_paths=False`` skips maintainer evidence/path existence checks, but
+    structural component and ownership validation remains an operational
+    invariant for hooks and proposal application.
+    """
     if not isinstance(runtime, str) or runtime == "generic" or not RUNTIME_ID_RE.fullmatch(runtime):
         raise ContextOSError(f"invalid runtime id: {runtime}")
     manifest_path = root / "runtimes" / f"{runtime}.json"
@@ -613,7 +626,44 @@ def runtime_manifest(
         validate_runtime_manifest(
             manifest, runtime_id=runtime, root=root, check_paths=check_paths
         )
-    except RuntimeManifestError as exc:
+        components = load_component_manifest(
+            root / "components" / "manifest.json", root=root, check_paths=False
+        )
+        selected = set(component_closure(components, manifest["components"]))
+        owners = component_owners(components)
+        required_paths = {
+            f"runtimes/{runtime}.json",
+            manifest["onboarding_doc"],
+        }
+        for surface in manifest["surfaces"].values():
+            required_paths.update(surface["conformance_tests"])
+            required_paths.update(
+                source["path"]
+                for source in surface["instruction_sources"] + surface["skill_sources"]
+                if source["scope"] == "repository"
+            )
+        required_paths.update(
+            source["location"]
+            for source in manifest["evidence"]["sources"]
+            if source["type"] == "conformance"
+        )
+        for required_path in sorted(required_paths):
+            required_identity = portable_path_identity(required_path.rstrip("/"))
+            matching_owners = {
+                owner for owned_path, owner in owners.items()
+                if portable_path_identity(owned_path) == required_identity
+                or portable_path_identity(owned_path).startswith(required_identity + "/")
+            }
+            if not matching_owners:
+                raise ComponentManifestError(
+                    f"runtime {runtime!r} references unowned path {required_path!r}"
+                )
+            if not matching_owners.intersection(selected):
+                raise ComponentManifestError(
+                    f"runtime {runtime!r} requires {required_path!r}, owned only by "
+                    f"unselected components {sorted(matching_owners)!r}"
+                )
+    except (RuntimeManifestError, ComponentManifestError, OSError, UnicodeError) as exc:
         raise ContextOSError(f"invalid runtime manifest: {manifest_path} ({exc})") from exc
     return manifest
 

--- a/docs/agent-template.md
+++ b/docs/agent-template.md
@@ -68,7 +68,7 @@ The example is deliberately read-only and user-invoked. Add a write, shell, or e
 - [ ] Host-specific tools, permission grants, hooks, and commands stay out of `.agents/skills/`
 - [ ] Routing rule added to ROUTING.md if appropriate
 - [ ] CHANGELOG.md updated with new files
-- [ ] Run `scripts/validate-all.sh` to verify structure
+- [ ] Run `scripts/validate-all.sh --workspace` to verify structure
 
 If you add the optional Claude adapter:
 

--- a/docs/claude-projects-sync.md
+++ b/docs/claude-projects-sync.md
@@ -50,7 +50,8 @@ Claude.ai cannot write this repository. If it drafts an improvement:
 2. Compare it with the maintained source and remove Project-only or sensitive
    context.
 3. Propose the exact destination and diff before changing repository files.
-4. Apply only the reviewed change, then run `bash scripts/validate-all.sh`.
+4. Apply only the reviewed change, then run
+   `bash scripts/validate-all.sh --workspace`.
 5. Review the git diff and approve any commit or push separately.
 
 Claude can follow provider-neutral instructions in an uploaded skill file, but

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -58,7 +58,7 @@ SSOTs.
 
 ```bash
 bash scripts/contextos.sh doctor --runtime codex
-bash scripts/validate-all.sh
+bash scripts/validate-all.sh --workspace
 ```
 
 Local validation proves kernel transitions and adapter contracts. Opt-in runtime

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -77,4 +77,5 @@ Uploading these files to claude.ai does not activate commands, hooks, tool
 permissions, or skill metadata. See `docs/claude-projects-sync.md`.
 
 Run `bash scripts/contextos.sh doctor` for runtime and state diagnostics, then
-`bash scripts/validate-all.sh` after repository changes.
+`bash scripts/validate-all.sh --workspace` after personalized repository
+changes. Product contributors use the strict form without `--workspace`.

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -21,13 +21,18 @@ Every currently tracked file has exactly one component owner and one policy:
 - `development`: repository maintenance, tests, CI, or contribution files.
   These prove or build the product but are not runtime workspace outputs.
 
-The roots `.agents/skills/`, `.claude/commands/`, `content/`, `identity/`,
-`inbox/`, `projects/`, `sessions/`, `state/`, and `writing/` are extensible.
+The roots `.agents/skills/`, `.claude/agents/`, `.claude/commands/`, `content/`,
+`identity/`, `inbox/`, `projects/`, `references/`, `sessions/`, `state/`, and
+`writing/` are extensible. The root configuration files `workspace.yaml` and
+`contextos.workspace.json` are exact extensible paths rather than directory
+roots.
 Checked-in files below them retain their explicit owner and policy, while new
 user files are workspace-owned rather than component-owned. The maintainer
 check remains strict over the repository's tracked source set;
 `bash scripts/validate-all.sh --workspace` selects the operational exception
-for a customized workspace. CI and product contributors use the strict default.
+for a customized workspace. That operational check also permits intentionally
+removed `seed` files, while missing `managed` or `development` files still fail.
+CI and product contributors use the strict default.
 
 ## Components
 

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -21,14 +21,13 @@ Every currently tracked file has exactly one component owner and one policy:
 - `development`: repository maintenance, tests, CI, or contribution files.
   These prove or build the product but are not runtime workspace outputs.
 
-The roots `content/`, `identity/`, `inbox/`, `projects/`, `sessions/`, `state/`,
-and `writing/` are extensible. Their checked-in seeds are inventoried, while new
-user files below those roots are workspace-owned rather than component-owned.
-The maintainer check remains strict over the repository's tracked source set;
-future operational callers must opt into the extensible-root exception when
-validating a customized workspace. `bash scripts/validate-all.sh --workspace`
-selects that operational mode; CI and product contributors use the strict
-default.
+The roots `.agents/skills/`, `.claude/commands/`, `content/`, `identity/`,
+`inbox/`, `projects/`, `sessions/`, `state/`, and `writing/` are extensible.
+Checked-in files below them retain their explicit owner and policy, while new
+user files are workspace-owned rather than component-owned. The maintainer
+check remains strict over the repository's tracked source set;
+`bash scripts/validate-all.sh --workspace` selects the operational exception
+for a customized workspace. CI and product contributors use the strict default.
 
 ## Components
 

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -1,0 +1,90 @@
+# Component inventory and ownership
+
+`components/manifest.json` is the authoritative inventory for the files that
+make up Context OS. Runtime descriptors name component IDs; the component graph
+resolves those IDs to one deterministic dependency closure and one owner for
+every checked-in path.
+
+This inventory is metadata, not a materializer. It does not copy, delete,
+upgrade, or rewrite a workspace. Those operations require the later
+configuration and transaction layers described in the multi-agent design epic.
+
+## Path policies
+
+Every currently tracked file has exactly one component owner and one policy:
+
+- `managed`: product code, instructions, adapters, or documentation that a
+  future composition tool may install and update.
+- `seed`: initial content that becomes user-owned after it is copied. Future
+  updates must preserve an existing destination unless a separately reviewed
+  migration says otherwise.
+- `development`: repository maintenance, tests, CI, or contribution files.
+  These prove or build the product but are not runtime workspace outputs.
+
+The roots `content/`, `identity/`, `inbox/`, `projects/`, `sessions/`, `state/`,
+and `writing/` are extensible. Their checked-in seeds are inventoried, while new
+user files below those roots are workspace-owned rather than component-owned.
+The maintainer check remains strict over the repository's tracked source set;
+future operational callers must opt into the extensible-root exception when
+validating a customized workspace.
+
+## Components
+
+| Component | Depends on | Responsibility |
+|---|---|---|
+| `core` | none | Provider-neutral kernel, shared docs and scripts, repository scaffolding, and user-owned seeds |
+| `portable-skills` | `core` | Provider-neutral lifecycle and migration skill bodies |
+| `openai-skill-metadata` | `portable-skills` | OpenAI discovery metadata, separate from portable skill bodies |
+| `agents-instructions` | `core`, `portable-skills` | The shared `AGENTS.md` instruction bridge |
+| `claude-adapter` | `core`, `portable-skills` | Claude Code instructions, commands, hooks, memory tooling, and descriptor |
+| `codex-adapter` | `core`, `portable-skills`, `agents-instructions`, `openai-skill-metadata` | Codex hooks, onboarding, metadata, and descriptor |
+| `hermes-adapter` | `core`, `portable-skills`, `agents-instructions` | Hermes guidance, optional hooks, and descriptor |
+| `example-project` | `core` | Optional removable example content |
+
+Shared dependencies have one owner. Selecting both Claude and Codex therefore
+includes `core` and `portable-skills` once; neither adapter becomes a second
+owner. OpenAI metadata is also isolated so an agentskills.io consumer can use
+portable skill bodies without inheriting Codex-specific presentation files.
+When a runtime names a directory source such as `.agents/skills`, the resolver
+materializes only descendant files owned by the selected closure; an unselected
+component may contribute a different fragment beneath the same directory.
+
+## Validation
+
+Run:
+
+```bash
+python scripts/component-manifests.py check
+```
+
+The full validator runs the same check. It rejects unknown dependencies,
+cycles, unknown runtime component references, unsafe or symlinked paths,
+case-insensitive, Unicode-normalized, and Windows-aliased collisions,
+file/descendant ownership conflicts, symlinked generated targets, missing or
+untracked owned files, duplicate owners, and any unclassified tracked source
+file. `components/schema.json` is generated from the Python contract and must
+stay current.
+
+## Clean-composition prerequisites
+
+Before a later command may materialize a selected component set, it must also:
+
+1. record the selected runtimes and components in workspace-local
+   configuration;
+2. distinguish pristine managed outputs from modified or user-owned targets;
+3. preflight case-folded paths, symlink ancestors, and destination containment;
+4. produce an exact add/change/remove plan with immutable source hashes;
+5. require digest-bound approval and use the transaction lock and receipts;
+6. preserve existing `seed` paths and arbitrary files below extensible roots;
+7. define how generated whole-file artifacts and maintainer-only conformance
+   evidence behave in a slim workspace; and
+8. validate the resulting selected runtime closure without assuming every
+   adapter or the development test tree is present;
+9. replace the current `AGENTS.md`-based root discovery and doctor requirement
+   with a provider-neutral marker before a Claude-only closure can omit the
+   `agents-instructions` component; and
+10. make shared instruction and documentation links closure-aware so a slim
+    workspace neither points at omitted adapter docs nor describes hooks that
+    were not selected.
+
+Until those guarantees ship, the catalog is intentionally read-only inventory.

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -26,7 +26,9 @@ and `writing/` are extensible. Their checked-in seeds are inventoried, while new
 user files below those roots are workspace-owned rather than component-owned.
 The maintainer check remains strict over the repository's tracked source set;
 future operational callers must opt into the extensible-root exception when
-validating a customized workspace.
+validating a customized workspace. `bash scripts/validate-all.sh --workspace`
+selects that operational mode; CI and product contributors use the strict
+default.
 
 ## Components
 

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -21,11 +21,10 @@ Every currently tracked file has exactly one component owner and one policy:
 - `development`: repository maintenance, tests, CI, or contribution files.
   These prove or build the product but are not runtime workspace outputs.
 
-The roots `.agents/skills/`, `.claude/agents/`, `.claude/commands/`, `content/`,
-`identity/`, `inbox/`, `projects/`, `references/`, `sessions/`, `state/`, and
-`writing/` are extensible. The root configuration files `workspace.yaml` and
-`contextos.workspace.json` are exact extensible paths rather than directory
-roots.
+The roots `.agents/skills/`, `.claude/commands/`, `content/`, `identity/`,
+`inbox/`, `projects/`, `references/`, `sessions/`, `state/`, and `writing/` are
+extensible. The legacy root configuration file `workspace.yaml` is an exact
+extensible path rather than a directory root.
 Checked-in files below them retain their explicit owner and policy, while new
 user files are workspace-owned rather than component-owned. The maintainer
 check remains strict over the repository's tracked source set;

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -12,10 +12,14 @@ models, tool names, or native memory.
    judgment without owning mutation mechanics.
 3. **Deterministic kernel:** `bash scripts/contextos.sh` owns paths, rendering,
    invariants, proposals, locks, optimistic hashes, applies, and receipts.
-4. **Runtime adapters:** discoverable schema-v2 descriptors in `runtimes/` map
+4. **Component inventory:** `components/manifest.json` assigns every tracked
+   product, seed, and development path to one owner and defines the dependency
+   closure shared by runtime selections. It is validated metadata, not a file
+   materializer. See [the component model](component-model.md).
+5. **Runtime adapters:** discoverable schema-v2 descriptors in `runtimes/` map
    each host surface to instructions, skills, lifecycle invocations, probes,
    capabilities, and evidence. Provider files remain in their adapter directories.
-5. **Conformance:** dependency-light tests assert exact state transitions;
+6. **Conformance:** dependency-light tests assert exact state transitions;
    opt-in launch tests exercise installed host discovery without hiding skips.
 
 ## Commands

--- a/docs/first-skill.md
+++ b/docs/first-skill.md
@@ -95,7 +95,7 @@ Run it in Claude Code with `/standup`. `allowed-tools` is a pre-approval grant, 
 ## 5. Validate and inspect
 
 ```bash
-bash scripts/validate-all.sh
+bash scripts/validate-all.sh --workspace
 git diff -- .agents/skills/standup .claude/commands/standup.md
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,7 @@ Then run:
 
 ```bash
 bash scripts/contextos.sh doctor
-bash scripts/validate-all.sh
+bash scripts/validate-all.sh --workspace
 git diff --check
 git status --short
 ```
@@ -143,6 +143,9 @@ Install and authenticate one add-on at a time. Run its narrow health check befor
 - Keep one fact in one canonical file and route to it elsewhere.
 - Review files that pass their staleness threshold.
 - Use one git worktree per concurrent agent session.
-- Run `bash scripts/validate-all.sh` after changing instructions, skills, scripts, or generated references.
+- Run `bash scripts/validate-all.sh --workspace` after changing instructions,
+  skills, scripts, generated references, or tracked personal context. The
+  contributor and CI form omits `--workspace` to enforce complete product-file
+  ownership.
 
 See [repository maintenance](repo-maintenance.md) and the [safety contract](safety-contract.md) for the operating rules.

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -36,7 +36,8 @@ For the selected entry:
 4. Start with the least privilege and the narrowest read-only health check available.
 5. Require a separate confirmation for sensitive reads, writes, remote writes, publish, overwrite, deletion, arbitrary execution, OAuth, or destructive actions when the catalog marks them.
 6. Record how to disable or uninstall it before relying on it.
-7. Re-run `bash scripts/validate-all.sh` after changing tracked configuration.
+7. Re-run `bash scripts/validate-all.sh --workspace` after changing tracked
+   configuration.
 
 Do not infer safety from the word `verified`. In this repository it means the catalog metadata was checked against linked evidence on the stated date; it is not live authentication, an end-to-end test, or a guarantee about future upstream behavior.
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -24,7 +24,8 @@ Maintenance should keep context accurate and permissions narrow without creating
 - Archive completed project context while preserving any durable decision that still matters.
 - Inspect optional integration permissions and remove entries that no longer serve a concrete task.
 - Review session logs for a genuinely repeatable workflow before creating a skill.
-- Run `bash scripts/validate-all.sh` and treat secret scanning as a limited tripwire, not a publication guarantee.
+- Run `bash scripts/validate-all.sh --workspace` and treat secret scanning as a
+  limited tripwire, not a publication guarantee.
 
 ## Portable continuity versus Claude memory
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -149,6 +149,6 @@ Before committing:
 - [ ] `ROUTING.md` points to each new project or skill
 - [ ] Populated files were merged, not silently replaced
 - [ ] The final diff contains only intended context
-- [ ] `bash scripts/validate-all.sh` passes
+- [ ] `bash scripts/validate-all.sh --workspace` passes
 
 When the packet is approved, run `/setup` in Claude Code or `$setup` in Codex and provide the packet as the selected import material. The setup workflow will inventory the current workspace, propose a file map, and wait before overwriting populated files.

--- a/docs/repo-maintenance.md
+++ b/docs/repo-maintenance.md
@@ -7,12 +7,16 @@ Context is useful only when it is current, scoped, and safe to load. Maintenance
 ## Before committing
 
 ```bash
-bash scripts/validate-all.sh
+bash scripts/validate-all.sh --workspace
 git diff --check
 git status --short
 ```
 
 Review the actual diff. Validation catches structure and known invariants, not an incorrect personal fact or an overly broad instruction.
+
+`--workspace` permits new tracked files only below the component catalog's
+declared extensible roots. Product contributors and CI omit that flag so every
+tracked template file must have an explicit component owner.
 
 ## Reviewing tracked context
 

--- a/scripts/component-manifests.py
+++ b/scripts/component-manifests.py
@@ -50,7 +50,11 @@ def git_tracked_paths(root: Path) -> list[str]:
         raise ComponentManifestError(f"git ls-files returned a non-UTF-8 path: {exc}") from None
     if decoded and not decoded.endswith("\0"):
         raise ComponentManifestError("git ls-files -z returned an unterminated path")
-    return decoded.rstrip("\0").split("\0") if decoded else []
+    paths = decoded.rstrip("\0").split("\0") if decoded else []
+    # An unresolved index can list one pathname once per stage. Preserve
+    # distinct spellings so portable collisions still fail, but collapse exact
+    # stage duplicates before applying the source-set contract.
+    return list(dict.fromkeys(paths))
 
 
 def check(
@@ -60,7 +64,12 @@ def check(
 ) -> tuple[int, int]:
     manifest_path = manifest_path or root / "components" / "manifest.json"
     schema_path = schema_path or root / "components" / "schema.json"
-    manifest = load_component_manifest(manifest_path, root=root, check_paths=True)
+    manifest = load_component_manifest(
+        manifest_path,
+        root=root,
+        check_paths=True,
+        allow_missing_seed=allow_extensible,
+    )
     if (not schema_path.exists()
             or schema_path.read_text(encoding="utf-8") != schema_text()):
         raise ComponentManifestError(
@@ -75,7 +84,9 @@ def check(
         if len(missing) > 20:
             preview += f", ... ({len(missing) - 20} more)"
         raise ComponentManifestError(f"unclassified tracked paths: {preview}")
-    untracked_owned = untracked_owned_paths(manifest, tracked, root=root)
+    untracked_owned = untracked_owned_paths(
+        manifest, tracked, root=root, allow_missing_seed=allow_extensible
+    )
     if untracked_owned:
         preview = ", ".join(untracked_owned[:20])
         if len(untracked_owned) > 20:

--- a/scripts/component-manifests.py
+++ b/scripts/component-manifests.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Validate the component inventory and its coverage of tracked files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "components" / "manifest.json"
+sys.path.insert(0, str(ROOT))
+
+from contextos.component_schema import (  # noqa: E402
+    ComponentManifestError,
+    component_schema_document,
+    load_component_manifest,
+    unclassified_tracked_paths,
+    untracked_owned_paths,
+    write_generated_file,
+)
+
+
+SCHEMA_PATH = ROOT / "components" / "schema.json"
+
+
+def schema_text() -> str:
+    return json.dumps(component_schema_document(), indent=2, ensure_ascii=False) + "\n"
+
+
+def git_tracked_paths(root: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--"],
+            cwd=root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = exc.stderr.decode("utf-8", errors="replace").strip() \
+            if isinstance(exc, subprocess.CalledProcessError) else str(exc)
+        raise ComponentManifestError(f"git ls-files failed: {detail}") from None
+    try:
+        decoded = result.stdout.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ComponentManifestError(f"git ls-files returned a non-UTF-8 path: {exc}") from None
+    if decoded and not decoded.endswith("\0"):
+        raise ComponentManifestError("git ls-files -z returned an unterminated path")
+    return decoded.rstrip("\0").split("\0") if decoded else []
+
+
+def check(
+    root: Path = ROOT, manifest_path: Path | None = None,
+    schema_path: Path | None = None,
+) -> tuple[int, int]:
+    manifest_path = manifest_path or root / "components" / "manifest.json"
+    schema_path = schema_path or root / "components" / "schema.json"
+    manifest = load_component_manifest(manifest_path, root=root, check_paths=True)
+    if (not schema_path.exists()
+            or schema_path.read_text(encoding="utf-8") != schema_text()):
+        raise ComponentManifestError(
+            "components/schema.json is stale; run scripts/component-manifests.py generate"
+        )
+    tracked = git_tracked_paths(root)
+    missing = unclassified_tracked_paths(manifest, tracked, root=root)
+    if missing:
+        preview = ", ".join(missing[:20])
+        if len(missing) > 20:
+            preview += f", ... ({len(missing) - 20} more)"
+        raise ComponentManifestError(f"unclassified tracked paths: {preview}")
+    untracked_owned = untracked_owned_paths(manifest, tracked, root=root)
+    if untracked_owned:
+        preview = ", ".join(untracked_owned[:20])
+        if len(untracked_owned) > 20:
+            preview += f", ... ({len(untracked_owned) - 20} more)"
+        raise ComponentManifestError(f"owned paths are not tracked by git: {preview}")
+    path_count = sum(len(component["paths"]) for component in manifest["components"])
+    return len(manifest["components"]), path_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "check"))
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "generate":
+            # Validate structure before writing. Full path and coverage checks run
+            # after the schema has been bootstrapped because it inventories itself.
+            load_component_manifest(MANIFEST_PATH, root=ROOT, check_paths=False)
+            write_generated_file(SCHEMA_PATH, schema_text(), root=ROOT)
+            component_count, path_count = check()
+        else:
+            component_count, path_count = check()
+    except (ComponentManifestError, OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(f"component-manifests: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"Component manifest {args.command} passed ({component_count} components, "
+        f"{path_count} exact paths)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/component-manifests.py
+++ b/scripts/component-manifests.py
@@ -56,6 +56,7 @@ def git_tracked_paths(root: Path) -> list[str]:
 def check(
     root: Path = ROOT, manifest_path: Path | None = None,
     schema_path: Path | None = None,
+    *, allow_extensible: bool = False,
 ) -> tuple[int, int]:
     manifest_path = manifest_path or root / "components" / "manifest.json"
     schema_path = schema_path or root / "components" / "schema.json"
@@ -66,7 +67,9 @@ def check(
             "components/schema.json is stale; run scripts/component-manifests.py generate"
         )
     tracked = git_tracked_paths(root)
-    missing = unclassified_tracked_paths(manifest, tracked, root=root)
+    missing = unclassified_tracked_paths(
+        manifest, tracked, root=root, allow_extensible=allow_extensible
+    )
     if missing:
         preview = ", ".join(missing[:20])
         if len(missing) > 20:
@@ -85,7 +88,17 @@ def check(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("command", choices=("generate", "check"))
+    parser.add_argument(
+        "--allow-extensible",
+        action="store_true",
+        help=(
+            "allow unowned tracked files below declared extensible roots; "
+            "use only when validating a personalized workspace"
+        ),
+    )
     args = parser.parse_args(argv)
+    if args.command != "check" and args.allow_extensible:
+        parser.error("--allow-extensible is only valid with check")
     try:
         if args.command == "generate":
             # Validate structure before writing. Full path and coverage checks run
@@ -94,7 +107,9 @@ def main(argv: list[str] | None = None) -> int:
             write_generated_file(SCHEMA_PATH, schema_text(), root=ROOT)
             component_count, path_count = check()
         else:
-            component_count, path_count = check()
+            component_count, path_count = check(
+                allow_extensible=args.allow_extensible
+            )
     except (ComponentManifestError, OSError, UnicodeError, json.JSONDecodeError) as exc:
         print(f"component-manifests: {exc}", file=sys.stderr)
         return 1

--- a/scripts/validate-all.sh
+++ b/scripts/validate-all.sh
@@ -18,6 +18,7 @@ done < <(find .claude/hooks scripts tests -name '*.sh' -print0)
 
 "$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_*.py'
 "$CONTEXTOS_PYTHON_CMD" scripts/integrations.py check
+"$CONTEXTOS_PYTHON_CMD" scripts/component-manifests.py check
 "$CONTEXTOS_PYTHON_CMD" scripts/runtime-manifests.py check
 
 "$CONTEXTOS_PYTHON_CMD" - <<'PY'

--- a/scripts/validate-all.sh
+++ b/scripts/validate-all.sh
@@ -6,6 +6,16 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 source "$ROOT/scripts/python-env.sh"
 
+COMPONENT_CHECK_ARGS=(check)
+if [[ ${1:-} == "--workspace" ]]; then
+  COMPONENT_CHECK_ARGS+=(--allow-extensible)
+  shift
+fi
+if (( $# )); then
+  echo "Usage: bash scripts/validate-all.sh [--workspace]" >&2
+  exit 2
+fi
+
 bash scripts/validate-skills.sh
 bash scripts/check-links.sh
 bash scripts/check-doc-reachability.sh
@@ -18,7 +28,7 @@ done < <(find .claude/hooks scripts tests -name '*.sh' -print0)
 
 "$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_*.py'
 "$CONTEXTOS_PYTHON_CMD" scripts/integrations.py check
-"$CONTEXTOS_PYTHON_CMD" scripts/component-manifests.py check
+"$CONTEXTOS_PYTHON_CMD" scripts/component-manifests.py "${COMPONENT_CHECK_ARGS[@]}"
 "$CONTEXTOS_PYTHON_CMD" scripts/runtime-manifests.py check
 
 "$CONTEXTOS_PYTHON_CMD" - <<'PY'

--- a/scripts/validate-all.sh
+++ b/scripts/validate-all.sh
@@ -7,8 +7,10 @@ cd "$ROOT"
 source "$ROOT/scripts/python-env.sh"
 
 COMPONENT_CHECK_ARGS=(check)
+VALIDATION_PROFILE=maintainer
 if [[ ${1:-} == "--workspace" ]]; then
   COMPONENT_CHECK_ARGS+=(--allow-extensible)
+  VALIDATION_PROFILE=workspace
   shift
 fi
 if (( $# )); then
@@ -26,7 +28,8 @@ while IFS= read -r -d '' script; do
   bash -n "$script"
 done < <(find .claude/hooks scripts tests -name '*.sh' -print0)
 
-"$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_*.py'
+CONTEXTOS_VALIDATION_PROFILE="$VALIDATION_PROFILE" \
+  "$CONTEXTOS_PYTHON_CMD" -m unittest discover -s tests -p 'test_*.py'
 "$CONTEXTOS_PYTHON_CMD" scripts/integrations.py check
 "$CONTEXTOS_PYTHON_CMD" scripts/component-manifests.py "${COMPONENT_CHECK_ARGS[@]}"
 "$CONTEXTOS_PYTHON_CMD" scripts/runtime-manifests.py check

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -59,6 +59,7 @@ cp "$ROOT/.claude/hooks/session-start.sh" "$SESSION_REPO/.claude/hooks/session-s
 cp "$ROOT/scripts/context-os-hook.py" "$ROOT/scripts/context-os-hook.sh" \
   "$ROOT/scripts/python-env.sh" "$SESSION_REPO/scripts/"
 cp -R "$ROOT/contextos" "$SESSION_REPO/contextos"
+cp -R "$ROOT/components" "$SESSION_REPO/"
 cp -R "$ROOT/runtimes" "$SESSION_REPO/"
 printf '# Test workspace\n' > "$SESSION_REPO/AGENTS.md"
 printf '# Test workspace\n' > "$SESSION_REPO/CLAUDE.md"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -84,6 +84,10 @@ for alias_name in "${aliases[@]}"; do
   grep -Fq "\$$alias_name" AGENTS.md || fail "AGENTS.md does not route to \$$alias_name"
 done
 
+portable_skill_roots=(.agents/skills)
+if [ -d projects/example-musician/workflow-examples ]; then
+  portable_skill_roots+=(projects/example-musician/workflow-examples)
+fi
 while IFS= read -r portable_skill; do
   frontmatter=$(awk '
     NR == 1 && $0 == "---" { inside = 1; next }
@@ -93,7 +97,7 @@ while IFS= read -r portable_skill; do
   if grep -Eq '^(requires|allowed-tools):' <<<"$frontmatter"; then
     fail "$portable_skill puts nonstandard dependencies or host permissions in portable frontmatter"
   fi
-done < <(find .agents/skills projects/example-musician/workflow-examples -name SKILL.md -type f | sort)
+done < <(find "${portable_skill_roots[@]}" -name SKILL.md -type f | sort)
 
 test ! -d projects/example-musician/skills || fail "example project still presents a nested skills directory as discoverable"
 
@@ -278,6 +282,10 @@ make_setup_fixture() {
   local destination="$1"
   mkdir -p "$destination"
   tar --exclude='.git' -cf - . | tar -xf - -C "$destination"
+  # Setup's prompt sequence must remain stable after a user removes the optional
+  # seed project from their own workspace. An empty fixture directory is enough
+  # to exercise the removal prompt without fabricating tracked source content.
+  mkdir -p "$destination/projects/example-musician"
   git -C "$destination" init -q
   git -C "$destination" config user.name "Portability Test"
   git -C "$destination" config user.email "portability@example.invalid"

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -239,6 +239,22 @@ class ComponentManifestTest(unittest.TestCase):
             with self.assertRaisesRegex(ComponentManifestError, "symlink"):
                 self.validate(symlink)
 
+        real_directory = self.root / "real-directory"
+        real_directory.mkdir()
+        (real_directory / "nested.txt").write_text("fixture\n", encoding="utf-8")
+        linked_directory = self.root / "linked-directory"
+        try:
+            linked_directory.symlink_to(real_directory, target_is_directory=True)
+        except OSError:
+            pass
+        else:
+            ancestor = fixture()
+            ancestor["components"][0]["paths"][0]["path"] = (
+                "linked-directory/nested.txt"
+            )
+            with self.assertRaisesRegex(ComponentManifestError, "symlink"):
+                self.validate(ancestor)
+
     def test_generated_write_rejects_symlink_leaf_and_ancestor(self) -> None:
         generated = self.root / "generated"
         generated.mkdir()

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -334,6 +334,25 @@ class ComponentManifestTest(unittest.TestCase):
                 fixture(), ["unowned.txt", "UNOWNED.txt"], root=self.root
             )
 
+    def test_workspace_extensions_reject_secrets_and_sibling_prefixes(self) -> None:
+        manifest = fixture()
+        with self.assertRaisesRegex(ComponentManifestError, "must not claim"):
+            unclassified_tracked_paths(
+                manifest,
+                ["extensions/.env.local"],
+                root=self.root,
+                allow_extensible=True,
+            )
+        self.assertEqual(
+            ["extensions-extra/user.md"],
+            unclassified_tracked_paths(
+                manifest,
+                ["extensions-extra/user.md"],
+                root=self.root,
+                allow_extensible=True,
+            ),
+        )
+
     def test_every_owned_path_must_come_from_the_tracked_source_set(self) -> None:
         tracked = ["feature.txt", "foundation.txt", "adapters/codex.txt"]
         self.assertEqual(
@@ -350,6 +369,11 @@ class ComponentManifestTest(unittest.TestCase):
             (ROOT / "components/manifest.json").read_text(encoding="utf-8")
         )
         owners = component_owners(manifest)
+        policies = {
+            path_entry["path"]: path_entry["policy"]
+            for component in manifest["components"]
+            for path_entry in component["paths"]
+        }
         self.assertEqual("agents-instructions", owners["AGENTS.md"])
         self.assertEqual("claude-adapter", owners["CLAUDE.md"])
         self.assertEqual(
@@ -358,6 +382,8 @@ class ComponentManifestTest(unittest.TestCase):
         )
         self.assertEqual("codex-adapter", owners[".codex/hooks.json"])
         self.assertEqual("hermes-adapter", owners["adapters/hermes/README.md"])
+        self.assertEqual("seed", policies["identity/who-i-am.md"])
+        self.assertEqual("seed", policies["state/current.md"])
 
         codex = component_closure(manifest, ["codex-adapter"])
         self.assertEqual(

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -90,7 +91,13 @@ class ComponentManifestTest(unittest.TestCase):
     def test_repository_manifest_validates(self) -> None:
         path = ROOT / "components/manifest.json"
         manifest = json.loads(path.read_text(encoding="utf-8"))
-        validated = validate_component_manifest(manifest, root=ROOT)
+        validated = validate_component_manifest(
+            manifest,
+            root=ROOT,
+            allow_missing_seed=(
+                os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace"
+            ),
+        )
         self.assertEqual(COMPONENT_MANIFEST_SCHEMA_VERSION, validated["schema_version"])
 
     def test_checked_in_schema_matches_authoritative_contract(self) -> None:
@@ -365,17 +372,20 @@ class ComponentManifestTest(unittest.TestCase):
                 fixture(), ["unowned.txt", "UNOWNED.txt"], root=self.root
             )
 
-    def test_workspace_extensions_allow_personal_files_but_not_sibling_prefixes(self) -> None:
+    def test_workspace_extensions_reject_secret_state_and_sibling_prefixes(self) -> None:
         manifest = fixture()
-        self.assertEqual(
-            [],
-            unclassified_tracked_paths(
-                manifest,
-                ["extensions/.env.local"],
-                root=self.root,
-                allow_extensible=True,
-            ),
-        )
+        for path in (
+            "extensions/.env.local",
+            "extensions/deck.key",
+            "extensions/debug.log",
+            "extensions/node_modules/package.js",
+        ):
+            with self.subTest(path=path), self.assertRaisesRegex(
+                ComponentManifestError, "must not claim"
+            ):
+                unclassified_tracked_paths(
+                    manifest, [path], root=self.root, allow_extensible=True
+                )
         with self.assertRaisesRegex(ComponentManifestError, "must not claim"):
             unclassified_tracked_paths(
                 manifest,
@@ -398,7 +408,7 @@ class ComponentManifestTest(unittest.TestCase):
             [],
             unclassified_tracked_paths(
                 manifest,
-                ["extensions/what next?.md", "extensions/deck.key", "workspace.yaml"],
+                ["extensions/what next?.md", "workspace.yaml"],
                 root=self.root,
                 allow_extensible=True,
             ),

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -185,12 +185,14 @@ class ComponentManifestTest(unittest.TestCase):
             ):
                 self.validate(manifest, check_paths=False)
 
-        managed_user_path = fixture()
-        managed_user_path["components"][0]["paths"][0] = {
-            "path": "extensions/user-file.md", "policy": "managed"
+        managed_extension = fixture()
+        managed_extension["components"][0]["paths"][0] = {
+            "path": "extensions/product-owned.md", "policy": "managed"
         }
-        with self.assertRaisesRegex(ComponentManifestError, "user-owned seed policy"):
-            self.validate(managed_user_path, check_paths=False)
+        self.assertIs(
+            managed_extension,
+            self.validate(managed_extension, check_paths=False),
+        )
 
     def test_unicode_nfc_casefold_duplicates_and_prefixes_are_rejected(self) -> None:
         path_duplicate = fixture()
@@ -375,6 +377,32 @@ class ComponentManifestTest(unittest.TestCase):
         self.assertIn(".agents/skills/start/agents/openai.yaml", paths)
         self.assertNotIn("adapters/hermes/README.md", paths)
         self.assertNotIn("tests/test_component_manifests.py", paths)
+
+        tracked_with_workspace_extensions = [
+            *owners,
+            ".agents/skills/standup/SKILL.md",
+            ".claude/commands/standup.md",
+            "sessions/2026-08-25.md",
+        ]
+        self.assertEqual(
+            [
+                ".agents/skills/standup/SKILL.md",
+                ".claude/commands/standup.md",
+                "sessions/2026-08-25.md",
+            ],
+            unclassified_tracked_paths(
+                manifest, tracked_with_workspace_extensions, root=ROOT
+            ),
+        )
+        self.assertEqual(
+            [],
+            unclassified_tracked_paths(
+                manifest,
+                tracked_with_workspace_extensions,
+                root=ROOT,
+                allow_extensible=True,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from contextos.component_schema import (
+    COMPONENT_MANIFEST_SCHEMA_VERSION,
+    ComponentManifestError,
+    component_closure,
+    component_owners,
+    resolved_component_paths,
+    untracked_owned_paths,
+    component_schema_document,
+    load_component_manifest,
+    unclassified_tracked_paths,
+    validate_component_manifest,
+    write_generated_file,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fixture() -> dict:
+    return {
+        "schema_version": 1,
+        "extensible_roots": ["extensions"],
+        "components": [
+            {
+                "id": "feature",
+                "description": "Optional feature.",
+                "depends_on": ["adapter", "foundation"],
+                "paths": [{"path": "feature.txt", "policy": "development"}],
+            },
+            {
+                "id": "foundation",
+                "description": "Base contract.",
+                "depends_on": [],
+                "paths": [{"path": "foundation.txt", "policy": "managed"}],
+            },
+            {
+                "id": "adapter",
+                "description": "Host adapter.",
+                "depends_on": ["foundation"],
+                "paths": [{"path": "adapters/codex.txt", "policy": "seed"}],
+            },
+        ],
+    }
+
+
+class ComponentManifestTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        (self.root / "adapters").mkdir()
+        (self.root / "extensions").mkdir()
+        for relative in ("feature.txt", "foundation.txt", "adapters/codex.txt"):
+            (self.root / relative).write_text("fixture\n", encoding="utf-8")
+
+    def validate(self, manifest: dict, *, check_paths: bool = True) -> dict:
+        return validate_component_manifest(
+            manifest, root=self.root, check_paths=check_paths
+        )
+
+    def test_valid_contract_and_deterministic_dependency_closure(self) -> None:
+        manifest = fixture()
+        self.assertIs(manifest, self.validate(manifest))
+        self.assertEqual(
+            ["foundation", "adapter", "feature"],
+            component_closure(manifest, ["feature"]),
+        )
+        self.assertEqual(
+            ["foundation", "adapter", "feature"],
+            component_closure(manifest, ["feature", "adapter"]),
+        )
+
+    def test_repository_manifest_validates(self) -> None:
+        path = ROOT / "components/manifest.json"
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        validated = validate_component_manifest(manifest, root=ROOT)
+        self.assertEqual(COMPONENT_MANIFEST_SCHEMA_VERSION, validated["schema_version"])
+
+    def test_checked_in_schema_matches_authoritative_contract(self) -> None:
+        path = ROOT / "components/schema.json"
+        self.assertEqual(
+            component_schema_document(),
+            json.loads(path.read_text(encoding="utf-8")),
+        )
+
+    def test_exact_keys_are_enforced_at_every_level(self) -> None:
+        mutations = []
+        top = fixture()
+        top["surprise"] = True
+        mutations.append((top, "unknown surprise"))
+        component = fixture()
+        component["components"][0]["surprise"] = True
+        mutations.append((component, "unknown surprise"))
+        path = fixture()
+        path["components"][0]["paths"][0]["surprise"] = True
+        mutations.append((path, "unknown surprise"))
+        missing = fixture()
+        del missing["components"][0]["description"]
+        mutations.append((missing, "missing description"))
+        for manifest, message in mutations:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ComponentManifestError, message
+            ):
+                self.validate(manifest, check_paths=False)
+
+    def test_invalid_json_is_reported_as_a_component_error(self) -> None:
+        path = self.root / "manifest.json"
+        path.write_text("{", encoding="utf-8")
+        with self.assertRaisesRegex(ComponentManifestError, "invalid JSON"):
+            load_component_manifest(path, root=self.root, check_paths=False)
+
+    def test_schema_types_arrays_text_and_policies_are_closed(self) -> None:
+        mutations = []
+        boolean_version = fixture()
+        boolean_version["schema_version"] = True
+        mutations.append((boolean_version, "integer 1"))
+        empty_components = fixture()
+        empty_components["components"] = []
+        mutations.append((empty_components, "non-empty array"))
+        empty_paths = fixture()
+        empty_paths["components"][0]["paths"] = []
+        mutations.append((empty_paths, "non-empty array"))
+        bad_policy = fixture()
+        bad_policy["components"][0]["paths"][0]["policy"] = "generated"
+        mutations.append((bad_policy, "unsupported value"))
+        bad_description = fixture()
+        bad_description["components"][0]["description"] = " padded "
+        mutations.append((bad_description, "surrounding whitespace"))
+        bad_id = fixture()
+        bad_id["components"][0]["id"] = "Feature Name"
+        mutations.append((bad_id, "lowercase kebab-case"))
+        for manifest, message in mutations:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ComponentManifestError, message
+            ):
+                self.validate(manifest, check_paths=False)
+
+    def test_paths_are_safe_canonical_posix_relative_paths(self) -> None:
+        unsafe = (
+            "../escape.txt", "/absolute.txt", "C:/absolute.txt", "a\\b.txt",
+            "a//b.txt", "a/./b.txt", "a/../b.txt", "trailing/", " padded.txt ",
+        )
+        for value in unsafe:
+            manifest = fixture()
+            manifest["components"][0]["paths"][0]["path"] = value
+            with self.subTest(value=value), self.assertRaises(ComponentManifestError):
+                self.validate(manifest, check_paths=False)
+
+    def test_local_ignored_and_user_owned_paths_cannot_be_managed(self) -> None:
+        for value in (
+            ".context-os/runtime.json", ".git/hooks/pre-commit",
+            ".claude/settings.local.json", "REPO_MAP.md", "cache/__pycache__/x",
+            "cache/result.pyc", "debug.log", "private.pem", ".VSCODE/settings.json",
+            ".Context-OS/runtime.json", ".DS_Store", "secrets/.ENV.production",
+            "node_modules/package/index.js", "cache/module.pyd",
+        ):
+            manifest = fixture()
+            manifest["components"][0]["paths"][0]["path"] = value
+            with self.subTest(value=value), self.assertRaisesRegex(
+                ComponentManifestError, "must not claim"
+            ):
+                self.validate(manifest, check_paths=False)
+
+        for value in (".Context-OS", "node_modules", ".VSCODE"):
+            manifest = fixture()
+            manifest["extensible_roots"] = [value]
+            with self.subTest(value=value), self.assertRaisesRegex(
+                ComponentManifestError, "must not claim"
+            ):
+                self.validate(manifest, check_paths=False)
+
+        for value in ("folder/name.", "folder/CON", "folder/file:stream"):
+            manifest = fixture()
+            manifest["components"][0]["paths"][0]["path"] = value
+            with self.subTest(value=value), self.assertRaisesRegex(
+                ComponentManifestError, "Windows-aliased or illegal"
+            ):
+                self.validate(manifest, check_paths=False)
+
+        managed_user_path = fixture()
+        managed_user_path["components"][0]["paths"][0] = {
+            "path": "extensions/user-file.md", "policy": "managed"
+        }
+        with self.assertRaisesRegex(ComponentManifestError, "user-owned seed policy"):
+            self.validate(managed_user_path, check_paths=False)
+
+    def test_unicode_nfc_casefold_duplicates_and_prefixes_are_rejected(self) -> None:
+        path_duplicate = fixture()
+        path_duplicate["components"][0]["paths"][0]["path"] = "Readme.md"
+        path_duplicate["components"][1]["paths"][0]["path"] = "README.md"
+        with self.assertRaisesRegex(ComponentManifestError, "Unicode NFC case-folding"):
+            self.validate(path_duplicate, check_paths=False)
+
+        root_duplicate = fixture()
+        root_duplicate["extensible_roots"] = ["Extensions", "extensions"]
+        with self.assertRaisesRegex(ComponentManifestError, "Unicode NFC case-folding"):
+            self.validate(root_duplicate, check_paths=False)
+
+        path_prefix = fixture()
+        path_prefix["components"][0]["paths"][0]["path"] = "owned"
+        path_prefix["components"][1]["paths"][0]["path"] = "owned/child"
+        with self.assertRaisesRegex(ComponentManifestError, "prefix conflict"):
+            self.validate(path_prefix, check_paths=False)
+
+        root_prefix = fixture()
+        root_prefix["extensible_roots"] = ["extensions", "extensions/nested"]
+        with self.assertRaisesRegex(ComponentManifestError, "prefix conflict"):
+            self.validate(root_prefix, check_paths=False)
+
+    def test_paths_must_be_existing_regular_non_symlink_files(self) -> None:
+        missing = fixture()
+        missing["components"][0]["paths"][0]["path"] = "missing.txt"
+        with self.assertRaisesRegex(ComponentManifestError, "does not exist"):
+            self.validate(missing)
+
+        directory = fixture()
+        directory["components"][0]["paths"][0] = {
+            "path": "extensions", "policy": "seed"
+        }
+        with self.assertRaisesRegex(ComponentManifestError, "regular file"):
+            self.validate(directory)
+
+        link = self.root / "linked.txt"
+        try:
+            link.symlink_to(self.root / "feature.txt")
+        except OSError:
+            pass
+        else:
+            symlink = fixture()
+            symlink["components"][0]["paths"][0]["path"] = "linked.txt"
+            with self.assertRaisesRegex(ComponentManifestError, "symlink"):
+                self.validate(symlink)
+
+    def test_generated_write_rejects_symlink_leaf_and_ancestor(self) -> None:
+        generated = self.root / "generated"
+        generated.mkdir()
+        outside = self.root / "outside.txt"
+        outside.write_text("unchanged\n", encoding="utf-8")
+        leaf = generated / "schema.json"
+        try:
+            leaf.symlink_to(outside)
+        except OSError:
+            self.skipTest("symlink creation is not available on this platform")
+        with self.assertRaisesRegex(ComponentManifestError, "must not be a symlink"):
+            write_generated_file(leaf, "changed\n", root=self.root)
+        self.assertEqual("unchanged\n", outside.read_text(encoding="utf-8"))
+
+        leaf.unlink()
+        generated.rmdir()
+        generated.symlink_to(self.root, target_is_directory=True)
+        with self.assertRaisesRegex(ComponentManifestError, "traverses a symlink"):
+            write_generated_file(
+                generated / "replacement.json", "changed\n", root=self.root
+            )
+        self.assertFalse((self.root / "replacement.json").exists())
+
+    def test_dependency_unknown_self_duplicate_and_cycles_are_rejected(self) -> None:
+        unknown = fixture()
+        unknown["components"][0]["depends_on"] = ["missing"]
+        self_ref = fixture()
+        self_ref["components"][0]["depends_on"] = ["FEATURE"]
+        duplicate = fixture()
+        duplicate["components"][0]["depends_on"] = ["adapter", "ADAPTER"]
+        cycle = fixture()
+        cycle["components"][1]["depends_on"] = ["feature"]
+        for manifest, message in (
+            (unknown, "unknown component"),
+            (self_ref, "itself"),
+            (duplicate, "Unicode NFC case-folding"),
+            (cycle, "dependency cycle"),
+        ):
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ComponentManifestError, message
+            ):
+                self.validate(manifest, check_paths=False)
+
+    def test_closure_rejects_unknown_and_duplicate_requests(self) -> None:
+        with self.assertRaisesRegex(ComponentManifestError, "unknown components"):
+            component_closure(fixture(), ["missing"])
+        with self.assertRaisesRegex(ComponentManifestError, "Unicode NFC case-folding"):
+            component_closure(fixture(), ["feature", "FEATURE"])
+
+    def test_tracked_coverage_requires_exact_classification_with_extensible_escape(self) -> None:
+        manifest = fixture()
+        tracked = [
+            "feature.txt", "foundation.txt", "adapters/codex.txt",
+            "extensions/new-plugin.txt", "unowned.txt",
+        ]
+        self.assertEqual(
+            ["extensions/new-plugin.txt", "unowned.txt"],
+            unclassified_tracked_paths(manifest, tracked, root=self.root),
+        )
+        tracked.remove("unowned.txt")
+        self.assertEqual(
+            ["extensions/new-plugin.txt"],
+            unclassified_tracked_paths(manifest, tracked, root=self.root),
+        )
+        self.assertEqual(
+            [],
+            unclassified_tracked_paths(
+                manifest, tracked, root=self.root, allow_extensible=True
+            ),
+        )
+
+    def test_tracked_coverage_rejects_portable_path_collisions(self) -> None:
+        with self.assertRaisesRegex(ComponentManifestError, "portable path collision"):
+            unclassified_tracked_paths(
+                fixture(), ["unowned.txt", "UNOWNED.txt"], root=self.root
+            )
+
+    def test_every_owned_path_must_come_from_the_tracked_source_set(self) -> None:
+        tracked = ["feature.txt", "foundation.txt", "adapters/codex.txt"]
+        self.assertEqual(
+            [], untracked_owned_paths(fixture(), tracked, root=self.root)
+        )
+        tracked.remove("feature.txt")
+        self.assertEqual(
+            ["feature.txt"],
+            untracked_owned_paths(fixture(), tracked, root=self.root),
+        )
+
+    def test_repository_component_boundaries_and_static_resolution(self) -> None:
+        manifest = json.loads(
+            (ROOT / "components/manifest.json").read_text(encoding="utf-8")
+        )
+        owners = component_owners(manifest)
+        self.assertEqual("agents-instructions", owners["AGENTS.md"])
+        self.assertEqual("claude-adapter", owners["CLAUDE.md"])
+        self.assertEqual(
+            "openai-skill-metadata",
+            owners[".agents/skills/start/agents/openai.yaml"],
+        )
+        self.assertEqual("codex-adapter", owners[".codex/hooks.json"])
+        self.assertEqual("hermes-adapter", owners["adapters/hermes/README.md"])
+
+        codex = component_closure(manifest, ["codex-adapter"])
+        self.assertEqual(
+            [
+                "core", "portable-skills", "agents-instructions",
+                "openai-skill-metadata", "codex-adapter",
+            ],
+            codex,
+        )
+        combined = resolved_component_paths(
+            manifest, ["claude-adapter", "codex-adapter"]
+        )
+        paths = [item["path"] for item in combined]
+        self.assertEqual(len(paths), len(set(paths)))
+        self.assertIn(".claude/settings.json", paths)
+        self.assertIn(".codex/hooks.json", paths)
+        self.assertIn(".agents/skills/start/agents/openai.yaml", paths)
+        self.assertNotIn("adapters/hermes/README.md", paths)
+        self.assertNotIn("tests/test_component_manifests.py", paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import copy
+import importlib.util
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from contextos.component_schema import (
     COMPONENT_MANIFEST_SCHEMA_VERSION,
@@ -27,6 +29,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def fixture() -> dict:
     return {
         "schema_version": 1,
+        "extensible_paths": ["workspace.yaml"],
         "extensible_roots": ["extensions"],
         "components": [
             {
@@ -61,9 +64,15 @@ class ComponentManifestTest(unittest.TestCase):
         for relative in ("feature.txt", "foundation.txt", "adapters/codex.txt"):
             (self.root / relative).write_text("fixture\n", encoding="utf-8")
 
-    def validate(self, manifest: dict, *, check_paths: bool = True) -> dict:
+    def validate(
+        self, manifest: dict, *, check_paths: bool = True,
+        allow_missing_seed: bool = False,
+    ) -> dict:
         return validate_component_manifest(
-            manifest, root=self.root, check_paths=check_paths
+            manifest,
+            root=self.root,
+            check_paths=check_paths,
+            allow_missing_seed=allow_missing_seed,
         )
 
     def test_valid_contract_and_deterministic_dependency_closure(self) -> None:
@@ -177,6 +186,13 @@ class ComponentManifestTest(unittest.TestCase):
             ):
                 self.validate(manifest, check_paths=False)
 
+            manifest = fixture()
+            manifest["extensible_paths"] = [value]
+            with self.subTest(value=f"exact:{value}"), self.assertRaisesRegex(
+                ComponentManifestError, "must not claim"
+            ):
+                self.validate(manifest, check_paths=False)
+
         for value in ("folder/name.", "folder/CON", "folder/file:stream"):
             manifest = fixture()
             manifest["components"][0]["paths"][0]["path"] = value
@@ -216,6 +232,21 @@ class ComponentManifestTest(unittest.TestCase):
         root_prefix["extensible_roots"] = ["extensions", "extensions/nested"]
         with self.assertRaisesRegex(ComponentManifestError, "prefix conflict"):
             self.validate(root_prefix, check_paths=False)
+
+        exact_duplicate = fixture()
+        exact_duplicate["extensible_paths"] = ["Workspace.yaml", "workspace.yaml"]
+        with self.assertRaisesRegex(ComponentManifestError, "Unicode NFC case-folding"):
+            self.validate(exact_duplicate, check_paths=False)
+
+        exact_prefix = fixture()
+        exact_prefix["extensible_paths"] = ["workspace", "workspace/nested"]
+        with self.assertRaisesRegex(ComponentManifestError, "prefix conflict"):
+            self.validate(exact_prefix, check_paths=False)
+
+        owned_extension = fixture()
+        owned_extension["extensible_paths"] = ["feature.txt"]
+        with self.assertRaisesRegex(ComponentManifestError, "component-owned"):
+            self.validate(owned_extension, check_paths=False)
 
     def test_paths_must_be_existing_regular_non_symlink_files(self) -> None:
         missing = fixture()
@@ -334,14 +365,22 @@ class ComponentManifestTest(unittest.TestCase):
                 fixture(), ["unowned.txt", "UNOWNED.txt"], root=self.root
             )
 
-    def test_workspace_extensions_reject_secrets_and_sibling_prefixes(self) -> None:
+    def test_workspace_extensions_allow_personal_files_but_not_sibling_prefixes(self) -> None:
         manifest = fixture()
-        with self.assertRaisesRegex(ComponentManifestError, "must not claim"):
+        self.assertEqual(
+            [],
             unclassified_tracked_paths(
                 manifest,
                 ["extensions/.env.local"],
                 root=self.root,
                 allow_extensible=True,
+            ),
+        )
+        with self.assertRaisesRegex(ComponentManifestError, "must not claim"):
+            unclassified_tracked_paths(
+                manifest,
+                ["extensions/.env.local"],
+                root=self.root,
             )
         self.assertEqual(
             ["extensions-extra/user.md"],
@@ -352,6 +391,98 @@ class ComponentManifestTest(unittest.TestCase):
                 allow_extensible=True,
             ),
         )
+
+    def test_workspace_extensions_allow_personal_names_and_exact_config_paths(self) -> None:
+        manifest = fixture()
+        self.assertEqual(
+            [],
+            unclassified_tracked_paths(
+                manifest,
+                ["extensions/what next?.md", "extensions/deck.key", "workspace.yaml"],
+                root=self.root,
+                allow_extensible=True,
+            ),
+        )
+        with self.assertRaisesRegex(ComponentManifestError, "Windows-aliased"):
+            unclassified_tracked_paths(
+                manifest, ["extensions/what next?.md"], root=self.root
+            )
+
+    def test_workspace_validation_allows_missing_seed_but_not_managed_files(self) -> None:
+        manifest = fixture()
+        (self.root / "adapters/codex.txt").unlink()
+        self.validate(manifest, allow_missing_seed=True)
+        self.assertEqual(
+            [],
+            untracked_owned_paths(
+                manifest,
+                ["feature.txt", "foundation.txt"],
+                root=self.root,
+                allow_missing_seed=True,
+            ),
+        )
+        (self.root / "foundation.txt").unlink()
+        with self.assertRaisesRegex(ComponentManifestError, "foundation.txt"):
+            self.validate(manifest, allow_missing_seed=True)
+
+    def test_git_source_set_deduplicates_unmerged_index_stages(self) -> None:
+        script = ROOT / "scripts/component-manifests.py"
+        spec = importlib.util.spec_from_file_location("component_manifests_script", script)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        with mock.patch.object(module.subprocess, "run") as run:
+            run.return_value = mock.Mock(
+                stdout=b"feature.txt\0feature.txt\0foundation.txt\0"
+            )
+            self.assertEqual(
+                ["feature.txt", "foundation.txt"],
+                module.git_tracked_paths(self.root),
+            )
+
+    def test_workspace_check_composes_seed_and_extension_exceptions(self) -> None:
+        script = ROOT / "scripts/component-manifests.py"
+        spec = importlib.util.spec_from_file_location("component_manifests_check", script)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        components = self.root / "components"
+        components.mkdir()
+        manifest_path = components / "manifest.json"
+        schema_path = components / "schema.json"
+        manifest_path.write_text(json.dumps(fixture()), encoding="utf-8")
+        schema_path.write_text(module.schema_text(), encoding="utf-8")
+        (self.root / "adapters/codex.txt").unlink()
+        tracked = [
+            "feature.txt",
+            "foundation.txt",
+            "extensions/what next?.md",
+            "workspace.yaml",
+        ]
+        with mock.patch.object(module, "git_tracked_paths", return_value=tracked):
+            self.assertEqual(
+                (3, 3),
+                module.check(
+                    self.root,
+                    manifest_path,
+                    schema_path,
+                    allow_extensible=True,
+                ),
+            )
+            with self.assertRaisesRegex(ComponentManifestError, "adapters/codex.txt"):
+                module.check(self.root, manifest_path, schema_path)
+
+            (self.root / "foundation.txt").unlink()
+            with self.assertRaisesRegex(ComponentManifestError, "foundation.txt"):
+                module.check(
+                    self.root,
+                    manifest_path,
+                    schema_path,
+                    allow_extensible=True,
+                )
 
     def test_every_owned_path_must_come_from_the_tracked_source_set(self) -> None:
         tracked = ["feature.txt", "foundation.txt", "adapters/codex.txt"]

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -58,7 +58,9 @@ class KernelTest(unittest.TestCase):
         for runtime in ("claude", "codex", "hermes"):
             source = ROOT / "runtimes" / f"{runtime}.json"
             (self.root / "runtimes" / f"{runtime}.json").write_bytes(source.read_bytes())
-        for directory in (".agents", ".claude", "adapters", "docs", "tests"):
+        for directory in (
+            ".agents", ".claude", "adapters", "components", "docs", "tests"
+        ):
             shutil.copytree(ROOT / directory, self.root / directory)
 
     def tearDown(self) -> None:

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import subprocess
 import sys
@@ -280,10 +281,14 @@ class DocumentationPositioningTests(unittest.TestCase):
 
     def test_command_index_covers_shipped_commands_and_portable_skills(self) -> None:
         index = self.text("docs/commands-and-skills.md")
+        workspace = os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace"
         shipped_commands = {path.stem for path in (ROOT / ".claude/commands").glob("*.md")}
         indexed_commands = set(re.findall(r"`/([a-z0-9]+(?:-[a-z0-9]+)*)`", index))
-        self.assertEqual(shipped_commands, indexed_commands)
-        for command in shipped_commands:
+        if workspace:
+            self.assertLessEqual(indexed_commands, shipped_commands)
+        else:
+            self.assertEqual(shipped_commands, indexed_commands)
+        for command in indexed_commands:
             rows = [line for line in index.splitlines() if line.startswith("|") and f"`/{command}`" in line]
             self.assertEqual(1, len(rows), f"/{command} must have exactly one indexed table row")
             cells = [cell.strip() for cell in rows[0].strip("|").split("|")]
@@ -291,11 +296,17 @@ class DocumentationPositioningTests(unittest.TestCase):
 
         shipped_skills = {path.parent.name for path in (ROOT / ".agents/skills").glob("*/SKILL.md")}
         indexed_skills = set(re.findall(r"`\$([a-z0-9]+(?:-[a-z0-9]+)*)`", index))
-        self.assertEqual(shipped_skills, indexed_skills)
+        if workspace:
+            self.assertLessEqual(indexed_skills, shipped_skills)
+        else:
+            self.assertEqual(shipped_skills, indexed_skills)
 
         command_table = self.text("CLAUDE.md").split("## Slash Commands", 1)[1].split("Add more commands", 1)[0]
         claude_commands = set(re.findall(r"^\| `/([a-z0-9]+(?:-[a-z0-9]+)*)`", command_table, re.MULTILINE))
-        self.assertEqual(shipped_commands, claude_commands)
+        if workspace:
+            self.assertLessEqual(claude_commands, shipped_commands)
+        else:
+            self.assertEqual(shipped_commands, claude_commands)
         self.assertIn("does not activate", index)
 
     def test_maintenance_separates_portable_and_host_local_state(self) -> None:

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -162,6 +162,49 @@ class RuntimeManifestTest(unittest.TestCase):
             surface["instruction_sources"] = [
                 {"scope": "workspace", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
             ]
+            (root / "components").mkdir()
+            component_manifest = {
+                "schema_version": 1,
+                "extensible_roots": [],
+                "components": [
+                    {
+                        "id": "core", "description": "Core fixture.",
+                        "depends_on": [],
+                        "paths": [
+                            {"path": "docs/onboarding.md", "policy": "managed"},
+                            {"path": "tests/conformance.py", "policy": "development"},
+                        ],
+                    },
+                    {
+                        "id": "portable-skills", "description": "Skill fixture.",
+                        "depends_on": ["core"],
+                        "paths": [{"path": "fixture/skill", "policy": "managed"}],
+                    },
+                    {
+                        "id": "agents-instructions", "description": "Instruction fixture.",
+                        "depends_on": ["core", "portable-skills"],
+                        "paths": [{"path": "fixture/agents", "policy": "managed"}],
+                    },
+                    {
+                        "id": "openai-skill-metadata", "description": "Metadata fixture.",
+                        "depends_on": ["portable-skills"],
+                        "paths": [{"path": "fixture/openai", "policy": "managed"}],
+                    },
+                    {
+                        "id": "codex-adapter", "description": "Adapter fixture.",
+                        "depends_on": [
+                            "core", "portable-skills", "agents-instructions",
+                            "openai-skill-metadata",
+                        ],
+                        "paths": [
+                            {"path": "runtimes/future-agent.json", "policy": "managed"}
+                        ],
+                    },
+                ],
+            }
+            (root / "components/manifest.json").write_text(
+                json.dumps(component_manifest), encoding="utf-8"
+            )
             surface["skill_sources"] = [
                 {"scope": "workspace", "role": "skills", "path": "skills", "precedence": 100}
             ]
@@ -172,6 +215,41 @@ class RuntimeManifestTest(unittest.TestCase):
             self.assertTrue(target.is_file())
             self.assertEqual("future-agent", installed["runtime"])
             self.assertEqual({"systemMessage": "notice"}, runtime_hook_payload(manifest, ["notice"]))
+
+            unknown_component = copy.deepcopy(manifest)
+            unknown_component["components"].append("missing-component")
+            (root / "runtimes/future-agent.json").write_text(
+                json.dumps(unknown_component), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ContextOSError, "unknown components"):
+                runtime_manifest(root, "future-agent")
+
+            (root / "runtimes/future-agent.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+            unowned_reference = copy.deepcopy(component_manifest)
+            unowned_reference["components"][0]["paths"].remove(
+                {"path": "docs/onboarding.md", "policy": "managed"}
+            )
+            (root / "components/manifest.json").write_text(
+                json.dumps(unowned_reference), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ContextOSError, "references unowned path"):
+                runtime_manifest(root, "future-agent")
+
+            unselected_owner = copy.deepcopy(component_manifest)
+            core_paths = unselected_owner["components"][0]["paths"]
+            core_paths.remove({"path": "docs/onboarding.md", "policy": "managed"})
+            unselected_owner["components"].append({
+                "id": "docs-extra", "description": "Unselected docs fixture.",
+                "depends_on": ["core"],
+                "paths": [{"path": "docs/onboarding.md", "policy": "managed"}],
+            })
+            (root / "components/manifest.json").write_text(
+                json.dumps(unselected_owner), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ContextOSError, "unselected components"):
+                runtime_manifest(root, "future-agent")
 
     def test_openclaw_spike_supports_precedence_and_multiple_surfaces(self) -> None:
         manifest = load("hermes")

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -165,6 +165,7 @@ class RuntimeManifestTest(unittest.TestCase):
             (root / "components").mkdir()
             component_manifest = {
                 "schema_version": 1,
+                "extensible_paths": [],
                 "extensible_roots": [],
                 "components": [
                     {


### PR DESCRIPTION
## What's in this PR

Implements #62 as the second foundation slice of #60.

- adds an authoritative eight-component inventory with exact managed, seed, and development ownership for 167 tracked paths
- validates dependencies, deterministic closure, bidirectional Git coverage, symlinks, traversal, Unicode/case collisions, Windows aliases, reserved local state, and generated-schema drift
- separates portable skill bodies from OpenAI discovery metadata
- cross-validates runtime instructions, skills, onboarding docs, descriptors, and conformance evidence against selected component closures
- documents the read-only inventory boundary and the remaining gates before clean materialization

This PR is intentionally stacked on #75 (base: feat/runtime-registry-v2). It does not copy, delete, upgrade, or slim workspace files.

## Review and verification

Two review rounds completed with Claude Opus, Hermes free-model routing (stealth/ox-alpha first; openrouter/free fallback after a 429), and two independent GPT-5.6-sol lenses. All final reviewers reported no blockers.

- 215 Python tests passed; 12 skips (11 opt-in runtime launches plus one Windows symlink-privilege skip)
- 32 portability tests passed
- 12 hook tests passed
- integration catalog, component inventory, runtime registry, links, generated artifacts, and whitespace checks passed
- component inventory: 8 components, 167 exact paths
- Bash aggregate runner reaches the known Windows/WSL linked-worktree Git-path limitation; native Windows Python and the independent Bash portability/hook suites pass

## Checklist

### Skills & commands
- [x] No new skills or commands are introduced
- [x] Portable workflows remain provider-neutral

### Repo hygiene
- [x] No sensitive data committed
- [x] CHANGELOG.md updated
- [ ] CI passes

Closes #62