### PR TITLE
Add Pandoc to integration catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
 - `CONTRIBUTING.md` — prerequisites, the validator as the one gate, which files are generated, how to add a catalog entry, skill/adapter structure, and the enforced size limits.
 - `SECURITY.md` — private reporting path, what is in and out of scope, and the design boundaries most likely to be misread (validation is not a publication guarantee; `verified` is a metadata claim; nothing here sandboxes an agent).

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -22,7 +22,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Manage Substack drafts or publish Notes | [Substack MCP](../references/integrations.md#substack-mcp) | Session credentials, sensitive analytics, and immediate public Notes |
 | Read or update a mounted Markdown vault | [Tolaria MCP](../references/integrations.md#tolaria-mcp) | Sensitive vault reads and full-note overwrite |
 | Convert an explicitly selected document or URI to Markdown | [MarkItDown MCP](../references/integrations.md#markitdown-mcp) | Local-file and network reads through an unauthenticated server process |
-| Export reviewed Markdown to DOCX, PDF, EPUB, or HTML | [Pandoc](../references/integrations.md#pandoc) | Local writes, overwrite confirmation, and high-risk flags |
+| Export reviewed Markdown to DOCX, PDF, EPUB, or HTML | [Pandoc](../references/integrations.md#pandoc) | Sensitive local or network reads, output overwrite, and PDF-engine execution |
 
 The obsolete checked-in `gws mcp` configuration was removed. The current Google Workspace path uses the reviewed CLI setup in [`references/google-workspace-cli-setup.md`](../references/google-workspace-cli-setup.md); it is still opt-in and is not pre-approved by the command adapters.
 

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -22,6 +22,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Manage Substack drafts or publish Notes | [Substack MCP](../references/integrations.md#substack-mcp) | Session credentials, sensitive analytics, and immediate public Notes |
 | Read or update a mounted Markdown vault | [Tolaria MCP](../references/integrations.md#tolaria-mcp) | Sensitive vault reads and full-note overwrite |
 | Convert an explicitly selected document or URI to Markdown | [MarkItDown MCP](../references/integrations.md#markitdown-mcp) | Local-file and network reads through an unauthenticated server process |
+| Export reviewed Markdown to DOCX, PDF, EPUB, or HTML | [Pandoc](../references/integrations.md#pandoc) | Local writes, overwrite confirmation, and high-risk flags |
 
 The obsolete checked-in `gws mcp` configuration was removed. The current Google Workspace path uses the reviewed CLI setup in [`references/google-workspace-cli-setup.md`](../references/google-workspace-cli-setup.md); it is still opt-in and is not pre-approved by the command adapters.
 

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -616,6 +616,75 @@
         "instructions": "Remove the MarkItDown MCP entry from the client and uninstall markitdown-mcp or remove its container image; preserve every source file and converted output unless separately requested.",
         "removes_user_data": false
       }
-    }
+    },
+    {
+  "id": "pandoc",
+  "name": "Pandoc",
+  "summary": "A local document-conversion CLI for turning reviewed Markdown into DOCX, PDF, EPUB, or HTML while keeping Markdown canonical in Git.",
+  "source_url": "https://github.com/jgm/pandoc",
+  "kind": "connector",
+  "supported_agents": ["generic"],
+  "installation": {
+    "automatic": false,
+    "scope": "project_or_user",
+    "prerequisites": ["Pandoc CLI"]
+  },
+  "data_boundary": {
+    "credentials": [],
+    "reads": [
+      "Explicitly selected local input Markdown files and explicitly referenced local assets"
+    ],
+    "writes": [
+      "Explicitly selected local output files, including overwrite of an existing output path when approved"
+    ]
+  },
+  "capabilities": {
+    "read": true,
+    "sensitive_read": false,
+    "write": true,
+    "remote_write": false,
+    "publish": false,
+    "overwrite": true,
+    "delete": false,
+    "arbitrary_execution": true,
+    "oauth": false,
+    "destructive": true,
+    "details": [
+      "Default bounded usage converts one exact input path to one exact output path",
+      "Require explicit confirmation before overwrite of an existing output file",
+      "Disallow filters, custom writers, include flags, and remote resource fetching in the default recipe",
+      "Pandoc's full flag surface can enable arbitrary execution via user-supplied filters or custom writers"
+    ]
+  },
+  "confirmation": {
+    "required_for": [
+      "external_install",
+      "write",
+      "overwrite",
+      "arbitrary_execution",
+      "destructive"
+    ],
+    "notes": "Confirm exact input and output paths before each run; separately confirm overwrite and any filter, custom writer, include, or remote-fetch option."
+  },
+  "risk_tags": [
+    "external-install",
+    "local-files",
+    "overwrite-capable",
+    "arbitrary-execution",
+    "destructive-capable"
+  ],
+  "maturity": "verified",
+  "last_verified": "2026-08-25",
+  "evidence": [
+    "https://github.com/jgm/pandoc",
+    "https://github.com/jgm/pandoc/releases/tag/3.10.2",
+    "https://pandoc.org/MANUAL.html"
+  ],
+  "health_check": "Run pandoc --version, then convert one known local Markdown file to a local output path without filters/includes and verify output is created at the expected path.",
+  "uninstall": {
+    "instructions": "Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them.",
+    "removes_user_data": false
+  }
+}
   ]
 }

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -618,73 +618,48 @@
       }
     },
     {
-  "id": "pandoc",
-  "name": "Pandoc",
-  "summary": "A local document-conversion CLI for turning reviewed Markdown into DOCX, PDF, EPUB, or HTML while keeping Markdown canonical in Git.",
-  "source_url": "https://github.com/jgm/pandoc",
-  "kind": "connector",
-  "supported_agents": ["generic"],
-  "installation": {
-    "automatic": false,
-    "scope": "project_or_user",
-    "prerequisites": ["Pandoc CLI"]
-  },
-  "data_boundary": {
-    "credentials": [],
-    "reads": [
-      "Explicitly selected local input Markdown files and explicitly referenced local assets"
-    ],
-    "writes": [
-      "Explicitly selected local output files, including overwrite of an existing output path when approved"
-    ]
-  },
-  "capabilities": {
-    "read": true,
-    "sensitive_read": false,
-    "write": true,
-    "remote_write": false,
-    "publish": false,
-    "overwrite": true,
-    "delete": false,
-    "arbitrary_execution": true,
-    "oauth": false,
-    "destructive": true,
-    "details": [
-      "Default bounded usage converts one exact input path to one exact output path",
-      "Require explicit confirmation before overwrite of an existing output file",
-      "Disallow filters, custom writers, include flags, and remote resource fetching in the default recipe",
-      "Pandoc's full flag surface can enable arbitrary execution via user-supplied filters or custom writers"
-    ]
-  },
-  "confirmation": {
-    "required_for": [
-      "external_install",
-      "write",
-      "overwrite",
-      "arbitrary_execution",
-      "destructive"
-    ],
-    "notes": "Confirm exact input and output paths before each run; separately confirm overwrite and any filter, custom writer, include, or remote-fetch option."
-  },
-  "risk_tags": [
-    "external-install",
-    "local-files",
-    "overwrite-capable",
-    "arbitrary-execution",
-    "destructive-capable"
-  ],
-  "maturity": "verified",
-  "last_verified": "2026-08-25",
-  "evidence": [
-    "https://github.com/jgm/pandoc",
-    "https://github.com/jgm/pandoc/releases/tag/3.10.2",
-    "https://pandoc.org/MANUAL.html"
-  ],
-  "health_check": "Run pandoc --version, then convert one known local Markdown file to a local output path without filters/includes and verify output is created at the expected path.",
-  "uninstall": {
-    "instructions": "Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them.",
-    "removes_user_data": false
-  }
-}
+      "id": "pandoc",
+      "name": "Pandoc",
+      "summary": "A document-conversion CLI for turning reviewed Markdown into DOCX, PDF, EPUB, or HTML while keeping Markdown canonical in Git.",
+      "source_url": "https://github.com/jgm/pandoc",
+      "kind": "connector",
+      "supported_agents": ["generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["Pandoc CLI", "A separately installed and reviewed PDF engine when producing PDF output"]
+      },
+      "data_boundary": {
+        "credentials": [],
+        "reads": ["Explicitly selected local input files and assets in the bounded profile", "Absolute HTTP or HTTPS inputs, URL-valued resources, and local or remote iframe sources when those surfaces are used", "Additional files and resources reachable by approved include directives, filters, custom writers, or PDF engines and their options"],
+        "writes": ["Explicitly selected local output files, including overwrite of an existing output path when approved", "Temporary files used during PDF production and any additional filesystem side effects introduced by approved filters, custom writers, or PDF engines"]
+      },
+      "capabilities": {
+        "read": true,
+        "sensitive_read": true,
+        "write": true,
+        "remote_write": false,
+        "publish": false,
+        "overwrite": true,
+        "delete": false,
+        "arbitrary_execution": true,
+        "oauth": false,
+        "destructive": true,
+        "details": ["The bounded non-PDF profile uses --sandbox with one exact local input and a new exact local output path; reject remote inputs and resources, include directives, filters, custom writers, and overwrite", "Pandoc accepts absolute HTTP or HTTPS inputs, and its HTML reader can fetch local or remote iframe sources; treat those as sensitive network reads outside the bounded profile", "--sandbox limits reader and writer IO to files named on the command line, but does not constrain filters or PDF production and can prevent formats such as DOCX from loading filesystem data files", "PDF output invokes a separately installed engine; audit and confirm the exact --pdf-engine and every --pdf-engine-opt because the engine can widen filesystem, network, and execution risk", "Pandoc's full flag surface can enable arbitrary execution and additional side effects through filters, custom writers, and PDF engines"]
+      },
+      "confirmation": {
+        "required_for": ["external_install", "read_sensitive", "write", "overwrite", "arbitrary_execution", "destructive"],
+        "notes": "Confirm exact input and output paths before each run. Separately confirm any remote input or resource, include directive, filter, custom writer, overwrite, or PDF production; for PDF, name the reviewed engine and exact engine options."
+      },
+      "risk_tags": ["external-install", "local-data", "sensitive-read", "network-capable", "overwrite-capable", "arbitrary-execution", "destructive-capable", "open-world"],
+      "maturity": "verified",
+      "last_verified": "2026-08-25",
+      "evidence": ["https://github.com/jgm/pandoc", "https://github.com/jgm/pandoc/releases/tag/3.10.2", "https://pandoc.org/MANUAL.html"],
+      "health_check": "Run pandoc --version, then use --sandbox to convert one non-sensitive local Markdown fixture to a new local HTML output path without remote resources, includes, filters, custom writers, or PDF production.",
+      "uninstall": {
+        "instructions": "Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them; review any separately installed PDF engine independently.",
+        "removes_user_data": false
+      }
+    }
   ]
 }

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -16,6 +16,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [MarkItDown MCP](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-24 |
 | [Notion MCP](https://developers.notion.com/guides/mcp/get-started-with-mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-15 |
 | [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-15 |
+| [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | No | Yes | 2026-08-25 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
@@ -291,6 +292,31 @@ Capabilities and limits:
 - No enforcement wrapper ships here; the calling harness must constrain commands, arguments, and flags, and default-deny eval, command, plugin, theme, web, publish, permanent delete, and mutating sync operations
 - For bounded file operations require explicit vault= plus path= and reject dangerous flags such as overwrite unless separately approved
 - Treat plugin commands and JavaScript eval as open-world execution with possible filesystem and network effects
+
+## Pandoc
+
+A local document-conversion CLI for turning reviewed Markdown into DOCX, PDF, EPUB, or HTML while keeping Markdown canonical in Git.
+
+- **Supported agents:** `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** Pandoc CLI
+- **Credentials:** None
+- **Reads:** Explicitly selected local input Markdown files and explicitly referenced local assets
+- **Writes / external effects:** Explicitly selected local output files, including overwrite of an existing output path when approved
+- **Typed safety signals:** overwrite, arbitrary execution
+- **Required confirmation gates:** `external_install`, `write`, `overwrite`, `arbitrary_execution`, `destructive`
+- **Confirmation:** Confirm exact input and output paths before each run; separately confirm overwrite and any filter, custom writer, include, or remote-fetch option.
+- **Risk tags:** `external-install`, `local-files`, `overwrite-capable`, `arbitrary-execution`, `destructive-capable`
+- **Evidence:** [1](https://github.com/jgm/pandoc); [2](https://github.com/jgm/pandoc/releases/tag/3.10.2); [3](https://pandoc.org/MANUAL.html)
+- **Health check:** Run pandoc --version, then convert one known local Markdown file to a local output path without filters/includes and verify output is created at the expected path.
+- **Uninstall:** Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them. (removes user data: No)
+
+Capabilities and limits:
+
+- Default bounded usage converts one exact input path to one exact output path
+- Require explicit confirmation before overwrite of an existing output file
+- Disallow filters, custom writers, include flags, and remote resource fetching in the default recipe
+- Pandoc's full flag surface can enable arbitrary execution via user-supplied filters or custom writers
 
 ## Readwise MCP
 

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -16,7 +16,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [MarkItDown MCP](https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp) | `mcp_server` | verified | No | No | No | Yes | No | 2026-08-24 |
 | [Notion MCP](https://developers.notion.com/guides/mcp/get-started-with-mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-15 |
 | [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-15 |
-| [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | No | Yes | 2026-08-25 |
+| [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | Yes | Yes | 2026-08-25 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
@@ -295,28 +295,29 @@ Capabilities and limits:
 
 ## Pandoc
 
-A local document-conversion CLI for turning reviewed Markdown into DOCX, PDF, EPUB, or HTML while keeping Markdown canonical in Git.
+A document-conversion CLI for turning reviewed Markdown into DOCX, PDF, EPUB, or HTML while keeping Markdown canonical in Git.
 
 - **Supported agents:** `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** Pandoc CLI
+- **Prerequisites:** Pandoc CLI; A separately installed and reviewed PDF engine when producing PDF output
 - **Credentials:** None
-- **Reads:** Explicitly selected local input Markdown files and explicitly referenced local assets
-- **Writes / external effects:** Explicitly selected local output files, including overwrite of an existing output path when approved
-- **Typed safety signals:** overwrite, arbitrary execution
-- **Required confirmation gates:** `external_install`, `write`, `overwrite`, `arbitrary_execution`, `destructive`
-- **Confirmation:** Confirm exact input and output paths before each run; separately confirm overwrite and any filter, custom writer, include, or remote-fetch option.
-- **Risk tags:** `external-install`, `local-files`, `overwrite-capable`, `arbitrary-execution`, `destructive-capable`
+- **Reads:** Explicitly selected local input files and assets in the bounded profile; Absolute HTTP or HTTPS inputs, URL-valued resources, and local or remote iframe sources when those surfaces are used; Additional files and resources reachable by approved include directives, filters, custom writers, or PDF engines and their options
+- **Writes / external effects:** Explicitly selected local output files, including overwrite of an existing output path when approved; Temporary files used during PDF production and any additional filesystem side effects introduced by approved filters, custom writers, or PDF engines
+- **Typed safety signals:** sensitive read, overwrite, arbitrary execution
+- **Required confirmation gates:** `external_install`, `read_sensitive`, `write`, `overwrite`, `arbitrary_execution`, `destructive`
+- **Confirmation:** Confirm exact input and output paths before each run. Separately confirm any remote input or resource, include directive, filter, custom writer, overwrite, or PDF production; for PDF, name the reviewed engine and exact engine options.
+- **Risk tags:** `external-install`, `local-data`, `sensitive-read`, `network-capable`, `overwrite-capable`, `arbitrary-execution`, `destructive-capable`, `open-world`
 - **Evidence:** [1](https://github.com/jgm/pandoc); [2](https://github.com/jgm/pandoc/releases/tag/3.10.2); [3](https://pandoc.org/MANUAL.html)
-- **Health check:** Run pandoc --version, then convert one known local Markdown file to a local output path without filters/includes and verify output is created at the expected path.
-- **Uninstall:** Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them. (removes user data: No)
+- **Health check:** Run pandoc --version, then use --sandbox to convert one non-sensitive local Markdown fixture to a new local HTML output path without remote resources, includes, filters, custom writers, or PDF production.
+- **Uninstall:** Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them; review any separately installed PDF engine independently. (removes user data: No)
 
 Capabilities and limits:
 
-- Default bounded usage converts one exact input path to one exact output path
-- Require explicit confirmation before overwrite of an existing output file
-- Disallow filters, custom writers, include flags, and remote resource fetching in the default recipe
-- Pandoc's full flag surface can enable arbitrary execution via user-supplied filters or custom writers
+- The bounded non-PDF profile uses --sandbox with one exact local input and a new exact local output path; reject remote inputs and resources, include directives, filters, custom writers, and overwrite
+- Pandoc accepts absolute HTTP or HTTPS inputs, and its HTML reader can fetch local or remote iframe sources; treat those as sensitive network reads outside the bounded profile
+- --sandbox limits reader and writer IO to files named on the command line, but does not constrain filters or PDF production and can prevent formats such as DOCX from loading filesystem data files
+- PDF output invokes a separately installed engine; audit and confirm the exact --pdf-engine and every --pdf-engine-opt because the engine can widen filesystem, network, and execution risk
+- Pandoc's full flag surface can enable arbitrary execution and additional side effects through filters, custom writers, and PDF engines
 
 ## Readwise MCP
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -27,7 +27,7 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
         self.assertEqual(self.catalog["schema_version"], 2)
-        self.assertEqual(len(self.catalog["integrations"]), 14)
+        self.assertEqual(len(self.catalog["integrations"]), 15)
         self.assertTrue(
             {
                 "github-mcp",

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -35,6 +35,7 @@ class IntegrationCatalogTests(unittest.TestCase):
                 "linear-mcp",
                 "markitdown-mcp",
                 "notion-mcp",
+                "pandoc",
                 "readwise-mcp",
             }.issubset(
                 {item["id"] for item in self.catalog["integrations"]}
@@ -63,6 +64,23 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assertTrue(
             any(url.endswith("/packages/markitdown-mcp/src/markitdown_mcp/__main__.py") for url in item["evidence"])
         )
+
+    def test_pandoc_types_network_reads_and_pdf_execution(self) -> None:
+        item = self.entry("pandoc")
+        for capability in ("sensitive_read", "write", "overwrite", "arbitrary_execution", "destructive"):
+            self.assertTrue(item["capabilities"][capability])
+        for gate in ("read_sensitive", "write", "overwrite", "arbitrary_execution", "destructive"):
+            self.assertIn(gate, item["confirmation"]["required_for"])
+        for tag in ("sensitive-read", "network-capable", "overwrite-capable", "arbitrary-execution"):
+            self.assertIn(tag, item["risk_tags"])
+        prerequisites = " ".join(item["installation"]["prerequisites"])
+        reads = " ".join(item["data_boundary"]["reads"])
+        details = " ".join(item["capabilities"]["details"])
+        self.assertIn("PDF engine", prerequisites)
+        self.assertIn("HTTP or HTTPS", reads)
+        self.assertIn("--sandbox", details)
+        self.assertIn("does not constrain filters or PDF production", details)
+        self.assertIn("--pdf-engine-opt", details)
 
     def test_issue_22_connectors_have_typed_sensitive_and_mutating_gates(self) -> None:
         for integration_id in ("google-workspace-cli", "notion-mcp"):


### PR DESCRIPTION
Adds a verified pandoc connector entry to integrations/catalog.json with bounded local conversion defaults and explicit confirmation gates for overwrite and arbitrary-execution flags.

What changed

Added pandoc integration entry in integrations/catalog.json
Regenerated references/integrations.md via scripts/integrations.py render
Updated CHANGELOG.md under Unreleased → Added
Files changed

integrations/catalog.json
references/integrations.md
CHANGELOG.md
Verification

Ran: python scripts/integrations.py render
Ran: bash scripts/validate-all.sh (all checks passed locally)
Closes #54