### PR TITLE
Make doctor aware of configured agent sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Changed
+- `doctor` is set-aware when tracked workspace configuration exists. It reports
+  support, component materialization, customization limits, local availability,
+  onboarding, descriptor drift, declared conformance, and evidence freshness
+  independently; inert adapters cannot fail a selected user profile, while
+  explicit and maintainer scopes remain strict.
 - Runtime descriptors move from schema v1 to the discoverable, incompatible
   schema v2 with surface-specific capabilities, resolution-only probes,
   instruction and skill precedence, typed evidence, generated JSON Schema and

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -48,13 +48,19 @@ def parser() -> argparse.ArgumentParser:
     apply.add_argument("--confirm", required=True, help="Exact proposal digest printed by propose")
     apply.add_argument("--runtime", metavar="RUNTIME", required=True)
 
-    install = commands.add_parser("install", help="Record the selected runtime and print host setup steps")
+    install = commands.add_parser(
+        "install", help="Record local onboarding for one runtime and print host setup steps"
+    )
     install.add_argument("--runtime", metavar="RUNTIME", required=True)
 
-    diagnose = commands.add_parser("doctor", help="Check kernel, state, manifests, locks, and runtime")
+    diagnose = commands.add_parser(
+        "doctor", help="Check workspace health with tracked agent-set awareness"
+    )
     diagnose_selection = diagnose.add_mutually_exclusive_group()
     diagnose_selection.add_argument("--runtime", metavar="RUNTIME")
-    diagnose_selection.add_argument("--all", action="store_true", help="Validate every shipped runtime descriptor")
+    diagnose_selection.add_argument(
+        "--all", action="store_true", help="Strictly validate every shipped runtime"
+    )
 
     workspace = commands.add_parser(
         "workspace", help="Inspect tracked workspace intent or preview migration"

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1078,9 +1078,10 @@ def _guard_local_artifact_path(root: Path, path: Path) -> None:
                     + ", ".join(sorted(aliases))
                 )
         current /= part
-        if current.is_symlink():
+        if _is_link_like(current):
             raise ContextOSError(
-                f"local artifact path must not traverse a symlink: {relative.as_posix()}"
+                "local artifact path must not traverse a symlink or reparse point: "
+                f"{relative.as_posix()}"
             )
         if index < len(relative.parts) - 1 and current.exists() and not current.is_dir():
             raise ContextOSError(
@@ -2662,9 +2663,10 @@ def _guard_local_state_path(root: Path, path: Path) -> None:
         raise ContextOSError(f"local state path escapes workspace: {path}") from exc
     for part in relative.parts:
         current /= part
-        if current.is_symlink():
+        if _is_link_like(current):
             raise ContextOSError(
-                f"local state path must not traverse a symlink: {relative.as_posix()}"
+                "local state path must not traverse a symlink or reparse point: "
+                f"{relative.as_posix()}"
             )
 
 
@@ -2698,7 +2700,8 @@ def _host_entry(value: Any, field: str) -> dict[str, str]:
 
 def _read_hosts_state(root: Path) -> dict[str, Any]:
     path = root / ".context-os" / "hosts.json"
-    if not path.exists() and not path.is_symlink():
+    _guard_local_state_path(root, path)
+    if not path.exists() and not _is_link_like(path):
         return {"schema_version": HOST_STATE_SCHEMA_VERSION, "hosts": {}}
     value = _local_json(path, root=root)
     if set(value) != {"schema_version", "hosts"}:
@@ -2730,7 +2733,8 @@ def _read_hosts_state(root: Path) -> dict[str, Any]:
 
 def _read_legacy_runtime_state(root: Path) -> tuple[str, dict[str, str]] | None:
     path = root / ".context-os" / "runtime.json"
-    if not path.exists() and not path.is_symlink():
+    _guard_local_state_path(root, path)
+    if not path.exists() and not _is_link_like(path):
         return None
     value = _local_json(path, root=root)
     allowed = {
@@ -2939,7 +2943,14 @@ def doctor(
         add("workspace-config", workspace_status, detail)
     except ContextOSError as exc:
         add("workspace-config", "fail", str(exc))
-        workspace = _workspace_from_paths(root, dict(DEFAULT_PATHS))
+        # Keep diagnostics total even when the default path itself is the
+        # malformed link that made workspace resolution fail.
+        workspace = Workspace(
+            root=root,
+            state_dir=root / DEFAULT_PATHS["state_dir"],
+            sessions_dir=root / DEFAULT_PATHS["sessions_dir"],
+            task_file=root / DEFAULT_PATHS["task_file"],
+        )
 
     # Provider-specific instruction files belong to their runtime components,
     # not the neutral core readiness gate.
@@ -2948,32 +2959,64 @@ def doctor(
         workspace.state_dir / "current-log.md",
         workspace.state_dir / "decisions.md",
     ]
-    for path in required_paths:
-        rel = relative_path(root, path)
-        add(f"file:{rel}", "pass" if path.exists() else "fail", rel)
-    initialized, initialization_files = _initialization_state(
-        workspace, effective_today
-    )
-    gate = relative_path(root, workspace.state_dir / INITIALIZATION_FILE)
-    add(
-        "initialization-state",
-        "pass" if initialized else "warn",
-        "ready"
-        if initialized
-        else f"guided setup required; {gate} carries no real **Last Updated:** date",
-    )
-    unresolved = [
-        path
-        for path, item in initialization_files.items()
-        if item["freshness_status"] in {"missing", "unknown", "future"}
+    freshness_paths = [
+        workspace.state_dir / filename for filename in STATE_THRESHOLDS
     ]
-    add(
-        "state-freshness",
-        "pass" if not unresolved else "warn",
-        "all tracked state files carry a real date"
-        if not unresolved
-        else f"no usable **Last Updated:** date in: {', '.join(unresolved)}",
-    )
+    state_path_errors: dict[Path, str] = {}
+    for path in dict.fromkeys([*required_paths, *freshness_paths]):
+        try:
+            _guard_local_state_path(root, path)
+        except ContextOSError as exc:
+            state_path_errors[path] = str(exc)
+    for path in required_paths:
+        rel = path.relative_to(root).as_posix()
+        error = state_path_errors.get(path)
+        add(
+            f"file:{rel}",
+            "fail" if error else "pass" if path.exists() else "fail",
+            error or rel,
+        )
+    unsafe_freshness = [
+        path.relative_to(root).as_posix()
+        for path in freshness_paths
+        if path in state_path_errors
+    ]
+    gate = (workspace.state_dir / INITIALIZATION_FILE).relative_to(root).as_posix()
+    if unsafe_freshness:
+        add(
+            "initialization-state",
+            "warn",
+            "guided setup required; unsafe state path(s): "
+            + ", ".join(unsafe_freshness),
+        )
+        add(
+            "state-freshness",
+            "warn",
+            "cannot inspect unsafe state path(s): " + ", ".join(unsafe_freshness),
+        )
+    else:
+        initialized, initialization_files = _initialization_state(
+            workspace, effective_today
+        )
+        add(
+            "initialization-state",
+            "pass" if initialized else "warn",
+            "ready"
+            if initialized
+            else f"guided setup required; {gate} carries no real **Last Updated:** date",
+        )
+        unresolved = [
+            path
+            for path, item in initialization_files.items()
+            if item["freshness_status"] in {"missing", "unknown", "future"}
+        ]
+        add(
+            "state-freshness",
+            "pass" if not unresolved else "warn",
+            "all tracked state files carry a real date"
+            if not unresolved
+            else f"no usable **Last Updated:** date in: {', '.join(unresolved)}",
+        )
 
     local_hosts = {"schema_version": HOST_STATE_SCHEMA_VERSION, "hosts": {}}
     local_hosts_valid = False
@@ -3369,6 +3412,7 @@ def doctor(
     )
     journals = root / ".context-os" / "journals"
     try:
+        _guard_local_state_path(root, journals)
         if _is_link_like(journals) or (journals.exists() and not journals.is_dir()):
             raise ContextOSError(f"invalid journal path: {journals}")
         pending_journals = list(journals.iterdir()) if journals.is_dir() else []
@@ -3389,22 +3433,27 @@ def doctor(
     except (ContextOSError, OSError) as exc:
         add("transaction-journals", "fail", str(exc))
     hosts_lock = root / ".context-os" / "hosts.lock"
-    add(
-        "host-state-lock",
-        "warn" if hosts_lock.exists() else "pass",
-        (
-            f"stale or active lock at {hosts_lock}; remove it only after confirming "
-            "no install or migration is running"
+    try:
+        _guard_local_state_path(root, hosts_lock)
+        add(
+            "host-state-lock",
+            "warn" if hosts_lock.exists() else "pass",
+            (
+                f"stale or active lock at {hosts_lock}; remove it only after confirming "
+                "no install or migration is running"
+            )
+            if hosts_lock.exists()
+            else "none",
         )
-        if hosts_lock.exists()
-        else "none",
-    )
+    except ContextOSError as exc:
+        add("host-state-lock", "fail", str(exc))
     cutoff = utc_now().timestamp() - (30 * 24 * 60 * 60)
     old_artifacts: list[Path] = []
     artifact_warnings: list[str] = []
     for folder in ("proposals", "receipts"):
         artifact_dir = root / ".context-os" / folder
         try:
+            _guard_local_state_path(root, artifact_dir)
             if _is_link_like(artifact_dir) or (
                 artifact_dir.exists() and not artifact_dir.is_dir()
             ):

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3232,6 +3232,8 @@ def doctor(
                         missing_paths
                         if scope == "maintainer-all"
                         else missing_by_policy["managed"]
+                        if scope in {"profile", "runtime"}
+                        else []
                     )
                     materialization_status = (
                         "fail"

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3157,6 +3157,11 @@ def doctor(
                     component_inventory, manifest["components"]
                 )
                 missing_paths: list[str] = []
+                missing_by_policy: dict[str, list[str]] = {
+                    "managed": [],
+                    "seed": [],
+                    "development": [],
+                }
                 present_count = 0
                 # Workspace paths have already passed lexical containment or
                 # come from the fixed diagnostic fallback. Do not resolve them
@@ -3196,16 +3201,19 @@ def doctor(
                             break
                     if traverses_link:
                         missing_paths.append(materialized_path)
+                        missing_by_policy[record["policy"]].append(materialized_path)
                         continue
                     try:
                         target = safe_repo_path(root, materialized_path)
                     except ContextOSError:
                         missing_paths.append(materialized_path)
+                        missing_by_policy[record["policy"]].append(materialized_path)
                         continue
                     if target.is_file() and not _is_link_like(target):
                         present_count += 1
                     else:
                         missing_paths.append(materialized_path)
+                        missing_by_policy[record["policy"]].append(materialized_path)
                 component_status = (
                     "materialized"
                     if not missing_paths
@@ -3217,12 +3225,17 @@ def doctor(
                     "status": component_status,
                     "closure": closure,
                     "missing_paths": missing_paths,
+                    "missing_by_policy": missing_by_policy,
                 }
                 if scoped:
+                    blocking_missing = (
+                        missing_paths
+                        if scope == "maintainer-all"
+                        else missing_by_policy["managed"]
+                    )
                     materialization_status = (
                         "fail"
-                        if component_status != "materialized"
-                        and scope in {"profile", "runtime", "maintainer-all"}
+                        if blocking_missing
                         else "warn"
                         if component_status != "materialized"
                         else "pass"
@@ -3326,7 +3339,7 @@ def doctor(
             evidence_age = (effective_today - checked_date).days
             evidence_status = (
                 "future"
-                if evidence_age < 0
+                if evidence_age < -1
                 else "stale"
                 if evidence_age > EVIDENCE_STALE_AFTER_DAYS
                 else "fresh"
@@ -3347,7 +3360,15 @@ def doctor(
             if evidence_report["status"] in {"stale", "future", "invalid"}:
                 add(
                     f"runtime-evidence:{runtime_id}",
-                    "warn" if evidence_report["status"] == "stale" else "fail",
+                    (
+                        "fail"
+                        if evidence_report["status"] == "invalid"
+                        or (
+                            evidence_report["status"] == "future"
+                            and scope == "maintainer-all"
+                        )
+                        else "warn"
+                    ),
                     f"{evidence_report['status']}; checked_on={evidence_report['checked_on']}",
                 )
 

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2973,7 +2973,7 @@ def doctor(
         error = state_path_errors.get(path)
         add(
             f"file:{rel}",
-            "fail" if error else "pass" if path.exists() else "fail",
+            "fail" if error else "pass" if path.exists() else "warn",
             error or rel,
         )
     unsafe_freshness = [
@@ -3437,11 +3437,15 @@ def doctor(
         )
 
     lock = root / ".context-os" / "apply.lock"
-    add(
-        "transaction-lock",
-        "warn" if lock.exists() else "pass",
-        str(lock) if lock.exists() else "none",
-    )
+    try:
+        _guard_local_state_path(root, lock)
+        add(
+            "transaction-lock",
+            "warn" if lock.exists() else "pass",
+            str(lock) if lock.exists() else "none",
+        )
+    except ContextOSError as exc:
+        add("transaction-lock", "fail", str(exc))
     journals = root / ".context-os" / "journals"
     try:
         _guard_local_state_path(root, journals)

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3135,12 +3135,22 @@ def doctor(
                                 break
                         if materialized_path == DEFAULT_PATHS["task_file"]:
                             materialized_path = relative_path(root, workspace.task_file)
+                    lexical_target = root
+                    traverses_link = False
+                    for part in PurePosixPath(materialized_path).parts:
+                        lexical_target /= part
+                        if _is_link_like(lexical_target):
+                            traverses_link = True
+                            break
+                    if traverses_link:
+                        missing_paths.append(materialized_path)
+                        continue
                     try:
                         target = safe_repo_path(root, materialized_path)
                     except ContextOSError:
                         missing_paths.append(materialized_path)
                         continue
-                    if target.is_file() and not target.is_symlink():
+                    if target.is_file() and not _is_link_like(target):
                         present_count += 1
                     else:
                         missing_paths.append(materialized_path)
@@ -3358,9 +3368,9 @@ def doctor(
         str(lock) if lock.exists() else "none",
     )
     journals = root / ".context-os" / "journals"
-    if journals.is_symlink() or (journals.exists() and not journals.is_dir()):
-        add("transaction-journals", "fail", f"invalid journal path: {journals}")
-    else:
+    try:
+        if _is_link_like(journals) or (journals.exists() and not journals.is_dir()):
+            raise ContextOSError(f"invalid journal path: {journals}")
         pending_journals = list(journals.iterdir()) if journals.is_dir() else []
         add(
             "transaction-journals",
@@ -3376,6 +3386,8 @@ def doctor(
             if pending_journals
             else "none",
         )
+    except (ContextOSError, OSError) as exc:
+        add("transaction-journals", "fail", str(exc))
     hosts_lock = root / ".context-os" / "hosts.lock"
     add(
         "host-state-lock",
@@ -3388,18 +3400,44 @@ def doctor(
         else "none",
     )
     cutoff = utc_now().timestamp() - (30 * 24 * 60 * 60)
-    old_artifacts = [
-        path
-        for folder in ("proposals", "receipts")
-        for path in (root / ".context-os" / folder).glob("*.json")
-        if path.stat().st_mtime < cutoff
-    ]
+    old_artifacts: list[Path] = []
+    artifact_warnings: list[str] = []
+    for folder in ("proposals", "receipts"):
+        artifact_dir = root / ".context-os" / folder
+        try:
+            if _is_link_like(artifact_dir) or (
+                artifact_dir.exists() and not artifact_dir.is_dir()
+            ):
+                artifact_warnings.append(f"invalid artifact directory: {folder}")
+                continue
+            candidates = list(artifact_dir.glob("*.json"))
+        except (ContextOSError, OSError) as exc:
+            artifact_warnings.append(f"cannot inspect {folder}: {exc}")
+            continue
+        for path in candidates:
+            try:
+                if _is_link_like(path):
+                    artifact_warnings.append(
+                        f"link-like artifact ignored: {folder}/{path.name}"
+                    )
+                elif path.is_file() and path.stat().st_mtime < cutoff:
+                    old_artifacts.append(path)
+            except (ContextOSError, OSError) as exc:
+                artifact_warnings.append(
+                    f"cannot inspect {folder}/{path.name}: {exc}"
+                )
+    retention_details = []
+    if old_artifacts:
+        retention_details.append(f"{len(old_artifacts)} artifacts older than 30 days")
+    if artifact_warnings:
+        retention_details.append(
+            f"{len(artifact_warnings)} invalid or unreadable artifact(s); "
+            + "; ".join(artifact_warnings[:3])
+        )
     add(
         "local-artifact-retention",
-        "warn" if old_artifacts else "pass",
-        f"{len(old_artifacts)} artifacts older than 30 days"
-        if old_artifacts
-        else "none older than 30 days",
+        "warn" if retention_details else "pass",
+        "; ".join(retention_details) if retention_details else "none older than 30 days",
     )
 
     status = (

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -23,6 +23,7 @@ from .component_schema import (
     component_owners,
     load_component_manifest,
     portable_path_identity,
+    resolved_component_paths,
     workspace_path_owner,
     write_generated_file,
 )
@@ -52,6 +53,7 @@ from .workspace_schema import (
 
 SCHEMA_VERSION = 1
 HOST_STATE_SCHEMA_VERSION = 1
+EVIDENCE_STALE_AFTER_DAYS = 90
 AGENT_LIFECYCLE_WORKFLOW = "agent-config"
 WORKSPACE_MIGRATION_OPERATION = "workspace-migrate"
 LOCAL_ARTIFACT_MODE = 0o600
@@ -2896,9 +2898,17 @@ def install_runtime(root: Path, runtime: str) -> tuple[Path, dict[str, Any]]:
 
 
 def doctor(
-    root: Path, runtime: str | None = None, *, all_runtimes: bool = False
+    root: Path,
+    runtime: str | None = None,
+    *,
+    all_runtimes: bool = False,
+    today: date | None = None,
 ) -> dict[str, Any]:
+    if runtime is not None and all_runtimes:
+        raise ContextOSError("doctor runtime selection and --all are mutually exclusive")
+
     checks: list[dict[str, str]] = []
+    effective_today = today or utc_now().date()
 
     def add(name: str, status: str, detail: str) -> None:
         checks.append({"name": name, "status": status, "detail": detail})
@@ -2906,9 +2916,16 @@ def doctor(
     git_location = shutil.which("git")
     add("command:git", "pass" if git_location else "fail", git_location or "not found")
     add("command:python", "pass", sys.executable)
+
+    workspace_source = "invalid"
+    configured_agents: tuple[str, ...] | None = None
+    workspace_valid = False
     try:
         workspace_resolution = resolve_workspace(root)
         workspace = workspace_resolution.workspace
+        workspace_source = workspace_resolution.source
+        configured_agents = workspace_resolution.agents
+        workspace_valid = True
         workspace_status = (
             "pass"
             if workspace_resolution.source == "json" and not workspace_resolution.notices
@@ -2923,22 +2940,31 @@ def doctor(
     except ContextOSError as exc:
         add("workspace-config", "fail", str(exc))
         workspace = _workspace_from_paths(root, dict(DEFAULT_PATHS))
+
+    # Provider-specific instruction files belong to their runtime components,
+    # not the neutral core readiness gate.
     required_paths = [
-        root / "AGENTS.md", workspace.state_dir / "current.md",
-        workspace.state_dir / "current-log.md", workspace.state_dir / "decisions.md",
+        workspace.state_dir / "current.md",
+        workspace.state_dir / "current-log.md",
+        workspace.state_dir / "decisions.md",
     ]
     for path in required_paths:
         rel = relative_path(root, path)
         add(f"file:{rel}", "pass" if path.exists() else "fail", rel)
-    initialized, initialization_files = _initialization_state(workspace, utc_now().date())
+    initialized, initialization_files = _initialization_state(
+        workspace, effective_today
+    )
     gate = relative_path(root, workspace.state_dir / INITIALIZATION_FILE)
     add(
         "initialization-state",
         "pass" if initialized else "warn",
-        "ready" if initialized else f"guided setup required; {gate} carries no real **Last Updated:** date",
+        "ready"
+        if initialized
+        else f"guided setup required; {gate} carries no real **Last Updated:** date",
     )
     unresolved = [
-        path for path, item in initialization_files.items()
+        path
+        for path, item in initialization_files.items()
         if item["freshness_status"] in {"missing", "unknown", "future"}
     ]
     add(
@@ -2948,35 +2974,389 @@ def doctor(
         if not unresolved
         else f"no usable **Last Updated:** date in: {', '.join(unresolved)}",
     )
-    selected = runtime
-    local_hosts: dict[str, Any] | None = None
+
+    local_hosts = {"schema_version": HOST_STATE_SCHEMA_VERSION, "hosts": {}}
+    local_hosts_valid = False
     legacy_runtime: str | None = None
     try:
         local_hosts, legacy_runtime = _hosts_with_legacy(root)
+        local_hosts_valid = True
         local_detail = f"{len(local_hosts['hosts'])} configured host(s)"
         if legacy_runtime is not None:
             local_detail += (
                 f"; legacy runtime.json for {legacy_runtime!r} is readable but retained; "
-                "run workspace migrate-local-runtime"
+                "run bash scripts/contextos.sh workspace migrate-local-runtime"
             )
         add("local-host-state", "warn" if legacy_runtime else "pass", local_detail)
     except ContextOSError as exc:
         add("local-host-state", "fail", str(exc))
-    if selected is None and local_hosts is not None:
+
+    try:
+        registry_ids = runtime_ids(root)
+    except ContextOSError as exc:
+        registry_ids = []
+        add("manifest-registry", "fail", str(exc))
+
+    if all_runtimes:
+        scope = "maintainer-all"
+        validation_ids = list(registry_ids)
+    elif runtime is not None:
+        scope = "runtime"
+        validation_ids = [runtime]
+    elif workspace_valid and configured_agents is not None:
+        scope = "profile"
+        validation_ids = list(configured_agents)
+    elif not workspace_valid:
+        scope = "invalid"
+        validation_ids = []
+    else:
+        scope = "legacy"
         configured_hosts = list(local_hosts["hosts"])
-        if len(configured_hosts) == 1:
-            selected = configured_hosts[0]
-    hosts = runtime_ids(root) if all_runtimes or not selected else [selected]
-    if not hosts:
-        add("manifest-registry", "fail", "no runtime descriptors found")
-    for host in hosts:
+        validation_ids = (
+            configured_hosts if len(configured_hosts) == 1 else list(registry_ids)
+        )
+
+    if not registry_ids and not (scope == "profile" and not validation_ids):
+        if not any(item["name"] == "manifest-registry" for item in checks):
+            add("manifest-registry", "fail", "no runtime descriptors found")
+    elif not any(item["name"] == "manifest-registry" for item in checks):
+        add(
+            "manifest-registry",
+            "pass",
+            f"{len(registry_ids)} shipped descriptor(s); {len(validation_ids)} in validation scope",
+        )
+
+    component_inventory: dict[str, Any] | None = None
+    try:
+        component_inventory = load_component_manifest(
+            root / "components" / "manifest.json", root=root, check_paths=False
+        )
+        add("component-inventory", "pass", "structurally valid")
+    except (ComponentManifestError, OSError, UnicodeError) as exc:
+        add("component-inventory", "fail", str(exc))
+
+    report_ids = (
+        [runtime]
+        if scope == "runtime" and runtime is not None
+        else list(registry_ids)
+        if scope == "maintainer-all"
+        else sorted(
+            set(registry_ids)
+            | set(configured_agents or ())
+            | set(local_hosts["hosts"])
+        )
+    )
+    validation_set = set(validation_ids)
+    runtime_reports: dict[str, Any] = {}
+    for runtime_id in report_ids:
+        if scope == "maintainer-all":
+            role = "maintainer"
+        elif scope == "runtime" and runtime_id == runtime:
+            role = "explicit"
+        elif configured_agents is not None:
+            role = "configured" if runtime_id in configured_agents else "inert"
+        elif runtime_id in local_hosts["hosts"]:
+            role = "legacy-local"
+        elif runtime_id in validation_set:
+            role = "legacy"
+        else:
+            role = "inert"
+        scoped = runtime_id in validation_set
+        configuration_status = (
+            "configured"
+            if configured_agents is not None and runtime_id in configured_agents
+            else "unconfigured"
+            if configured_agents is not None
+            else "unknown"
+        )
+
+        manifest: dict[str, Any] | None = None
+        manifest_error: str | None = None
         try:
-            manifest = runtime_manifest(root, host)
-            add(f"manifest:{host}", "pass", f"schema {manifest['schema_version']}")
+            manifest = runtime_manifest(root, runtime_id, check_paths=False)
+            if scoped:
+                add(
+                    f"manifest:{runtime_id}",
+                    "pass",
+                    f"schema {manifest['schema_version']}",
+                )
         except ContextOSError as exc:
-            add(f"manifest:{host}", "fail", str(exc))
+            manifest_error = str(exc)
+            if scoped:
+                add(f"manifest:{runtime_id}", "fail", manifest_error)
+
+        if manifest is not None and scope in {"runtime", "maintainer-all"}:
+            try:
+                validate_runtime_manifest(
+                    manifest,
+                    runtime_id=runtime_id,
+                    root=root,
+                    today=effective_today,
+                    check_paths=True,
+                )
+                add(f"runtime-paths:{runtime_id}", "pass", "referenced paths exist")
+            except (RuntimeManifestError, OSError, UnicodeError) as exc:
+                add(f"runtime-paths:{runtime_id}", "fail", str(exc))
+
+        component_report: dict[str, Any]
+        if manifest is None or component_inventory is None:
+            component_report = {
+                "status": "unknown",
+                "closure": [],
+                "missing_paths": [],
+            }
+        else:
+            try:
+                closure = component_closure(
+                    component_inventory, manifest["components"]
+                )
+                records = resolved_component_paths(
+                    component_inventory, manifest["components"]
+                )
+                missing_paths: list[str] = []
+                present_count = 0
+                for record in records:
+                    materialized_path = record["path"]
+                    if record["policy"] == "seed":
+                        seed_roots = (
+                            (DEFAULT_PATHS["state_dir"], relative_path(root, workspace.state_dir)),
+                            (
+                                DEFAULT_PATHS["sessions_dir"],
+                                relative_path(root, workspace.sessions_dir),
+                            ),
+                        )
+                        for default_root, effective_root in seed_roots:
+                            if materialized_path == default_root or materialized_path.startswith(
+                                default_root + "/"
+                            ):
+                                materialized_path = effective_root + materialized_path[
+                                    len(default_root) :
+                                ]
+                                break
+                        if materialized_path == DEFAULT_PATHS["task_file"]:
+                            materialized_path = relative_path(root, workspace.task_file)
+                    try:
+                        target = safe_repo_path(root, materialized_path)
+                    except ContextOSError:
+                        missing_paths.append(materialized_path)
+                        continue
+                    if target.is_file() and not target.is_symlink():
+                        present_count += 1
+                    else:
+                        missing_paths.append(materialized_path)
+                component_status = (
+                    "materialized"
+                    if not missing_paths
+                    else "absent"
+                    if present_count == 0
+                    else "partial"
+                )
+                component_report = {
+                    "status": component_status,
+                    "closure": closure,
+                    "missing_paths": missing_paths,
+                }
+                if scoped:
+                    materialization_status = (
+                        "fail"
+                        if component_status != "materialized"
+                        and scope in {"profile", "runtime", "maintainer-all"}
+                        else "warn"
+                        if component_status != "materialized"
+                        else "pass"
+                    )
+                    add(
+                        f"components:{runtime_id}",
+                        materialization_status,
+                        "materialized"
+                        if component_status == "materialized"
+                        else (
+                            f"{component_status}; {len(missing_paths)} missing; "
+                            f"first: {', '.join(missing_paths[:5])}"
+                        ),
+                    )
+            except (ComponentManifestError, ContextOSError) as exc:
+                component_report = {
+                    "status": "invalid",
+                    "closure": [],
+                    "missing_paths": [],
+                    "detail": str(exc),
+                }
+                if scoped:
+                    add(f"components:{runtime_id}", "fail", str(exc))
+
+        probe_reports: list[dict[str, Any]] = []
+        availability_results: list[bool] = []
+        conformance_tests: set[str] = set()
+        if manifest is not None:
+            for surface_id, surface in manifest["surfaces"].items():
+                conformance_tests.update(surface["conformance_tests"])
+                for probe in surface["binary_probes"]:
+                    locations = {
+                        candidate: shutil.which(candidate)
+                        for candidate in probe["candidates"]
+                    }
+                    resolved = any(locations.values())
+                    if probe["purpose"] == "availability":
+                        availability_results.append(resolved)
+                    probe_reports.append(
+                        {
+                            "surface": surface_id,
+                            "purpose": probe["purpose"],
+                            "candidates": locations,
+                            "resolved": resolved,
+                            "executed": False,
+                        }
+                    )
+                    if scoped:
+                        detail = "resolution only; not executed; " + ", ".join(
+                            f"{candidate}={location or 'not installed'}"
+                            for candidate, location in locations.items()
+                        )
+                        add(
+                            f"runtime:{runtime_id}:{surface_id}:{probe['purpose']}",
+                            "pass" if resolved else "warn",
+                            detail,
+                        )
+        availability_status = (
+            "available"
+            if availability_results and all(availability_results)
+            else "mixed"
+            if any(availability_results)
+            else "unavailable"
+            if availability_results
+            else "unknown"
+        )
+
+        host_entry = local_hosts["hosts"].get(runtime_id) if local_hosts_valid else None
+        onboarding_status = (
+            "unknown"
+            if not local_hosts_valid
+            else "configured"
+            if host_entry is not None
+            else "not-configured"
+        )
+        if not local_hosts_valid:
+            drift_status = "unknown"
+        elif host_entry is None:
+            drift_status = "not-recorded"
+        elif manifest is None:
+            drift_status = "unknown"
+        else:
+            expected_source = sha256_text(canonical_json(manifest))
+            drift_status = (
+                "current"
+                if host_entry["source_manifest_sha256"] == expected_source
+                else "drifted"
+            )
+
+        evidence = manifest.get("evidence") if manifest is not None else None
+        if evidence is None:
+            evidence_report = {
+                "status": "invalid",
+                "checked_on": None,
+                "age_days": None,
+                "stale_after_days": EVIDENCE_STALE_AFTER_DAYS,
+            }
+        else:
+            checked_on = evidence["checked_on"]
+            checked_date = date.fromisoformat(checked_on)
+            evidence_age = (effective_today - checked_date).days
+            evidence_status = (
+                "future"
+                if evidence_age < 0
+                else "stale"
+                if evidence_age > EVIDENCE_STALE_AFTER_DAYS
+                else "fresh"
+            )
+            evidence_report = {
+                "status": evidence_status,
+                "checked_on": checked_on,
+                "age_days": evidence_age,
+                "stale_after_days": EVIDENCE_STALE_AFTER_DAYS,
+            }
+
+        if scoped and manifest is not None:
+            add(
+                f"runtime-onboarding:{runtime_id}",
+                "pass" if onboarding_status == "configured" else "warn",
+                onboarding_status,
+            )
+            if evidence_report["status"] in {"stale", "future", "invalid"}:
+                add(
+                    f"runtime-evidence:{runtime_id}",
+                    "warn" if evidence_report["status"] == "stale" else "fail",
+                    f"{evidence_report['status']}; checked_on={evidence_report['checked_on']}",
+                )
+
+        runtime_reports[runtime_id] = {
+            "role": role,
+            "configuration": {
+                "status": configuration_status,
+                "inert": (
+                    configuration_status == "unconfigured"
+                    if configuration_status != "unknown"
+                    else None
+                ),
+                "validation_scope": scoped,
+            },
+            "support": {
+                "status": "supported" if manifest is not None else "invalid-descriptor",
+                "tier": manifest["support_tier"] if manifest is not None else None,
+                "summary": manifest["support_summary"] if manifest is not None else manifest_error,
+            },
+            "components": component_report,
+            "customization": {
+                "status": "not-verifiable",
+                "reason": "owned-file base hashes require the immutable bundle lock",
+            },
+            "local_availability": {
+                "status": availability_status,
+                "probes": probe_reports,
+            },
+            "local_onboarding": {
+                "status": onboarding_status,
+                "installed_at": host_entry["installed_at"] if host_entry else None,
+            },
+            "descriptor_drift": {"status": drift_status},
+            "conformance": {
+                "status": "declared" if manifest is not None else "invalid",
+                "tests": sorted(conformance_tests),
+                "executed": False,
+            },
+            "evidence": evidence_report,
+        }
+
+    drift_targets = [
+        runtime_id
+        for runtime_id in validation_ids
+        if runtime_id in local_hosts["hosts"]
+    ]
+    if scope == "legacy" and len(local_hosts["hosts"]) != 1:
+        drift_targets = list(local_hosts["hosts"])
+    for drift_runtime in drift_targets:
+        drift_name = (
+            "runtime-manifest-drift"
+            if len(drift_targets) == 1
+            else f"runtime-manifest-drift:{drift_runtime}"
+        )
+        drift_status = runtime_reports.get(drift_runtime, {}).get(
+            "descriptor_drift", {}
+        ).get("status", "unknown")
+        add(
+            drift_name,
+            "pass" if drift_status == "current" else "warn",
+            "current"
+            if drift_status == "current"
+            else "rerun bash scripts/contextos.sh install --runtime " + drift_runtime,
+        )
+
     lock = root / ".context-os" / "apply.lock"
-    add("transaction-lock", "warn" if lock.exists() else "pass", str(lock) if lock.exists() else "none")
+    add(
+        "transaction-lock",
+        "warn" if lock.exists() else "pass",
+        str(lock) if lock.exists() else "none",
+    )
     journals = root / ".context-os" / "journals"
     if journals.is_symlink() or (journals.exists() and not journals.is_dir()):
         add("transaction-journals", "fail", f"invalid journal path: {journals}")
@@ -3009,60 +3389,39 @@ def doctor(
     )
     cutoff = utc_now().timestamp() - (30 * 24 * 60 * 60)
     old_artifacts = [
-        path for folder in ("proposals", "receipts")
+        path
+        for folder in ("proposals", "receipts")
         for path in (root / ".context-os" / folder).glob("*.json")
         if path.stat().st_mtime < cutoff
     ]
     add(
-        "local-artifact-retention", "warn" if old_artifacts else "pass",
-        f"{len(old_artifacts)} artifacts older than 30 days" if old_artifacts else "none older than 30 days",
+        "local-artifact-retention",
+        "warn" if old_artifacts else "pass",
+        f"{len(old_artifacts)} artifacts older than 30 days"
+        if old_artifacts
+        else "none older than 30 days",
     )
-    drift_targets = (
-        [selected]
-        if selected
-        else list(local_hosts["hosts"])
-        if local_hosts is not None
-        else []
+
+    status = (
+        "fail"
+        if any(item["status"] == "fail" for item in checks)
+        else "warn"
+        if any(item["status"] == "warn" for item in checks)
+        else "pass"
     )
-    for drift_runtime in drift_targets:
-        drift_name = (
-            "runtime-manifest-drift"
-            if len(drift_targets) == 1
-            else f"runtime-manifest-drift:{drift_runtime}"
-        )
-        try:
-            drift_manifest = runtime_manifest(root, drift_runtime)
-            expected_source = sha256_text(canonical_json(drift_manifest))
-            if local_hosts is not None and drift_runtime in local_hosts["hosts"]:
-                recorded_source = local_hosts["hosts"][drift_runtime]["source_manifest_sha256"]
-                add(
-                    drift_name,
-                    "pass" if recorded_source == expected_source else "warn",
-                    "current" if recorded_source == expected_source else "rerun context-os install",
-                )
-        except ContextOSError as exc:
-            add(drift_name, "fail", str(exc))
-    if selected:
-        selected_manifest: dict[str, Any] | None = None
-        try:
-            selected_manifest = runtime_manifest(root, selected)
-        except ContextOSError:
-            selected_manifest = None
-        if selected_manifest:
-            for surface_id, surface in selected_manifest["surfaces"].items():
-                for probe in surface["binary_probes"]:
-                    locations = {
-                        candidate: shutil.which(candidate) for candidate in probe["candidates"]
-                    }
-                    executable = next((location for location in locations.values() if location), None)
-                    check_name = f"runtime:{selected}:{surface_id}:{probe['purpose']}"
-                    detail = ", ".join(
-                        f"{candidate}={location or 'not installed'}"
-                        for candidate, location in locations.items()
-                    )
-                    add(check_name, "pass" if executable else "warn", detail)
-    status = "fail" if any(item["status"] == "fail" for item in checks) else "warn" if any(item["status"] == "warn" for item in checks) else "pass"
-    return {"schema_version": SCHEMA_VERSION, "status": status, "checks": checks}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "scope": scope,
+        "workspace": {
+            "source": workspace_source,
+            "configured_agents": (
+                list(configured_agents) if configured_agents is not None else None
+            ),
+        },
+        "runtimes": runtime_reports,
+        "checks": checks,
+    }
 
 
 def _hook_targets(payload: dict[str, Any]) -> set[str]:

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2908,6 +2908,7 @@ def doctor(
     all_runtimes: bool = False,
     today: date | None = None,
 ) -> dict[str, Any]:
+    root = root.resolve()
     if runtime is not None and all_runtimes:
         raise ContextOSError("doctor runtime selection and --all are mutually exclusive")
 
@@ -3077,6 +3078,40 @@ def doctor(
         add("component-inventory", "pass", "structurally valid")
     except (ComponentManifestError, OSError, UnicodeError) as exc:
         add("component-inventory", "fail", str(exc))
+
+    if scope == "profile" and not validation_ids and component_inventory is not None:
+        missing_managed: list[str] = []
+        for record in resolved_component_paths(component_inventory, ["core"]):
+            if record["policy"] != "managed":
+                continue
+            materialized_path = record["path"]
+            lexical_target = root
+            traverses_link = False
+            for part in PurePosixPath(materialized_path).parts:
+                lexical_target /= part
+                if _is_link_like(lexical_target):
+                    traverses_link = True
+                    break
+            if traverses_link:
+                missing_managed.append(materialized_path)
+                continue
+            try:
+                target = safe_repo_path(root, materialized_path)
+            except ContextOSError:
+                missing_managed.append(materialized_path)
+                continue
+            if not target.is_file() or _is_link_like(target):
+                missing_managed.append(materialized_path)
+        add(
+            "components:core",
+            "fail" if missing_managed else "pass",
+            (
+                f"{len(missing_managed)} managed path(s) missing or unsafe: "
+                + ", ".join(missing_managed[:3])
+            )
+            if missing_managed
+            else "managed core materialized",
+        )
 
     report_ids = (
         [runtime]
@@ -3486,6 +3521,7 @@ def doctor(
     cutoff = utc_now().timestamp() - (30 * 24 * 60 * 60)
     old_artifacts: list[Path] = []
     artifact_warnings: list[str] = []
+    artifact_directory_failures: list[str] = []
     for folder in ("proposals", "receipts"):
         artifact_dir = root / ".context-os" / folder
         try:
@@ -3493,11 +3529,13 @@ def doctor(
             if _is_link_like(artifact_dir) or (
                 artifact_dir.exists() and not artifact_dir.is_dir()
             ):
-                artifact_warnings.append(f"invalid artifact directory: {folder}")
+                artifact_directory_failures.append(
+                    f"invalid artifact directory: {folder}"
+                )
                 continue
             candidates = list(artifact_dir.glob("*.json"))
         except (ContextOSError, OSError) as exc:
-            artifact_warnings.append(f"cannot inspect {folder}: {exc}")
+            artifact_directory_failures.append(f"cannot inspect {folder}: {exc}")
             continue
         for path in candidates:
             try:
@@ -3519,9 +3557,15 @@ def doctor(
             f"{len(artifact_warnings)} invalid or unreadable artifact(s); "
             + "; ".join(artifact_warnings[:3])
         )
+    if artifact_directory_failures:
+        retention_details.append("; ".join(artifact_directory_failures[:2]))
     add(
         "local-artifact-retention",
-        "warn" if retention_details else "pass",
+        "fail"
+        if artifact_directory_failures
+        else "warn"
+        if retention_details
+        else "pass",
         "; ".join(retention_details) if retention_details else "none older than 30 days",
     )
 

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3158,14 +3158,23 @@ def doctor(
                 )
                 missing_paths: list[str] = []
                 present_count = 0
+                # Workspace paths have already passed lexical containment or
+                # come from the fixed diagnostic fallback. Do not resolve them
+                # here: resolution would follow the malformed link doctor is
+                # trying to report and could escape before the link scan below.
+                effective_state_root = workspace.state_dir.relative_to(root).as_posix()
+                effective_sessions_root = (
+                    workspace.sessions_dir.relative_to(root).as_posix()
+                )
+                effective_task_file = workspace.task_file.relative_to(root).as_posix()
                 for record in records:
                     materialized_path = record["path"]
                     if record["policy"] == "seed":
                         seed_roots = (
-                            (DEFAULT_PATHS["state_dir"], relative_path(root, workspace.state_dir)),
+                            (DEFAULT_PATHS["state_dir"], effective_state_root),
                             (
                                 DEFAULT_PATHS["sessions_dir"],
-                                relative_path(root, workspace.sessions_dir),
+                                effective_sessions_root,
                             ),
                         )
                         for default_root, effective_root in seed_roots:
@@ -3177,7 +3186,7 @@ def doctor(
                                 ]
                                 break
                         if materialized_path == DEFAULT_PATHS["task_file"]:
-                            materialized_path = relative_path(root, workspace.task_file)
+                            materialized_path = effective_task_file
                     lexical_target = root
                     traverses_link = False
                     for part in PurePosixPath(materialized_path).parts:

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3080,38 +3080,41 @@ def doctor(
         add("component-inventory", "fail", str(exc))
 
     if scope == "profile" and not validation_ids and component_inventory is not None:
-        missing_managed: list[str] = []
-        for record in resolved_component_paths(component_inventory, ["core"]):
-            if record["policy"] != "managed":
-                continue
-            materialized_path = record["path"]
-            lexical_target = root
-            traverses_link = False
-            for part in PurePosixPath(materialized_path).parts:
-                lexical_target /= part
-                if _is_link_like(lexical_target):
-                    traverses_link = True
-                    break
-            if traverses_link:
-                missing_managed.append(materialized_path)
-                continue
-            try:
-                target = safe_repo_path(root, materialized_path)
-            except ContextOSError:
-                missing_managed.append(materialized_path)
-                continue
-            if not target.is_file() or _is_link_like(target):
-                missing_managed.append(materialized_path)
-        add(
-            "components:core",
-            "fail" if missing_managed else "pass",
-            (
-                f"{len(missing_managed)} managed path(s) missing or unsafe: "
-                + ", ".join(missing_managed[:3])
+        try:
+            missing_managed: list[str] = []
+            for record in resolved_component_paths(component_inventory, ["core"]):
+                if record["policy"] != "managed":
+                    continue
+                materialized_path = record["path"]
+                lexical_target = root
+                traverses_link = False
+                for part in PurePosixPath(materialized_path).parts:
+                    lexical_target /= part
+                    if _is_link_like(lexical_target):
+                        traverses_link = True
+                        break
+                if traverses_link:
+                    missing_managed.append(materialized_path)
+                    continue
+                try:
+                    target = safe_repo_path(root, materialized_path)
+                except ContextOSError:
+                    missing_managed.append(materialized_path)
+                    continue
+                if not target.is_file() or _is_link_like(target):
+                    missing_managed.append(materialized_path)
+            add(
+                "components:core",
+                "fail" if missing_managed else "pass",
+                (
+                    f"{len(missing_managed)} managed path(s) missing or unsafe: "
+                    + ", ".join(missing_managed[:3])
+                )
+                if missing_managed
+                else "managed core materialized",
             )
-            if missing_managed
-            else "managed core materialized",
-        )
+        except (ComponentManifestError, ContextOSError, OSError) as exc:
+            add("components:core", "fail", str(exc))
 
     report_ids = (
         [runtime]
@@ -3189,7 +3192,9 @@ def doctor(
                     component_inventory, manifest["components"]
                 )
                 records = resolved_component_paths(
-                    component_inventory, manifest["components"]
+                    component_inventory,
+                    manifest["components"],
+                    include_development=scope == "maintainer-all",
                 )
                 missing_paths: list[str] = []
                 missing_by_policy: dict[str, list[str]] = {

--- a/contextos/runtime_schema.py
+++ b/contextos/runtime_schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 from urllib.parse import urlparse
@@ -182,8 +182,8 @@ def validate_runtime_manifest(
         checked_date = date.fromisoformat(checked_on)
     except ValueError:
         _fail("evidence.checked_on", "must be an ISO-8601 date")
-    if check_paths and checked_date > (today or date.today()):
-        _fail("evidence.checked_on", "must not be in the future")
+    if check_paths and checked_date > (today or date.today()) + timedelta(days=1):
+        _fail("evidence.checked_on", "must not be more than one day in the future")
 
     sources = evidence.get("sources")
     if not isinstance(sources, list) or not sources:

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -94,9 +94,7 @@ Before a later command may materialize a selected component set, it must also:
    evidence behave in a slim workspace; and
 8. validate the resulting selected runtime closure without assuming every
    adapter or the development test tree is present;
-9. remove the remaining unconditional `AGENTS.md` doctor requirement before a
-   Claude-only closure can omit the `agents-instructions` component; and
-10. make shared instruction and documentation links closure-aware so a slim
+9. make shared instruction and documentation links closure-aware so a slim
     workspace neither points at omitted adapter docs nor describes hooks that
     were not selected.
 

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -98,6 +98,20 @@ listed executable candidates with `PATH`, but runtime descriptors cannot supply
 arguments or cause a process to execute. Native diagnostic execution requires a
 separate code-owned trust policy.
 
+Bare `doctor` follows tracked `agents` when `contextos.workspace.json` exists.
+Shipped but unselected adapters remain visible as inert and cannot make that
+profile fail. Without tracked JSON, the legacy compatibility scope remains: one
+locally onboarded host narrows the check, while zero or multiple hosts inspect
+the registry. `doctor --runtime ID` explicitly inspects one runtime and
+`doctor --all` applies the strict maintainer scope to every shipped descriptor.
+
+The report keeps separate facts separate: declared support, selected-component
+materialization, customization (not verifiable until immutable bundle hashes
+exist), local executable availability, local onboarding, descriptor drift,
+declared conformance, and evidence freshness. A missing binary is unavailable,
+not unsupported. Declared conformance is not reported as executed, and binary
+resolution never launches the candidate.
+
 ## Conformance policy
 
 Every lifecycle mutation needs:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,6 +115,12 @@ git diff --check
 git status --short
 ```
 
+With tracked workspace configuration, bare `doctor` validates the selected
+agent set and reports the other shipped adapters as inert. Missing local
+binaries warn without changing support claims. Use `doctor --runtime ID` for a
+strict one-runtime inspection and reserve `doctor --all` for maintainers
+checking every shipped adapter.
+
 Commit and push only after the diff matches what you intend to preserve.
 
 ## Run the daily loop

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -38,8 +38,8 @@ means core-only. The CLI token `none` maps to that empty set but is never stored
 intent. `generic` is reserved for operation receipts and is not a runtime ID.
 
 Version 1 intentionally uses only `full-template`. Selecting agents records
-intent; set-aware validation scope and removal of unselected adapters are later
-transaction-backed work.
+intent and controls bare `doctor` validation scope. Removal of unselected
+adapters remains later transaction-backed work.
 
 The public template ships `workspace/example.json` with `agents: []`, but no
 live root configuration. This avoids overriding an existing clone's legacy YAML
@@ -157,6 +157,13 @@ preserves an unchanged runtime's original timestamp.
 Host-state writes use `.context-os/hosts.lock`. A crash can leave that lock
 behind; `doctor` warns with recovery guidance. Remove it only after confirming
 that no install or migration process is still running.
+
+Local host records never activate a tracked runtime. Bare `doctor` validates
+the JSON `agents` set, reports unselected shipped adapters as inert, and treats
+availability, onboarding, descriptor drift, component materialization,
+conformance declarations, and evidence freshness as independent dimensions.
+An empty `agents` array is therefore a real core-only profile, even when a host
+has additional runtimes installed locally.
 
 ## Setup compatibility contract
 

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -9,7 +9,7 @@ import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 from contextos.kernel import (
@@ -27,6 +27,7 @@ from contextos.kernel import (
     sha256_text,
     start_report,
 )
+from contextos.component_schema import load_component_manifest, resolved_component_paths
 from contextos.workspace_schema import render_workspace_config
 
 
@@ -356,6 +357,23 @@ class KernelTest(unittest.TestCase):
                 f"# {filename}\n\n**Last Updated:** [DATE]\n",
                 encoding="utf-8",
             )
+
+    def _configure_profile(self, *agents: str) -> None:
+        (self.root / "contextos.workspace.json").write_text(
+            root_config(agents=list(agents)), encoding="utf-8"
+        )
+
+    def _materialize_components(self, *component_ids: str) -> None:
+        manifest = load_component_manifest(
+            ROOT / "components" / "manifest.json", root=ROOT, check_paths=False
+        )
+        for record in resolved_component_paths(manifest, component_ids):
+            source = ROOT / record["path"]
+            target = self.root / record["path"]
+            if target.exists():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, target)
 
     def test_update_propose_apply_writes_receipt_and_history_once(self) -> None:
         current = (
@@ -690,6 +708,7 @@ class KernelTest(unittest.TestCase):
             self.assertEqual(1, content.count("**Last Updated:**"))
         self.assertTrue(start_report(self.root, NOW)["initialized"])
     def test_install_and_doctor_are_machine_local(self) -> None:
+        self._materialize_components("hermes-adapter")
         target, installed = install_runtime(self.root, "hermes")
         self.assertEqual(self.root / ".context-os/hosts.json", target)
         self.assertEqual("hermes", installed["runtime"])
@@ -824,6 +843,12 @@ class KernelTest(unittest.TestCase):
         report = doctor(self.root)
         check = next(item for item in report["checks"] if item["name"] == "local-host-state")
         self.assertEqual("fail", check["status"])
+        self.assertTrue(
+            all(
+                runtime["local_onboarding"]["status"] == "unknown"
+                for runtime in report["runtimes"].values()
+            )
+        )
 
     def test_local_host_write_failure_preserves_previous_bytes(self) -> None:
         local = self.root / ".context-os"
@@ -858,6 +883,7 @@ class KernelTest(unittest.TestCase):
         self.assertFalse((outside / "hosts.json").exists())
 
     def test_doctor_uses_configured_state_and_selected_manifest_only(self) -> None:
+        self._materialize_components("hermes-adapter")
         custom = self.root / "custom-state"
         (self.root / "state").rename(custom)
         (self.root / "workspace.yaml").write_text("state_dir: custom-state\n", encoding="utf-8")
@@ -865,6 +891,135 @@ class KernelTest(unittest.TestCase):
         report = doctor(self.root, "hermes")
         self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
         self.assertTrue(any(item["name"] == "file:custom-state/current.md" for item in report["checks"]))
+        self.assertEqual(["hermes"], list(report["runtimes"]))
+
+    def test_empty_profile_keeps_every_shipped_runtime_inert(self) -> None:
+        self._configure_profile()
+        manifest = json.loads(
+            (self.root / "runtimes/claude.json").read_text(encoding="utf-8")
+        )
+        manifest["unknown"] = True
+        (self.root / "runtimes/claude.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+        report = doctor(self.root)
+
+        self.assertEqual("profile", report["scope"])
+        self.assertEqual([], report["workspace"]["configured_agents"])
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
+        self.assertEqual("invalid-descriptor", report["runtimes"]["claude"]["support"]["status"])
+        self.assertEqual(
+            {
+                "status": "unconfigured",
+                "inert": True,
+                "validation_scope": False,
+            },
+            report["runtimes"]["claude"]["configuration"],
+        )
+
+    def test_profile_scope_comes_from_tracked_agents_not_local_hosts(self) -> None:
+        self._materialize_components("hermes-adapter")
+        install_runtime(self.root, "codex")
+        self._configure_profile("hermes")
+        manifest = json.loads(
+            (self.root / "runtimes/codex.json").read_text(encoding="utf-8")
+        )
+        manifest["unknown"] = True
+        (self.root / "runtimes/codex.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+        report = doctor(self.root)
+        names = {item["name"] for item in report["checks"]}
+
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
+        self.assertIn("manifest:hermes", names)
+        self.assertNotIn("manifest:codex", names)
+        self.assertTrue(report["runtimes"]["codex"]["configuration"]["inert"])
+        self.assertEqual(
+            "configured", report["runtimes"]["codex"]["local_onboarding"]["status"]
+        )
+
+    def test_profile_materialization_blocks_only_configured_adapters(self) -> None:
+        self._materialize_components("claude-adapter", "codex-adapter")
+        (self.root / ".codex/hooks.json").unlink()
+        self._configure_profile("codex")
+
+        configured = doctor(self.root)
+        check = next(
+            item for item in configured["checks"] if item["name"] == "components:codex"
+        )
+        self.assertEqual("fail", check["status"])
+
+        self._configure_profile("claude")
+        inert = doctor(self.root)
+        self.assertFalse(any(item["status"] == "fail" for item in inert["checks"]))
+        self.assertEqual("partial", inert["runtimes"]["codex"]["components"]["status"])
+
+    def test_availability_is_independent_from_support_and_onboarding(self) -> None:
+        self._materialize_components("hermes-adapter")
+        self._configure_profile("hermes")
+        with mock.patch(
+            "contextos.kernel.shutil.which",
+            side_effect=lambda command: "git-path" if command == "git" else None,
+        ):
+            report = doctor(self.root)
+        runtime = report["runtimes"]["hermes"]
+        self.assertEqual("supported", runtime["support"]["status"])
+        self.assertEqual("unavailable", runtime["local_availability"]["status"])
+        self.assertEqual("not-configured", runtime["local_onboarding"]["status"])
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
+
+    def test_evidence_freshness_boundary_is_deterministic(self) -> None:
+        self._materialize_components("hermes-adapter")
+        self._configure_profile("hermes")
+        path = self.root / "runtimes/hermes.json"
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        manifest["evidence"]["checked_on"] = "2026-05-27"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        fresh = doctor(self.root, today=date(2026, 8, 25))["runtimes"]["hermes"]["evidence"]
+        self.assertEqual(("fresh", 90, 90), (fresh["status"], fresh["age_days"], fresh["stale_after_days"]))
+
+        manifest["evidence"]["checked_on"] = "2026-05-26"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        stale_report = doctor(self.root, today=date(2026, 8, 25))
+        stale = stale_report["runtimes"]["hermes"]["evidence"]
+        self.assertEqual(("stale", 91), (stale["status"], stale["age_days"]))
+        self.assertEqual(
+            "warn",
+            next(
+                item
+                for item in stale_report["checks"]
+                if item["name"] == "runtime-evidence:hermes"
+            )["status"],
+        )
+
+    def test_agents_instruction_is_required_only_by_selected_closure(self) -> None:
+        self._materialize_components("claude-adapter", "hermes-adapter")
+        (self.root / "AGENTS.md").unlink()
+        self._configure_profile("claude")
+        claude = doctor(self.root)
+        self.assertFalse(any(item["status"] == "fail" for item in claude["checks"]))
+        self.assertNotIn("file:AGENTS.md", {item["name"] for item in claude["checks"]})
+
+        self._configure_profile("hermes")
+        hermes = doctor(self.root)
+        check = next(
+            item for item in hermes["checks"] if item["name"] == "components:hermes"
+        )
+        self.assertEqual("fail", check["status"])
+
+    def test_all_scope_reports_only_shipped_registry_runtimes(self) -> None:
+        install_runtime(self.root, "hermes")
+        hosts_path = self.root / ".context-os/hosts.json"
+        hosts = json.loads(hosts_path.read_text(encoding="utf-8"))
+        hosts["hosts"]["orphan"] = dict(hosts["hosts"]["hermes"])
+        hosts_path.write_text(json.dumps(hosts), encoding="utf-8")
+
+        report = doctor(self.root, all_runtimes=True)
+        self.assertEqual({"claude", "codex", "hermes"}, set(report["runtimes"]))
 
     def test_bare_doctor_validates_all_manifests_during_setup(self) -> None:
         manifest = json.loads((self.root / "runtimes/claude.json").read_text(encoding="utf-8"))
@@ -921,6 +1076,7 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("fail", check["status"])
 
     def test_doctor_handles_runtime_without_a_cli_surface(self) -> None:
+        self._materialize_components("hermes-adapter")
         path = self.root / "runtimes/hermes.json"
         manifest = json.loads(path.read_text(encoding="utf-8"))
         cloud = manifest["surfaces"].pop("cli")
@@ -944,6 +1100,7 @@ class KernelTest(unittest.TestCase):
         )
 
     def test_doctor_never_executes_descriptor_probe_commands(self) -> None:
+        self._materialize_components("hermes-adapter")
         with mock.patch("contextos.kernel.shutil.which", return_value="resolved-command"), mock.patch(
             "contextos.kernel.subprocess.run",
             side_effect=AssertionError("descriptor probe executed a process"),

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -957,6 +957,39 @@ class KernelTest(unittest.TestCase):
         self.assertFalse(any(item["status"] == "fail" for item in inert["checks"]))
         self.assertEqual("partial", inert["runtimes"]["codex"]["components"]["status"])
 
+    def test_profile_missing_user_owned_seed_warns_but_managed_path_still_fails(self) -> None:
+        self._materialize_components("hermes-adapter")
+        self._configure_profile("hermes")
+        (self.root / "content/log.md").unlink()
+
+        seed_report = doctor(self.root)
+        seed_check = next(
+            item
+            for item in seed_report["checks"]
+            if item["name"] == "components:hermes"
+        )
+        self.assertEqual("warn", seed_check["status"])
+        self.assertFalse(any(item["status"] == "fail" for item in seed_report["checks"]))
+        self.assertIn(
+            "content/log.md",
+            seed_report["runtimes"]["hermes"]["components"]["missing_by_policy"]["seed"],
+        )
+        maintainer_check = next(
+            item
+            for item in doctor(self.root, all_runtimes=True)["checks"]
+            if item["name"] == "components:hermes"
+        )
+        self.assertEqual("fail", maintainer_check["status"])
+
+        (self.root / "AGENTS.md").unlink()
+        managed_report = doctor(self.root)
+        managed_check = next(
+            item
+            for item in managed_report["checks"]
+            if item["name"] == "components:hermes"
+        )
+        self.assertEqual("fail", managed_check["status"])
+
     def test_availability_is_independent_from_support_and_onboarding(self) -> None:
         self._materialize_components("hermes-adapter")
         self._configure_profile("hermes")
@@ -992,6 +1025,25 @@ class KernelTest(unittest.TestCase):
             next(
                 item
                 for item in stale_report["checks"]
+                if item["name"] == "runtime-evidence:hermes"
+            )["status"],
+        )
+
+        manifest["evidence"]["checked_on"] = "2026-08-26"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        skew_report = doctor(self.root, today=date(2026, 8, 25))
+        skew = skew_report["runtimes"]["hermes"]["evidence"]
+        self.assertEqual(("fresh", -1), (skew["status"], skew["age_days"]))
+        self.assertFalse(any(item["status"] == "fail" for item in skew_report["checks"]))
+
+        future_report = doctor(self.root, today=date(2026, 8, 24))
+        future = future_report["runtimes"]["hermes"]["evidence"]
+        self.assertEqual(("future", -2), (future["status"], future["age_days"]))
+        self.assertEqual(
+            "warn",
+            next(
+                item
+                for item in future_report["checks"]
                 if item["name"] == "runtime-evidence:hermes"
             )["status"],
         )

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -894,6 +894,7 @@ class KernelTest(unittest.TestCase):
         self.assertEqual(["hermes"], list(report["runtimes"]))
 
     def test_empty_profile_keeps_every_shipped_runtime_inert(self) -> None:
+        self._materialize_components("core")
         self._configure_profile()
         manifest = json.loads(
             (self.root / "runtimes/claude.json").read_text(encoding="utf-8")
@@ -1184,6 +1185,45 @@ class KernelTest(unittest.TestCase):
         )
         self.assertEqual("warn", check["status"])
         self.assertIn("link-like artifact ignored", check["detail"])
+
+    def test_doctor_fails_closed_on_linked_artifact_directory(self) -> None:
+        outside = Path(self.temp.name) / "outside-proposals"
+        outside.mkdir()
+        proposals = self.root / ".context-os/proposals"
+        proposals.parent.mkdir(parents=True, exist_ok=True)
+        if not make_directory_link(proposals, outside):
+            self.skipTest("directory link creation is unavailable")
+        try:
+            report = doctor(self.root)
+        finally:
+            proposals.rmdir() if os.name == "nt" else proposals.unlink()
+        check = next(
+            item
+            for item in report["checks"]
+            if item["name"] == "local-artifact-retention"
+        )
+        self.assertEqual("fail", check["status"])
+        self.assertIn("cannot inspect proposals", check["detail"])
+
+    def test_core_only_profile_checks_managed_core_materialization(self) -> None:
+        self._materialize_components("core")
+        self._configure_profile()
+        (self.root / "docs/getting-started.md").unlink()
+
+        report = doctor(self.root)
+
+        check = next(
+            item for item in report["checks"] if item["name"] == "components:core"
+        )
+        self.assertEqual("fail", check["status"])
+        self.assertIn("docs/getting-started.md", check["detail"])
+
+    def test_doctor_normalizes_an_unresolved_root(self) -> None:
+        unresolved = self.root / "nested" / ".."
+
+        report = doctor(unresolved)
+
+        self.assertIn(report["status"], {"pass", "warn"})
 
     def test_doctor_reports_linked_state_file_without_crashing(self) -> None:
         with tempfile.TemporaryDirectory() as external:

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1092,8 +1092,14 @@ class KernelTest(unittest.TestCase):
         )
         report = doctor(self.root)
         names = {item["name"] for item in report["checks"]}
+        self.assertEqual("legacy", report["scope"])
         self.assertIn("manifest:hermes", names)
         self.assertNotIn("manifest:claude", names)
+        components = next(
+            item for item in report["checks"] if item["name"] == "components:hermes"
+        )
+        self.assertEqual("warn", components["status"])
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
 
     def test_bare_doctor_checks_drift_for_every_installed_host(self) -> None:
         install_runtime(self.root, "hermes")

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -990,6 +990,26 @@ class KernelTest(unittest.TestCase):
         )
         self.assertEqual("fail", managed_check["status"])
 
+    def test_profile_missing_core_state_seed_warns_without_failing(self) -> None:
+        self._materialize_components("hermes-adapter")
+        self._configure_profile("hermes")
+        (self.root / "state/current.md").unlink()
+
+        report = doctor(self.root)
+        file_check = next(
+            item
+            for item in report["checks"]
+            if item["name"] == "file:state/current.md"
+        )
+        component_check = next(
+            item
+            for item in report["checks"]
+            if item["name"] == "components:hermes"
+        )
+        self.assertEqual("warn", file_check["status"])
+        self.assertEqual("warn", component_check["status"])
+        self.assertFalse(any(item["status"] == "fail" for item in report["checks"]))
+
     def test_availability_is_independent_from_support_and_onboarding(self) -> None:
         self._materialize_components("hermes-adapter")
         self._configure_profile("hermes")
@@ -1126,6 +1146,26 @@ class KernelTest(unittest.TestCase):
         )
         self.assertEqual("warn", check["status"])
         self.assertIn("confirming no install or migration is running", check["detail"])
+
+    def test_doctor_fails_closed_on_linked_apply_lock(self) -> None:
+        local = self.root / ".context-os"
+        local.mkdir()
+        lock = local / "apply.lock"
+        with tempfile.TemporaryDirectory() as external:
+            try:
+                make_directory_link(lock, Path(external))
+            except OSError:
+                self.skipTest("directory link creation is unavailable")
+            try:
+                report = doctor(self.root)
+            finally:
+                lock.rmdir() if os.name == "nt" else lock.unlink()
+
+        check = next(
+            item for item in report["checks"] if item["name"] == "transaction-lock"
+        )
+        self.assertEqual("fail", check["status"])
+        self.assertIn("symlink or reparse point", check["detail"])
 
     def test_doctor_reports_dangling_local_artifact_link_without_crashing(self) -> None:
         proposals = self.root / ".context-os/proposals"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1218,6 +1218,26 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("fail", check["status"])
         self.assertIn("docs/getting-started.md", check["detail"])
 
+    def test_core_only_profile_reports_shadowed_directory_as_a_failure(self) -> None:
+        self._materialize_components("core")
+        self._configure_profile()
+        shutil.rmtree(self.root / "docs")
+        (self.root / "docs").write_text("not a directory\n", encoding="utf-8")
+
+        report = doctor(self.root)
+
+        check = next(
+            item for item in report["checks"] if item["name"] == "components:core"
+        )
+        self.assertEqual("fail", check["status"])
+        self.assertEqual("fail", report["status"])
+
+    def test_maintainer_scope_includes_development_component_paths(self) -> None:
+        report = doctor(self.root, all_runtimes=True)
+
+        missing = report["runtimes"]["claude"]["components"]["missing_by_policy"]
+        self.assertIn("CONTRIBUTING.md", missing["development"])
+
     def test_doctor_normalizes_an_unresolved_root(self) -> None:
         unresolved = self.root / "nested" / ".."
 

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1069,6 +1069,24 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("warn", check["status"])
         self.assertIn("confirming no install or migration is running", check["detail"])
 
+    def test_doctor_reports_dangling_local_artifact_link_without_crashing(self) -> None:
+        proposals = self.root / ".context-os/proposals"
+        proposals.mkdir(parents=True)
+        artifact = proposals / "dangling.json"
+        try:
+            artifact.symlink_to(self.root / "missing-artifact.json")
+        except OSError:
+            self.skipTest("symlink creation is unavailable")
+
+        report = doctor(self.root)
+        check = next(
+            item
+            for item in report["checks"]
+            if item["name"] == "local-artifact-retention"
+        )
+        self.assertEqual("warn", check["status"])
+        self.assertIn("link-like artifact ignored", check["detail"])
+
     def test_bare_doctor_fails_when_registry_is_empty(self) -> None:
         shutil.rmtree(self.root / "runtimes")
         report = doctor(self.root)

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1087,6 +1087,58 @@ class KernelTest(unittest.TestCase):
         self.assertEqual("warn", check["status"])
         self.assertIn("link-like artifact ignored", check["detail"])
 
+    def test_doctor_reports_linked_state_file_without_crashing(self) -> None:
+        outside = self.root / "outside-current.md"
+        outside.write_text("# external\n", encoding="utf-8")
+        current = self.root / "state/current.md"
+        current.unlink()
+        try:
+            current.symlink_to(outside)
+        except OSError:
+            self.skipTest("symlink creation is unavailable")
+
+        report = doctor(self.root)
+        check = next(
+            item for item in report["checks"] if item["name"] == "file:state/current.md"
+        )
+        self.assertEqual("fail", check["status"])
+        self.assertIn("symlink or reparse point", check["detail"])
+
+    def test_doctor_reports_linked_state_directory_without_crashing(self) -> None:
+        outside = self.root / "outside-state"
+        (self.root / "state").rename(outside)
+        state = self.root / "state"
+        try:
+            state.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            outside.rename(state)
+            self.skipTest("directory symlink creation is unavailable")
+
+        report = doctor(self.root)
+        self.assertEqual("fail", report["status"])
+        self.assertEqual("invalid", report["scope"])
+        self.assertTrue(
+            any(
+                "symlink or reparse point" in item["detail"]
+                for item in report["checks"]
+            )
+        )
+
+    def test_doctor_fails_closed_on_linked_local_state_root(self) -> None:
+        outside = self.root / "outside-context-os"
+        outside.mkdir()
+        local = self.root / ".context-os"
+        try:
+            local.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            self.skipTest("directory symlink creation is unavailable")
+
+        report = doctor(self.root)
+        checks = {item["name"]: item for item in report["checks"]}
+        self.assertEqual("fail", checks["local-host-state"]["status"])
+        self.assertEqual("fail", checks["transaction-journals"]["status"])
+        self.assertEqual("fail", checks["host-state-lock"]["status"])
+
     def test_bare_doctor_fails_when_registry_is_empty(self) -> None:
         shutil.rmtree(self.root / "runtimes")
         report = doctor(self.root)

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1088,16 +1088,16 @@ class KernelTest(unittest.TestCase):
         self.assertIn("link-like artifact ignored", check["detail"])
 
     def test_doctor_reports_linked_state_file_without_crashing(self) -> None:
-        outside = self.root / "outside-current.md"
-        outside.write_text("# external\n", encoding="utf-8")
-        current = self.root / "state/current.md"
-        current.unlink()
-        try:
-            current.symlink_to(outside)
-        except OSError:
-            self.skipTest("symlink creation is unavailable")
-
-        report = doctor(self.root)
+        with tempfile.TemporaryDirectory() as external:
+            outside = Path(external) / "outside-current.md"
+            outside.write_text("# external\n", encoding="utf-8")
+            current = self.root / "state/current.md"
+            current.unlink()
+            try:
+                current.symlink_to(outside)
+            except OSError:
+                self.skipTest("symlink creation is unavailable")
+            report = doctor(self.root)
         check = next(
             item for item in report["checks"] if item["name"] == "file:state/current.md"
         )
@@ -1105,16 +1105,16 @@ class KernelTest(unittest.TestCase):
         self.assertIn("symlink or reparse point", check["detail"])
 
     def test_doctor_reports_linked_state_directory_without_crashing(self) -> None:
-        outside = self.root / "outside-state"
-        (self.root / "state").rename(outside)
-        state = self.root / "state"
-        try:
-            state.symlink_to(outside, target_is_directory=True)
-        except OSError:
-            outside.rename(state)
-            self.skipTest("directory symlink creation is unavailable")
-
-        report = doctor(self.root)
+        with tempfile.TemporaryDirectory() as external:
+            outside = Path(external) / "outside-state"
+            (self.root / "state").rename(outside)
+            state = self.root / "state"
+            try:
+                state.symlink_to(outside, target_is_directory=True)
+            except OSError:
+                outside.rename(state)
+                self.skipTest("directory symlink creation is unavailable")
+            report = doctor(self.root)
         self.assertEqual("fail", report["status"])
         self.assertEqual("invalid", report["scope"])
         self.assertTrue(
@@ -1123,6 +1123,35 @@ class KernelTest(unittest.TestCase):
                 for item in report["checks"]
             )
         )
+
+    def test_doctor_reports_external_links_for_every_configurable_seed_path(self) -> None:
+        with tempfile.TemporaryDirectory() as external:
+            external_root = Path(external)
+            cases = (
+                (self.root / "sessions", external_root / "sessions", True),
+                (self.root / "TODO.md", external_root / "TODO.md", False),
+            )
+            for target, outside, is_directory in cases:
+                with self.subTest(path=target.name):
+                    target.rename(outside)
+                    try:
+                        target.symlink_to(outside, target_is_directory=is_directory)
+                    except OSError:
+                        outside.rename(target)
+                        self.skipTest("symlink creation is unavailable")
+                    report = doctor(self.root)
+                    self.assertEqual("fail", report["status"])
+                    self.assertEqual("invalid", report["scope"])
+                    self.assertTrue(
+                        any(
+                            missing == target.name
+                            or missing.startswith(target.name + "/")
+                            for runtime in report["runtimes"].values()
+                            for missing in runtime["components"]["missing_paths"]
+                        )
+                    )
+                    target.unlink()
+                    outside.rename(target)
 
     def test_doctor_fails_closed_on_linked_local_state_root(self) -> None:
         outside = self.root / "outside-context-os"

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -103,6 +103,13 @@ class RuntimeManifestTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeManifestError, "match filename"):
             validate_runtime_manifest(manifest, runtime_id="other", root=ROOT)
 
+    def test_contract_tolerates_one_day_of_evidence_clock_skew(self) -> None:
+        manifest = load("codex")
+        manifest["evidence"]["checked_on"] = "2026-08-25"
+        validate_runtime_manifest(
+            manifest, runtime_id="codex", root=ROOT, today=date(2026, 8, 24)
+        )
+
     def test_operational_validation_ignores_clock_skew_but_keeps_date_shape(self) -> None:
         manifest = load("codex")
         validate_runtime_manifest(


### PR DESCRIPTION
## Summary

- make bare `doctor` follow tracked `contextos.workspace.json` agent intent while preserving legacy host-state fallback
- report support, component materialization, customization limits, availability, onboarding, descriptor drift, conformance declarations, and evidence freshness independently
- keep unselected adapters visible but inert, with strict explicit-runtime and maintainer scopes
- harden diagnostic path handling so malformed links, Windows reparse points, journals, and local artifacts produce structured results instead of suppressing the report
- document the set-aware scope and add regression coverage for custom paths, empty/multi-agent profiles, inert defects, evidence boundaries, and hostile local paths

Closes #68.

Stacked on #81 (`feat/neutral-root-discovery`).

## Verification

- `bash scripts/validate-all.sh`
  - 300 Python tests passed (27 intentional skips)
  - 69 portability tests passed (11 intentional skips)
  - 12 hook tests passed
  - integration, component, runtime, workspace, JSON, link, and doc-reachability checks passed
- `git diff --check`

## Exact-SHA review

Final reviewed commit: `ed1c6a230970d078aa1c96b32b76b591be847a42`

- `claude-opus-5`: no confirmed release blocker; ship
- Hermes `stealth/ox-alpha` through OpenRouter, live price $0 input / $0 output: no confirmed release blocker; pass

Three repair cycles were used. Confirmed findings fixed dangling artifact diagnostics, linked state and `.context-os` handling, Windows symlink/mount-point reparse guards, and external seed-path remapping. The repair budget is exhausted; no confirmed blocker remains.
