### PR TITLE
Add provider-neutral root discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ### Added
 - A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
+- Provider-neutral root discovery through validated `contextos.workspace.json`,
+  with legacy compound-marker compatibility, nearest-root selection, explicit
+  nested Git boundaries, fail-closed invalid markers, and actionable migration
+  notices.
 - A workflow-specific `agent-config` transaction for workspace migration. It
   creates digest-bound write/delete proposals, revalidates raw target and
   authorization-source hashes under the shared lock, records exact virtual

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ in the same recoverable transaction. Setup-time agent selection remains tracked
 in #65. The template does not ship a live root file because that would override
 an existing clone's legacy YAML before its migration is reviewed.
 
+Once present, `contextos.workspace.json` is the provider-neutral root marker,
+including for a core-only workspace. Existing `AGENTS.md` plus `state/` or
+`workspace.yaml` roots remain discoverable. The nearest recognized root wins,
+and discovery never climbs past a nested `.git` repository boundary; use
+`--root` when deliberately targeting an outer workspace.
+
 Each fact should have one canonical home. `ROUTING.md` points an agent to the right file instead of copying the same context across prompts.
 
 ## Skills and memory

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -148,13 +148,64 @@ def parse_now(raw: str | None) -> datetime:
 
 
 def discover_root(start: Path | None = None) -> Path:
-    candidate = (start or Path.cwd()).resolve()
+    raw_start = start or Path.cwd()
+    if not raw_start.exists():
+        raise ContextOSError(f"root discovery start path does not exist: {raw_start}")
+    candidate = raw_start.resolve()
+    if candidate.is_file():
+        candidate = candidate.parent
+    elif not candidate.is_dir():
+        raise ContextOSError(f"root discovery start path is not a directory or file: {raw_start}")
+
     for path in (candidate, *candidate.parents):
+        # The tracked JSON marker is authoritative at the nearest candidate.
+        # Reject portable aliases before looking for the exact spelling so an
+        # invalid inner marker can never silently fall through to an outer root.
+        _reject_config_aliases(path, "contextos.workspace.json")
+        marker = path / "contextos.workspace.json"
+        if marker.exists() or marker.is_symlink():
+            if marker.is_symlink():
+                raise ContextOSError(
+                    "invalid tracked workspace configuration: "
+                    "contextos.workspace.json must not be a symlink"
+                )
+            if not marker.is_file():
+                raise ContextOSError(
+                    "invalid tracked workspace configuration: "
+                    "contextos.workspace.json must be a regular file"
+                )
+            try:
+                load_workspace_config(
+                    marker,
+                    root=path,
+                    known_runtime_ids=runtime_ids(path),
+                )
+            except WorkspaceConfigError as exc:
+                raise ContextOSError(
+                    f"invalid tracked workspace configuration: {exc}"
+                ) from exc
+            return path
+
+        # Preserve the original legacy compound marker for existing clones.
         if (path / "AGENTS.md").is_file() and (
             (path / "state").is_dir() or (path / "workspace.yaml").is_file()
         ):
             return path
-    raise ContextOSError("could not find a Context OS root (AGENTS.md plus state/ or workspace.yaml)")
+
+        # A nested repository without its own Context OS marker must not be
+        # captured by an outer repository. Check the candidate before stopping
+        # so a marker at a worktree or submodule root still wins.
+        git_marker = path / ".git"
+        if git_marker.exists() or git_marker.is_symlink():
+            raise ContextOSError(
+                "could not find a Context OS root before repository boundary: "
+                f"{path}"
+            )
+
+    raise ContextOSError(
+        "could not find a Context OS root "
+        "(contextos.workspace.json, or legacy AGENTS.md plus state/ or workspace.yaml)"
+    )
 
 
 def _reject_config_aliases(root: Path, canonical_name: str) -> None:
@@ -238,11 +289,20 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
         if not canonical:
             notices.append({
                 "code": "workspace-json-noncanonical",
-                "message": "contextos.workspace.json is valid but not canonically rendered",
+                "message": (
+                    "contextos.workspace.json is valid but not canonically rendered; "
+                    "preview the same-agent repair with bash scripts/contextos.sh "
+                    f"workspace migrate --agents {','.join(config['agents']) or 'none'}, "
+                    "then create its reviewed proposal with workspace propose-migration"
+                ),
             })
         if legacy_path.exists() or legacy_path.is_symlink():
             conflicts: list[str] = []
-            legacy_detail = "legacy workspace.yaml is shadowed by contextos.workspace.json"
+            legacy_detail = (
+                "legacy workspace.yaml is shadowed by contextos.workspace.json; "
+                "retire it through bash scripts/contextos.sh workspace "
+                f"propose-migration --agents {','.join(config['agents']) or 'none'}"
+            )
             if legacy_path.is_symlink():
                 legacy_detail += "; legacy file must not be a symlink"
             else:
@@ -284,8 +344,10 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
         notices.append({
             "code": "legacy-workspace",
             "message": (
-                "workspace.yaml remains readable but is deprecated; preview migration "
-                "with context-os workspace migrate"
+                "workspace.yaml remains readable but is deprecated; choose the intended "
+                "agent set and preview migration with bash scripts/contextos.sh workspace "
+                "migrate --agents <comma-separated-runtime-ids|none>, then create its "
+                "reviewed proposal with workspace propose-migration using the same --agents"
             ),
         })
     else:

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -147,15 +147,72 @@ def parse_now(raw: str | None) -> datetime:
     return parsed
 
 
+def _is_link_like(path: Path) -> bool:
+    """Recognize symlinks and Windows reparse points without following them."""
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ContextOSError(f"cannot inspect path without following links {path}: {exc}") from exc
+    reparse_tag = getattr(metadata, "st_reparse_tag", 0)
+    link_tags = {
+        getattr(stat, "IO_REPARSE_TAG_SYMLINK", -1),
+        getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", -2),
+    }
+    return stat.S_ISLNK(metadata.st_mode) or reparse_tag in link_tags
+
+
+def _config_filename_identity(value: str) -> str:
+    # Windows aliases trailing spaces and periods even when a POSIX checkout can
+    # contain them, so discovery must reject those names portably.
+    return workspace_portable_identity(value).rstrip(" .")
+
+
 def discover_root(start: Path | None = None) -> Path:
-    raw_start = start or Path.cwd()
-    if not raw_start.exists():
-        raise ContextOSError(f"root discovery start path does not exist: {raw_start}")
-    candidate = raw_start.resolve()
-    if candidate.is_file():
-        candidate = candidate.parent
-    elif not candidate.is_dir():
-        raise ContextOSError(f"root discovery start path is not a directory or file: {raw_start}")
+    raw_start = (start or Path.cwd()).absolute()
+    if _config_filename_identity(raw_start.name) == _config_filename_identity(
+        "contextos.workspace.json"
+    ):
+        # Treat a marker passed directly as a marker in its lexical parent. Do
+        # not resolve it first: it may be a dangling link or Windows junction.
+        if not raw_start.exists() and not _is_link_like(raw_start):
+            raise ContextOSError(f"root discovery start path does not exist: {raw_start}")
+        candidate = raw_start.parent
+    else:
+        if _is_link_like(raw_start):
+            raise ContextOSError(
+                f"root discovery start path must not be a symlink or reparse point: {raw_start}"
+            )
+        if not raw_start.exists():
+            raise ContextOSError(f"root discovery start path does not exist: {raw_start}")
+        if raw_start.is_file():
+            candidate = raw_start.parent
+        elif raw_start.is_dir():
+            candidate = raw_start
+        else:
+            raise ContextOSError(
+                f"root discovery start path is not a directory or file: {raw_start}"
+            )
+
+    # Reject linked components below a lexical repository boundary before
+    # resolving the start. Links above that boundary are irrelevant, and
+    # symlinked system ancestors such as macOS /tmp remain compatible. Without
+    # any repository boundary, normal resolution preserves legacy behavior.
+    linked_below_boundary: Path | None = None
+    for lexical in (candidate, *candidate.parents):
+        if _is_link_like(lexical) and linked_below_boundary is None:
+            linked_below_boundary = lexical
+        git_marker = lexical / ".git"
+        if git_marker.exists() or _is_link_like(git_marker):
+            if linked_below_boundary is not None:
+                raise ContextOSError(
+                    "root discovery start path must not traverse a symlink or "
+                    f"reparse point below repository boundary {lexical}: "
+                    f"{linked_below_boundary}"
+                )
+            break
+    candidate = candidate.resolve()
 
     for path in (candidate, *candidate.parents):
         # The tracked JSON marker is authoritative at the nearest candidate.
@@ -163,11 +220,11 @@ def discover_root(start: Path | None = None) -> Path:
         # invalid inner marker can never silently fall through to an outer root.
         _reject_config_aliases(path, "contextos.workspace.json")
         marker = path / "contextos.workspace.json"
-        if marker.exists() or marker.is_symlink():
-            if marker.is_symlink():
+        if marker.exists() or _is_link_like(marker):
+            if _is_link_like(marker):
                 raise ContextOSError(
                     "invalid tracked workspace configuration: "
-                    "contextos.workspace.json must not be a symlink"
+                    "contextos.workspace.json must not be a symlink or reparse point"
                 )
             if not marker.is_file():
                 raise ContextOSError(
@@ -196,7 +253,7 @@ def discover_root(start: Path | None = None) -> Path:
         # captured by an outer repository. Check the candidate before stopping
         # so a marker at a worktree or submodule root still wins.
         git_marker = path / ".git"
-        if git_marker.exists() or git_marker.is_symlink():
+        if git_marker.exists() or _is_link_like(git_marker):
             raise ContextOSError(
                 "could not find a Context OS root before repository boundary: "
                 f"{path}"
@@ -209,12 +266,12 @@ def discover_root(start: Path | None = None) -> Path:
 
 
 def _reject_config_aliases(root: Path, canonical_name: str) -> None:
-    identity = workspace_portable_identity(canonical_name)
+    identity = _config_filename_identity(canonical_name)
     try:
         matches = [
             path.name
             for path in root.iterdir()
-            if workspace_portable_identity(path.name) == identity
+            if _config_filename_identity(path.name) == identity
         ]
     except OSError as exc:
         raise ContextOSError(f"cannot inspect workspace root {root}: {exc}") from exc
@@ -293,7 +350,9 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
                     "contextos.workspace.json is valid but not canonically rendered; "
                     "preview the same-agent repair with bash scripts/contextos.sh "
                     f"workspace migrate --agents {','.join(config['agents']) or 'none'}, "
-                    "then create its reviewed proposal with workspace propose-migration"
+                    "then create its reviewed proposal with bash scripts/contextos.sh "
+                    f"workspace propose-migration --agents "
+                    f"{','.join(config['agents']) or 'none'}"
                 ),
             })
         if legacy_path.exists() or legacy_path.is_symlink():
@@ -347,7 +406,8 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
                 "workspace.yaml remains readable but is deprecated; choose the intended "
                 "agent set and preview migration with bash scripts/contextos.sh workspace "
                 "migrate --agents <comma-separated-runtime-ids|none>, then create its "
-                "reviewed proposal with workspace propose-migration using the same --agents"
+                "reviewed proposal with bash scripts/contextos.sh workspace "
+                "propose-migration --agents <the-same-selection>"
             ),
         })
     else:

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -180,10 +180,6 @@ def discover_root(start: Path | None = None) -> Path:
             raise ContextOSError(f"root discovery start path does not exist: {raw_start}")
         candidate = raw_start.parent
     else:
-        if _is_link_like(raw_start):
-            raise ContextOSError(
-                f"root discovery start path must not be a symlink or reparse point: {raw_start}"
-            )
         if not raw_start.exists():
             raise ContextOSError(f"root discovery start path does not exist: {raw_start}")
         if raw_start.is_file():
@@ -195,32 +191,47 @@ def discover_root(start: Path | None = None) -> Path:
                 f"root discovery start path is not a directory or file: {raw_start}"
             )
 
-    # Reject linked components below a lexical repository boundary before
-    # resolving the start. Links above that boundary are irrelevant, and
-    # symlinked system ancestors such as macOS /tmp remain compatible. Without
-    # any repository boundary, normal resolution preserves legacy behavior.
-    linked_below_boundary: Path | None = None
+    # A link may be an ordinary internal repository path. Reject it only when
+    # resolving the start would escape the nearest lexical repository boundary.
+    # Do not treat `.git` reached through the link itself as lexical ownership;
+    # that preserves common `~/current -> repo` entrypoints.
+    lexical_boundary: Path | None = None
     for lexical in (candidate, *candidate.parents):
-        if _is_link_like(lexical) and linked_below_boundary is None:
-            linked_below_boundary = lexical
+        if _is_link_like(lexical):
+            continue
         git_marker = lexical / ".git"
         if git_marker.exists() or _is_link_like(git_marker):
-            if linked_below_boundary is not None:
-                raise ContextOSError(
-                    "root discovery start path must not traverse a symlink or "
-                    f"reparse point below repository boundary {lexical}: "
-                    f"{linked_below_boundary}"
-                )
+            lexical_boundary = lexical
             break
-    candidate = candidate.resolve()
+    resolved_candidate = candidate.resolve()
+    if lexical_boundary is not None:
+        try:
+            resolved_candidate.relative_to(lexical_boundary.resolve())
+        except ValueError as exc:
+            raise ContextOSError(
+                "root discovery start path must not escape repository boundary "
+                f"{lexical_boundary}: {candidate}"
+            ) from exc
+    candidate = resolved_candidate
 
-    for path in (candidate, *candidate.parents):
+    for index, path in enumerate((candidate, *candidate.parents)):
         # The tracked JSON marker is authoritative at the nearest candidate.
-        # Reject portable aliases before looking for the exact spelling so an
-        # invalid inner marker can never silently fall through to an outer root.
-        _reject_config_aliases(path, "contextos.workspace.json")
         marker = path / "contextos.workspace.json"
-        if marker.exists() or _is_link_like(marker):
+        marker_present = marker.exists() or _is_link_like(marker)
+        legacy_present = (path / "AGENTS.md").is_file() and (
+            (path / "state").is_dir() or (path / "workspace.yaml").is_file()
+        )
+        git_marker = path / ".git"
+        boundary_present = git_marker.exists() or _is_link_like(git_marker)
+
+        # Directory enumeration is needed only where a marker/root is actually
+        # plausible, plus the explicit start directory for alias-only controls.
+        # Intermediate traverse-only directories and unrelated outer ancestors
+        # remain compatible with legacy discovery.
+        if index == 0 or marker_present or legacy_present or boundary_present:
+            _reject_config_aliases(path, "contextos.workspace.json")
+
+        if marker_present:
             if _is_link_like(marker):
                 raise ContextOSError(
                     "invalid tracked workspace configuration: "
@@ -244,16 +255,13 @@ def discover_root(start: Path | None = None) -> Path:
             return path
 
         # Preserve the original legacy compound marker for existing clones.
-        if (path / "AGENTS.md").is_file() and (
-            (path / "state").is_dir() or (path / "workspace.yaml").is_file()
-        ):
+        if legacy_present:
             return path
 
         # A nested repository without its own Context OS marker must not be
         # captured by an outer repository. Check the candidate before stopping
         # so a marker at a worktree or submodule root still wins.
-        git_marker = path / ".git"
-        if git_marker.exists() or _is_link_like(git_marker):
+        if boundary_present:
             raise ContextOSError(
                 "could not find a Context OS root before repository boundary: "
                 f"{path}"

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -290,22 +290,6 @@ def _reject_config_aliases(root: Path, canonical_name: str) -> None:
         )
 
 
-def _is_link_like(path: Path) -> bool:
-    """Recognize symlinks and Windows reparse points without following them."""
-    try:
-        metadata = path.lstat()
-    except FileNotFoundError:
-        return False
-    except OSError as exc:
-        raise ContextOSError(f"cannot inspect path without following links {path}: {exc}") from exc
-    reparse_tag = getattr(metadata, "st_reparse_tag", 0)
-    link_tags = {
-        getattr(stat, "IO_REPARSE_TAG_SYMLINK", -1),
-        getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", -2),
-    }
-    return stat.S_ISLNK(metadata.st_mode) or reparse_tag in link_tags
-
-
 def _legacy_repo_path(root: Path, raw: str, field: str) -> Path:
     relative = Path(raw)
     if relative.is_absolute():

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -94,9 +94,8 @@ Before a later command may materialize a selected component set, it must also:
    evidence behave in a slim workspace; and
 8. validate the resulting selected runtime closure without assuming every
    adapter or the development test tree is present;
-9. replace the current `AGENTS.md`-based root discovery and doctor requirement
-   with a provider-neutral marker before a Claude-only closure can omit the
-   `agents-instructions` component; and
+9. remove the remaining unconditional `AGENTS.md` doctor requirement before a
+   Claude-only closure can omit the `agents-instructions` component; and
 10. make shared instruction and documentation links closure-aware so a slim
     workspace neither points at omitted adapter docs nor describes hooks that
     were not selected.

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -188,7 +188,9 @@ chooses the nearest recognized root. After evaluating a directory, it stops at
 an exact `.git` file, directory, or symlink, so an unconfigured nested repository
 cannot accidentally inherit an outer repository's Context OS state. Pass an
 explicit `--root` only when deliberately operating on an outer workspace. A
-discovery start may be a real directory or regular file, but a link or Windows
-mount-point start is rejected. Link-like path components below a nested `.git`
-boundary are also rejected before resolution; symlinked system ancestors above
-the boundary and non-Git legacy paths remain compatible.
+discovery start may be a real directory, regular file, or link-like entrypoint.
+Internal links and entrypoints such as `current -> repo` remain compatible when
+their resolved start stays inside the nearest lexical `.git` boundary. A link
+that escapes that boundary fails before an outer workspace can be selected;
+symlinked system ancestors above the boundary and non-Git legacy paths remain
+compatible.

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -187,4 +187,8 @@ Existing clones remain discoverable through the legacy compound marker:
 chooses the nearest recognized root. After evaluating a directory, it stops at
 an exact `.git` file, directory, or symlink, so an unconfigured nested repository
 cannot accidentally inherit an outer repository's Context OS state. Pass an
-explicit `--root` only when deliberately operating on an outer workspace.
+explicit `--root` only when deliberately operating on an outer workspace. A
+discovery start may be a real directory or regular file, but a link or Windows
+mount-point start is rejected. Link-like path components below a nested `.git`
+boundary are also rejected before resolution; symlinked system ancestors above
+the boundary and non-Git legacy paths remain compatible.

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -173,6 +173,18 @@ the multi-select setup work is completed separately. Its semantics are fixed:
 - Cursor and OpenClaw remain launch/read compatibility names until registered
   runtime descriptors exist, so they cannot be stored in `agents` yet.
 
-Root discovery still requires the existing `AGENTS.md` plus `state/` or
-`workspace.yaml` markers during this phase. Making JSON a standalone root marker
-is a separate compatibility step.
+## Root discovery
+
+`contextos.workspace.json` is the provider-neutral root marker. A valid tracked
+configuration is sufficient even for a minimal core-only workspace with no
+`AGENTS.md`, runtime adapter, or materialized state paths. Discovery validates
+the nearest JSON marker before accepting it; malformed, aliased, symlinked, or
+non-file markers fail at that directory instead of falling through to an outer
+workspace.
+
+Existing clones remain discoverable through the legacy compound marker:
+`AGENTS.md` plus either a `state/` directory or `workspace.yaml`. Discovery
+chooses the nearest recognized root. After evaluating a directory, it stops at
+an exact `.git` file, directory, or symlink, so an unconfigured nested repository
+cannot accidentally inherit an outer repository's Context OS state. Pass an
+explicit `--root` only when deliberately operating on an outer workspace.

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -15,6 +15,7 @@ from contextos.kernel import (
     ContextOSError,
     apply_proposal,
     create_proposal,
+    discover_root,
     doctor,
     hook_report,
     install_runtime,
@@ -25,10 +26,159 @@ from contextos.kernel import (
     sha256_text,
     start_report,
 )
+from contextos.workspace_schema import render_workspace_config
 
 
 ROOT = Path(__file__).resolve().parents[1]
 NOW = datetime.fromisoformat("2026-08-23T14:30:00-07:00")
+
+
+def root_config(*, canonical: bool = True) -> str:
+    value = {
+        "schema_version": 1,
+        "mode": "full-template",
+        "agents": [],
+        "paths": {
+            "state_dir": "state",
+            "sessions_dir": "sessions",
+            "task_file": "TODO.md",
+        },
+        "template": {"version": "0.12.0", "source": "test"},
+    }
+    if canonical:
+        return render_workspace_config(value)
+    return json.dumps(value, separators=(",", ":"))
+
+
+class RootDiscoveryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+
+    def write_json(self, root: Path, content: str | None = None) -> Path:
+        marker = root / "contextos.workspace.json"
+        marker.write_text(content or root_config(), encoding="utf-8")
+        return marker
+
+    def test_json_marker_supports_minimal_core_only_workspace(self) -> None:
+        self.write_json(self.root)
+        child = self.root / "uncreated-state-parent"
+        child.mkdir()
+        self.assertEqual(self.root, discover_root(child))
+        self.assertEqual(self.root, discover_root(self.root / "contextos.workspace.json"))
+
+    def test_valid_noncanonical_json_is_still_a_root(self) -> None:
+        self.write_json(self.root, root_config(canonical=False))
+        self.assertEqual(self.root, discover_root(self.root))
+
+    def test_legacy_compound_markers_remain_supported(self) -> None:
+        for companion, is_directory in (("state", True), ("workspace.yaml", False)):
+            with self.subTest(companion=companion):
+                root = self.root / companion.replace(".", "-")
+                root.mkdir()
+                (root / "AGENTS.md").write_text("# fixture\n", encoding="utf-8")
+                if is_directory:
+                    (root / companion).mkdir()
+                else:
+                    (root / companion).write_text("state_dir: state\n", encoding="utf-8")
+                self.assertEqual(root, discover_root(root))
+
+    def test_partial_and_near_name_markers_are_false_positives(self) -> None:
+        fixtures = (
+            ("agents-only", "AGENTS.md", False),
+            ("state-only", "state", True),
+            ("yaml-only", "workspace.yaml", False),
+            ("near-json", "contextos.workspace.json.bak", False),
+        )
+        for name, marker, is_directory in fixtures:
+            with self.subTest(name=name):
+                root = self.root / name
+                root.mkdir()
+                (root / ".git").mkdir()
+                if is_directory:
+                    (root / marker).mkdir()
+                else:
+                    (root / marker).write_text("fixture\n", encoding="utf-8")
+                with self.assertRaisesRegex(ContextOSError, "repository boundary"):
+                    discover_root(root)
+
+    def test_nearest_root_wins_across_json_and_legacy_markers(self) -> None:
+        self.write_json(self.root)
+        inner = self.root / "inner"
+        inner.mkdir()
+        (inner / "AGENTS.md").write_text("# fixture\n", encoding="utf-8")
+        (inner / "state").mkdir()
+        leaf = inner / "leaf"
+        leaf.mkdir()
+        self.assertEqual(inner, discover_root(leaf))
+
+        nested = inner / "nested"
+        nested.mkdir()
+        self.write_json(nested)
+        self.assertEqual(nested, discover_root(nested))
+
+    def test_invalid_inner_json_never_falls_back_to_legacy_or_outer_root(self) -> None:
+        self.write_json(self.root)
+        inner = self.root / "inner"
+        inner.mkdir()
+        (inner / "AGENTS.md").write_text("# fixture\n", encoding="utf-8")
+        (inner / "state").mkdir()
+        self.write_json(inner, "{")
+        with self.assertRaisesRegex(ContextOSError, "invalid tracked"):
+            discover_root(inner)
+
+    def test_nested_git_directory_and_file_stop_ascent(self) -> None:
+        self.write_json(self.root)
+        for name, git_content in (("repo", None), ("worktree", "gitdir: elsewhere\n")):
+            with self.subTest(name=name):
+                nested = self.root / name
+                nested.mkdir()
+                if git_content is None:
+                    (nested / ".git").mkdir()
+                else:
+                    (nested / ".git").write_text(git_content, encoding="utf-8")
+                leaf = nested / "leaf"
+                leaf.mkdir()
+                with self.assertRaisesRegex(ContextOSError, "repository boundary"):
+                    discover_root(leaf)
+                self.write_json(nested)
+                self.assertEqual(nested, discover_root(leaf))
+
+    def test_invalid_marker_types_and_portable_aliases_fail_closed(self) -> None:
+        marker = self.root / "contextos.workspace.json"
+        marker.mkdir()
+        with self.assertRaisesRegex(ContextOSError, "regular file"):
+            discover_root(self.root)
+        marker.rmdir()
+
+        alias = self.root / "ContextOS.Workspace.json"
+        alias.write_text(root_config(), encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "filename collision"):
+            discover_root(self.root)
+
+    def test_symlink_marker_fails_without_using_its_target(self) -> None:
+        outside = self.root / "outside.json"
+        outside.write_text(root_config(), encoding="utf-8")
+        nested = self.root / "nested"
+        nested.mkdir()
+        marker = nested / "contextos.workspace.json"
+        try:
+            marker.symlink_to(outside)
+        except OSError:
+            self.skipTest("symlink creation is unavailable")
+        with self.assertRaisesRegex(ContextOSError, "must not be a symlink"):
+            discover_root(nested)
+
+    def test_existing_file_start_uses_parent_and_missing_start_is_rejected(self) -> None:
+        self.write_json(self.root)
+        child = self.root / "child"
+        child.mkdir()
+        source = child / "input.txt"
+        source.write_text("fixture\n", encoding="utf-8")
+        self.assertEqual(self.root, discover_root(source))
+        with self.assertRaisesRegex(ContextOSError, "does not exist"):
+            discover_root(child / "missing")
 
 
 class KernelTest(unittest.TestCase):

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import threading
 import unittest
@@ -31,6 +32,20 @@ from contextos.workspace_schema import render_workspace_config
 
 ROOT = Path(__file__).resolve().parents[1]
 NOW = datetime.fromisoformat("2026-08-23T14:30:00-07:00")
+
+
+def make_directory_link(link: Path, target: Path) -> None:
+    if os.name == "nt":
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise OSError(result.stderr or result.stdout)
+    else:
+        link.symlink_to(target, target_is_directory=True)
 
 
 def root_config(*, canonical: bool = True, agents: list[str] | None = None) -> str:
@@ -188,10 +203,10 @@ class RootDiscoveryTest(unittest.TestCase):
         (nested / ".git").mkdir()
         linked = nested / "linked"
         try:
-            linked.symlink_to(self.root, target_is_directory=True)
+            make_directory_link(linked, self.root)
         except OSError:
-            self.skipTest("directory symlink creation is unavailable")
-        with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
+            self.skipTest("directory link creation is unavailable")
+        with self.assertRaisesRegex(ContextOSError, "escape repository boundary"):
             discover_root(linked)
 
     def test_symlinked_ancestor_without_git_boundary_remains_compatible(self) -> None:
@@ -202,10 +217,67 @@ class RootDiscoveryTest(unittest.TestCase):
         self.write_json(workspace)
         linked_parent = self.root / "linked-parent"
         try:
-            linked_parent.symlink_to(real_parent, target_is_directory=True)
+            make_directory_link(linked_parent, real_parent)
         except OSError:
-            self.skipTest("directory symlink creation is unavailable")
+            self.skipTest("directory link creation is unavailable")
         self.assertEqual(workspace, discover_root(linked_parent / "workspace"))
+
+    def test_internal_directory_link_remains_within_repository_boundary(self) -> None:
+        repository = self.root / "repo"
+        repository.mkdir()
+        (repository / ".git").mkdir()
+        (repository / "AGENTS.md").write_text("# fixture\n", encoding="utf-8")
+        (repository / "state").mkdir()
+        docs = repository / "docs"
+        deep = docs / "deep"
+        deep.mkdir(parents=True)
+        linked = repository / "linked-docs"
+        try:
+            make_directory_link(linked, docs)
+        except OSError:
+            self.skipTest("directory link creation is unavailable")
+        self.assertEqual(repository, discover_root(linked / "deep"))
+
+    def test_link_to_repository_entrypoint_remains_compatible(self) -> None:
+        repository = self.root / "repo"
+        repository.mkdir()
+        (repository / ".git").mkdir()
+        (repository / "AGENTS.md").write_text("# fixture\n", encoding="utf-8")
+        (repository / "state").mkdir()
+        current = self.root / "current"
+        try:
+            make_directory_link(current, repository)
+        except OSError:
+            self.skipTest("directory link creation is unavailable")
+        self.assertEqual(repository, discover_root(current / "state"))
+
+    def test_alias_scan_skips_intermediate_and_unrelated_ancestors(self) -> None:
+        workspace = self.root / "workspace"
+        workspace.mkdir()
+        self.write_json(workspace)
+        intermediate = workspace / "intermediate"
+        child = intermediate / "child"
+        child.mkdir(parents=True)
+        original_iterdir = Path.iterdir
+
+        def guarded_iterdir(path: Path):
+            if path == intermediate:
+                raise PermissionError("traverse-only fixture")
+            return original_iterdir(path)
+
+        with mock.patch.object(Path, "iterdir", guarded_iterdir):
+            self.assertEqual(workspace, discover_root(child))
+
+        if os.name == "nt":
+            return
+        unrelated = self.root / "unrelated"
+        leaf = unrelated / "leaf"
+        leaf.mkdir(parents=True)
+        (unrelated / "ContextOS.Workspace.json").write_text(
+            "not a workspace\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(ContextOSError, "could not find a Context OS root"):
+            discover_root(leaf)
 
     @unittest.skipIf(os.name == "nt", "Windows aliases trailing dots at creation time")
     def test_windows_trailing_dot_filename_alias_fails_portably(self) -> None:

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -69,7 +69,9 @@ class RootDiscoveryTest(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
-        self.root = Path(self.temporary.name)
+        # Hosted Windows may spell TEMP with an 8.3 short path, while
+        # discover_root() intentionally returns the resolved canonical path.
+        self.root = Path(self.temporary.name).resolve()
 
     def write_json(self, root: Path, content: str | None = None) -> Path:
         marker = root / "contextos.workspace.json"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -33,11 +33,11 @@ ROOT = Path(__file__).resolve().parents[1]
 NOW = datetime.fromisoformat("2026-08-23T14:30:00-07:00")
 
 
-def root_config(*, canonical: bool = True) -> str:
+def root_config(*, canonical: bool = True, agents: list[str] | None = None) -> str:
     value = {
         "schema_version": 1,
         "mode": "full-template",
-        "agents": [],
+        "agents": agents or [],
         "paths": {
             "state_dir": "state",
             "sessions_dir": "sessions",
@@ -70,6 +70,15 @@ class RootDiscoveryTest(unittest.TestCase):
 
     def test_valid_noncanonical_json_is_still_a_root(self) -> None:
         self.write_json(self.root, root_config(canonical=False))
+        self.assertEqual(self.root, discover_root(self.root))
+
+    def test_configured_agent_requires_only_its_registry_descriptor(self) -> None:
+        self.write_json(self.root, root_config(agents=["claude"]))
+        with self.assertRaisesRegex(ContextOSError, "unknown runtime"):
+            discover_root(self.root)
+        runtimes = self.root / "runtimes"
+        runtimes.mkdir()
+        shutil.copyfile(ROOT / "runtimes" / "claude.json", runtimes / "claude.json")
         self.assertEqual(self.root, discover_root(self.root))
 
     def test_legacy_compound_markers_remain_supported(self) -> None:
@@ -169,6 +178,41 @@ class RootDiscoveryTest(unittest.TestCase):
             self.skipTest("symlink creation is unavailable")
         with self.assertRaisesRegex(ContextOSError, "must not be a symlink"):
             discover_root(nested)
+        with self.assertRaisesRegex(ContextOSError, "must not be a symlink"):
+            discover_root(marker)
+
+    def test_symlinked_directory_start_cannot_bypass_repository_boundary(self) -> None:
+        self.write_json(self.root)
+        nested = self.root / "nested"
+        nested.mkdir()
+        (nested / ".git").mkdir()
+        linked = nested / "linked"
+        try:
+            linked.symlink_to(self.root, target_is_directory=True)
+        except OSError:
+            self.skipTest("directory symlink creation is unavailable")
+        with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
+            discover_root(linked)
+
+    def test_symlinked_ancestor_without_git_boundary_remains_compatible(self) -> None:
+        real_parent = self.root / "real-parent"
+        real_parent.mkdir()
+        workspace = real_parent / "workspace"
+        workspace.mkdir()
+        self.write_json(workspace)
+        linked_parent = self.root / "linked-parent"
+        try:
+            linked_parent.symlink_to(real_parent, target_is_directory=True)
+        except OSError:
+            self.skipTest("directory symlink creation is unavailable")
+        self.assertEqual(workspace, discover_root(linked_parent / "workspace"))
+
+    @unittest.skipIf(os.name == "nt", "Windows aliases trailing dots at creation time")
+    def test_windows_trailing_dot_filename_alias_fails_portably(self) -> None:
+        alias = self.root / "contextos.workspace.json."
+        alias.write_text(root_config(), encoding="utf-8")
+        with self.assertRaisesRegex(ContextOSError, "filename collision"):
+            discover_root(self.root)
 
     def test_existing_file_start_uses_parent_and_missing_start_is_rejected(self) -> None:
         self.write_json(self.root)
@@ -179,6 +223,8 @@ class RootDiscoveryTest(unittest.TestCase):
         self.assertEqual(self.root, discover_root(source))
         with self.assertRaisesRegex(ContextOSError, "does not exist"):
             discover_root(child / "missing")
+        with self.assertRaisesRegex(ContextOSError, "does not exist"):
+            discover_root(child / "contextos.workspace.json")
 
 
 class KernelTest(unittest.TestCase):

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -314,6 +314,36 @@ class WorkspaceConfigTest(unittest.TestCase):
         )
         self.assertEqual("warn", check["status"])
 
+    def test_migration_notices_name_complete_preview_and_proposal_commands(self) -> None:
+        self.write_json(json.dumps(config(agents=[]), separators=(",", ":")))
+        resolution = resolve_workspace(self.root)
+        self.assertIn(
+            "workspace migrate --agents none",
+            resolution.notices[0]["message"],
+        )
+        self.assertIn("workspace propose-migration", resolution.notices[0]["message"])
+
+        (self.root / "workspace.yaml").write_text(
+            "state_dir: state\n", encoding="utf-8"
+        )
+        resolution = resolve_workspace(self.root)
+        shadowed = next(
+            notice for notice in resolution.notices
+            if notice["code"] == "legacy-workspace-shadowed"
+        )
+        self.assertIn(
+            "workspace propose-migration --agents none",
+            shadowed["message"],
+        )
+
+        (self.root / "contextos.workspace.json").unlink()
+        resolution = resolve_workspace(self.root)
+        self.assertIn(
+            "workspace migrate --agents <comma-separated-runtime-ids|none>",
+            resolution.notices[0]["message"],
+        )
+        self.assertIn("workspace propose-migration", resolution.notices[0]["message"])
+
     def test_legacy_reader_remains_compatible_but_preview_is_loss_aware(self) -> None:
         legacy = self.root / "workspace.yaml"
         legacy.write_text(

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -321,7 +321,10 @@ class WorkspaceConfigTest(unittest.TestCase):
             "workspace migrate --agents none",
             resolution.notices[0]["message"],
         )
-        self.assertIn("workspace propose-migration", resolution.notices[0]["message"])
+        self.assertIn(
+            "bash scripts/contextos.sh workspace propose-migration --agents none",
+            resolution.notices[0]["message"],
+        )
 
         (self.root / "workspace.yaml").write_text(
             "state_dir: state\n", encoding="utf-8"
@@ -342,7 +345,11 @@ class WorkspaceConfigTest(unittest.TestCase):
             "workspace migrate --agents <comma-separated-runtime-ids|none>",
             resolution.notices[0]["message"],
         )
-        self.assertIn("workspace propose-migration", resolution.notices[0]["message"])
+        self.assertIn(
+            "bash scripts/contextos.sh workspace propose-migration "
+            "--agents <the-same-selection>",
+            resolution.notices[0]["message"],
+        )
 
     def test_legacy_reader_remains_compatible_but_preview_is_loss_aware(self) -> None:
         legacy = self.root / "workspace.yaml"


### PR DESCRIPTION
Closes #66.

Adds provider-neutral root discovery through validated contextos.workspace.json while preserving the legacy AGENTS.md plus state/workspace.yaml compound marker. The nearest valid marker wins, invalid explicit markers fail closed, and nested Git repository boundaries stop ascent. Start-path handling rejects symlink/junction boundary bypasses without breaking non-Git paths under symlinked macOS system ancestors.

Also makes workspace migration notices name complete preview and proposal commands, and documents the compatibility contract.

Validation:
- bash scripts/validate-all.sh
- 288 Python tests passed (21 platform skips)
- 57 portability tests passed (5 platform skips)
- 12 hook tests passed
- Manual Windows junction probes fail closed for both direct marker and directory starts

Review:
- claude-opus-5 at 0a21f2c0dcb33bf65e4119c4478046cd73cc0ea9: no release blocker
- thinkingmachines/inkling:free via Hermes at the same SHA: no release blocker
- Supplemental Codex 5.6 review found the junction bypass; repair and macOS portability re-review are included

Stacked on #80; retarget to main after its parent stack lands.