### PR TITLE
Add multi-agent setup selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Additive multi-agent setup through `scripts/setup.sh --agents`, with TTY
+  selection, exact digest-bound approval, local registration of every approved
+  runtime, a deprecated singleton alias, and local-only `auto` behavior.
 - A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
 - Provider-neutral root discovery through validated `contextos.workspace.json`,

--- a/README.md
+++ b/README.md
@@ -41,16 +41,18 @@ cd my-context
 git remote rename origin upstream
 git remote add origin <YOUR_PRIVATE_REPO_URL>
 
-# Pick a host, or omit --agent to auto-detect one:
-bash scripts/setup.sh --agent claude
-# bash scripts/setup.sh --agent codex
-# bash scripts/setup.sh --agent hermes
+# Select every agent this repository will use:
+bash scripts/setup.sh --agents claude,codex
+# bash scripts/setup.sh --agents hermes
+# bash scripts/setup.sh --agents none  # core-only
 ```
 
-The current singular `--agent` option chooses what bootstrap launches locally;
-it does not infer or rewrite the tracked runtime set. See [workspace
-configuration](docs/workspace-configuration.md) for the canonical agent-set and
-migration contract.
+Setup presents an exact, digest-bound proposal before recording the selected
+set. Reruns add agents but never remove them; use the explicit lifecycle to
+disable one later. Omit the option, or use `--agents auto`, for local
+auto-detection without changing repository intent. The singular `--agent` form
+is a deprecated singleton alias. See [workspace
+configuration](docs/workspace-configuration.md) for the full contract.
 
 Then start your agent from the repository root:
 

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -11,6 +11,7 @@ from .kernel import (
     apply_proposal,
     create_proposal,
     create_workspace_migration_proposal,
+    create_workspace_setup_proposal,
     discover_root,
     doctor,
     hook_report,
@@ -99,6 +100,22 @@ def parser() -> argparse.ArgumentParser:
     propose_migration.add_argument(
         "--now", help="ISO-8601 timestamp for deterministic proposal IDs"
     )
+    propose_setup = workspace_commands.add_parser(
+        "propose-setup",
+        help="Create an additive digest-bound setup proposal for tracked agents",
+    )
+    setup_selection = propose_setup.add_mutually_exclusive_group(required=True)
+    setup_selection.add_argument(
+        "--agents", action="append", help="Comma-separated runtime ids, or none for core-only"
+    )
+    setup_selection.add_argument(
+        "--agent",
+        action="append",
+        help="Deprecated singleton compatibility alias; use --agents",
+    )
+    propose_setup.add_argument(
+        "--now", help="ISO-8601 timestamp for deterministic proposal IDs"
+    )
     workspace_commands.add_parser(
         "migrate-local-runtime",
         help="Atomically copy legacy local runtime state into hosts.json",
@@ -130,6 +147,58 @@ def selected_workspace_agents(args: argparse.Namespace, root: Path) -> list[str]
     if selected_agents is None:
         raise ContextOSError("workspace migration requires explicit agents")
     return selected_agents
+
+
+def workspace_proposal_report(
+    root: Path,
+    path: Path | None,
+    document: dict[str, object] | None,
+    notices: list[str],
+) -> dict[str, object]:
+    if path is None or document is None:
+        return {
+            "schema_version": 1,
+            "writes": False,
+            "action": "noop",
+            "proposal": None,
+            "proposal_id": None,
+            "proposal_digest": None,
+            "changes": [],
+            "notices": notices,
+        }
+    changes = document["changes"]
+    source_hashes = document["source_hashes"]
+    assert isinstance(changes, list)
+    assert isinstance(source_hashes, dict)
+    return {
+        "schema_version": document["schema_version"],
+        "writes": False,
+        "action": "proposed",
+        "workflow": document["workflow"],
+        "operation": document["operation"],
+        "proposal": path.relative_to(root).as_posix(),
+        "proposal_id": document["proposal_id"],
+        "proposal_digest": document["proposal_digest"],
+        "changes": [
+            {
+                "action": item["action"],
+                "path": item["path"],
+                "owner": item["authorization"]["owner"],
+                "policy": item["authorization"]["policy"],
+                "before_sha256_raw": item["before_raw_sha256"],
+                "after_sha256_raw": item["after_raw_sha256"],
+                "diff": item["diff"],
+            }
+            for item in changes
+        ],
+        "authorization_inputs": [
+            {"path": source, "sha256_raw": digest}
+            for source, digest in source_hashes.items()
+        ],
+        "source_git_head": document["source_git_head"],
+        "authorization": document["authorization"],
+        "notices": notices,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -180,47 +249,20 @@ def main(argv: list[str] | None = None) -> int:
                     notices.append(
                         "--agent is a deprecated singleton compatibility alias; use --agents"
                     )
-                if path is None or document is None:
-                    emit({
-                        "schema_version": 1,
-                        "writes": False,
-                        "action": "noop",
-                        "proposal": None,
-                        "proposal_id": None,
-                        "proposal_digest": None,
-                        "changes": [],
-                        "notices": notices,
-                    })
-                    return 0
-                emit({
-                    "schema_version": document["schema_version"],
-                    "writes": False,
-                    "action": "proposed",
-                    "workflow": document["workflow"],
-                    "operation": document["operation"],
-                    "proposal": path.relative_to(root).as_posix(),
-                    "proposal_id": document["proposal_id"],
-                    "proposal_digest": document["proposal_digest"],
-                    "changes": [
-                        {
-                            "action": item["action"],
-                            "path": item["path"],
-                            "owner": item["authorization"]["owner"],
-                            "policy": item["authorization"]["policy"],
-                            "before_sha256_raw": item["before_raw_sha256"],
-                            "after_sha256_raw": item["after_raw_sha256"],
-                            "diff": item["diff"],
-                        }
-                        for item in document["changes"]
-                    ],
-                    "authorization_inputs": [
-                        {"path": source, "sha256_raw": digest}
-                        for source, digest in document["source_hashes"].items()
-                    ],
-                    "source_git_head": document["source_git_head"],
-                    "authorization": document["authorization"],
-                    "notices": notices,
-                })
+                emit(workspace_proposal_report(root, path, document, notices))
+            elif args.workspace_command == "propose-setup":
+                selected_agents = selected_workspace_agents(args, root)
+                path, document = create_workspace_setup_proposal(
+                    root, selected_agents, parse_now(args.now)
+                )
+                notices = [
+                    "setup selection is additive and never removes configured agents"
+                ]
+                if args.agent is not None:
+                    notices.append(
+                        "--agent is a deprecated singleton compatibility alias; use --agents"
+                    )
+                emit(workspace_proposal_report(root, path, document, notices))
             elif args.workspace_command == "migrate-local-runtime":
                 path, state, changed, migrated_runtime = migrate_legacy_runtime_state(root)
                 emit({

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -779,10 +779,13 @@ def _agent_change(
     }
 
 
-def create_workspace_migration_proposal(
+def _create_workspace_config_proposal(
     root: Path,
     agents: Sequence[str],
     now: datetime,
+    *,
+    allow_initial: bool,
+    allow_agent_expansion: bool,
 ) -> tuple[Path | None, dict[str, Any] | None]:
     target = root / "contextos.workspace.json"
     target_content: str | None = None
@@ -796,12 +799,16 @@ def create_workspace_migration_proposal(
                 "contextos.workspace.json"
             ) from exc
     resolution = resolve_workspace(root)
-    if resolution.source == "defaults":
+    if resolution.source == "defaults" and not allow_initial:
         raise ContextOSError(
             "workspace migration requires legacy workspace.yaml; "
             "initial agent selection belongs to setup"
         )
-    if resolution.source == "json" and list(agents) != list(resolution.agents or []):
+    if (
+        resolution.source == "json"
+        and list(agents) != list(resolution.agents or [])
+        and not allow_agent_expansion
+    ):
         raise ContextOSError(
             "workspace migration cannot change an existing agent set; "
             "use the agent lifecycle"
@@ -868,6 +875,51 @@ def create_workspace_migration_proposal(
         root=root,
     )
     return proposal_path, document
+
+
+def create_workspace_migration_proposal(
+    root: Path,
+    agents: Sequence[str],
+    now: datetime,
+) -> tuple[Path | None, dict[str, Any] | None]:
+    return _create_workspace_config_proposal(
+        root,
+        agents,
+        now,
+        allow_initial=False,
+        allow_agent_expansion=False,
+    )
+
+
+def create_workspace_setup_proposal(
+    root: Path,
+    requested_agents: Sequence[str],
+    now: datetime,
+) -> tuple[Path | None, dict[str, Any] | None]:
+    """Create an additive setup proposal without inferring tracked intent."""
+    requested_config = validate_workspace_config(
+        {
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "mode": WORKSPACE_MODE,
+            "agents": list(requested_agents),
+            "paths": dict(DEFAULT_PATHS),
+            "template": {
+                "version": DEFAULT_TEMPLATE_VERSION,
+                "source": DEFAULT_TEMPLATE_SOURCE,
+            },
+        },
+        known_runtime_ids=runtime_ids(root),
+    )
+    resolution = resolve_workspace(root)
+    configured = set(resolution.agents or ())
+    selected = sorted(configured | set(requested_config["agents"]))
+    return _create_workspace_config_proposal(
+        root,
+        selected,
+        now,
+        allow_initial=True,
+        allow_agent_expansion=True,
+    )
 
 
 def relative_path(root: Path, path: Path) -> str:

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -7,14 +7,16 @@ other supported runtimes. The portable boundary is `AGENTS.md`,
 ## Set up
 
 ```bash
-bash scripts/setup.sh --agent codex
+bash scripts/setup.sh --agents codex
 ```
 
 Then launch Codex from the repository root and explicitly invoke `$setup`.
 Use `$start`, `$update`, and `$end` for the daily loop. The namespaced
 `$context-*` forms remain compatibility aliases.
 
-Setup records a gitignored local runtime selection. Inspect it with:
+After you approve the exact setup proposal, setup records Codex in tracked
+repository intent and registers it in the gitignored local host map. Inspect
+the resulting dimensions with:
 
 ```bash
 bash scripts/contextos.sh doctor --runtime codex

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,24 +39,24 @@ Do not push until you have reviewed the placeholder files, example project, and 
 
 ## Run the local setup
 
-Choose the host you expect to use first:
+Choose every registered agent you expect to use with this repository:
 
 ```bash
-bash scripts/setup.sh --agent claude
+bash scripts/setup.sh --agents claude,codex
 # or
-bash scripts/setup.sh --agent codex
-# or
-bash scripts/setup.sh --agent hermes
+bash scripts/setup.sh --agents hermes
+# or, for the provider-neutral core only
+bash scripts/setup.sh --agents none
 ```
 
-You can omit `--agent` to auto-detect an installed host, or use `--agent none` to prepare the repository without launching one.
-
-That bootstrap option is currently a local launch choice. A reviewed
-`workspace propose-migration` transaction can create tracked
-`contextos.workspace.json`; setup-time selection remains separate work. Local
-detection and `.context-os/hosts.json` never infer or rewrite it. See [workspace
-configuration](workspace-configuration.md) for `none`, `auto`, legacy YAML,
-previewed migration, and rerun behavior.
+Setup shows the exact tracked workspace diff and proposal digest, then defaults
+the apply decision to no. An approved selection is additive: rerunning with a
+subset or `none` preserves the existing set, while a new runtime expands it.
+Selected runtimes are also registered in the gitignored local host map. Omit
+the option, or use `--agents auto`, to auto-detect local launch instructions
+without changing tracked intent. `--agent` remains a deprecated singleton
+alias. See [workspace configuration](workspace-configuration.md) for the full
+transaction and rerun contract.
 
 The script can:
 
@@ -64,7 +64,8 @@ The script can:
 - point `origin` at your repository;
 - remove the sample musician project;
 - install the local pre-commit hook; and
-- generate a local, gitignored repository map.
+- generate a local, gitignored repository map; and
+- propose an additive tracked agent set and register approved selections locally.
 
 Each optional change is prompted. The script shows setup-file changes before offering a narrowly scoped commit, and that commit defaults to no.
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -165,18 +165,26 @@ conformance declarations, and evidence freshness as independent dimensions.
 An empty `agents` array is therefore a real core-only profile, even when a host
 has additional runtimes installed locally.
 
-## Setup compatibility contract
+## Setup selection contract
 
-The current bootstrap still exposes singular `scripts/setup.sh --agent` while
-the multi-select setup work is completed separately. Its semantics are fixed:
+`scripts/setup.sh --agents <comma-separated-runtime-ids>` selects every agent
+the repository is intended to support. On a TTY, omission prompts for that set;
+in non-interactive use omission performs local auto-detection only. Explicit
+`--agents auto` has the same local-only behavior. The singular `--agent` form
+is a deprecated singleton compatibility alias.
 
-- explicit runtime selection may later establish tracked intent through a
-  reviewed transaction;
-- `none` means an intentional empty set only when explicitly selected;
-- omitted selection and `auto` are local launch choices and never tracked;
-- reruns preserve the configured set unless an explicit expansion is reviewed;
-- subset, disjoint, or `none` requests against a non-empty set never silently
-  remove adapters;
+Setup uses the existing proposal/apply transaction boundary. It shows the exact
+workspace diff, source commit, and digest, then defaults approval to no. An
+approved selection is registered in the gitignored host map and updates tracked
+intent with these rules:
+
+- setup is additive and idempotent: requested agents are unioned with the
+  configured set;
+- `none` creates an intentional empty set only for a fresh or legacy workspace;
+- subset or `none` reruns against a non-empty set are no-ops;
+- only the explicit disable lifecycle may shrink the configured set;
+- local launch choice is ephemeral and never creates a stored primary agent;
+- no adapter or component is deleted merely because it was not selected; and
 - Cursor and OpenClaw remain launch/read compatibility names until registered
   runtime descriptors exist, so they cannot be stored in `agents` yet.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,43 +8,136 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
-AGENT_TARGET="auto"
+SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex|auto|none] [--agent auto|RUNTIME|none]"
+AGENT_SELECTION_KIND=""
+AGENT_SELECTION_RAW=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --agent)
+    --agents)
       if [ "$#" -lt 2 ]; then
-        echo "Usage: bash scripts/setup.sh [--agent auto|claude|codex|hermes|cursor|openclaw|none]" >&2
+        echo "$SETUP_USAGE" >&2
         exit 2
       fi
-      AGENT_TARGET="$2"
+      if [ -n "$AGENT_SELECTION_KIND" ]; then
+        echo "Agent selection may be specified only once" >&2
+        exit 2
+      fi
+      AGENT_SELECTION_KIND="agents"
+      AGENT_SELECTION_RAW="$2"
+      shift 2
+      ;;
+    --agents=*)
+      if [ -n "$AGENT_SELECTION_KIND" ]; then
+        echo "Agent selection may be specified only once" >&2
+        exit 2
+      fi
+      AGENT_SELECTION_KIND="agents"
+      AGENT_SELECTION_RAW="${1#--agents=}"
+      shift
+      ;;
+    --agent)
+      if [ "$#" -lt 2 ]; then
+        echo "$SETUP_USAGE" >&2
+        exit 2
+      fi
+      if [ -n "$AGENT_SELECTION_KIND" ]; then
+        echo "Agent selection may be specified only once" >&2
+        exit 2
+      fi
+      AGENT_SELECTION_KIND="agent"
+      AGENT_SELECTION_RAW="$2"
       shift 2
       ;;
     --agent=*)
-      AGENT_TARGET="${1#--agent=}"
+      if [ -n "$AGENT_SELECTION_KIND" ]; then
+        echo "Agent selection may be specified only once" >&2
+        exit 2
+      fi
+      AGENT_SELECTION_KIND="agent"
+      AGENT_SELECTION_RAW="${1#--agent=}"
       shift
       ;;
     -h|--help)
-      echo "Usage: bash scripts/setup.sh [--agent auto|claude|codex|hermes|cursor|openclaw|none]"
+      echo "$SETUP_USAGE"
+      echo "  --agents records an additive tracked runtime set; it never removes agents."
+      echo "  --agent is the deprecated singleton alias and retains auto/Cursor/OpenClaw launch compatibility."
       exit 0
       ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: bash scripts/setup.sh [--agent auto|claude|codex|hermes|cursor|openclaw|none]" >&2
+      echo "$SETUP_USAGE" >&2
       exit 2
       ;;
   esac
 done
 
-case "$AGENT_TARGET" in
-  auto|claude|codex|hermes|cursor|openclaw|none) ;;
-  *)
-    echo "Invalid --agent value: $AGENT_TARGET" >&2
-    echo "Expected one of: auto, claude, codex, hermes, cursor, openclaw, none" >&2
-    exit 2
-    ;;
-esac
-
 source "$SCRIPT_DIR/python-env.sh"
+
+TRACKED_AGENT_SELECTION=""
+REQUESTED_REGISTERED_AGENTS=""
+LAUNCH_SELECTION="auto"
+
+validate_agent_selection() {
+  local kind="$1" raw="$2"
+  if [ "$kind" = "agent" ]; then
+    echo "  Note: --agent is deprecated; use --agents for tracked runtime selection."
+    if [[ "$raw" == *,* ]]; then
+      echo "--agent is a deprecated singleton alias and accepts exactly one runtime id" >&2
+      exit 2
+    fi
+    case "$raw" in
+      auto)
+        LAUNCH_SELECTION="auto"
+        return
+        ;;
+      cursor|openclaw)
+        LAUNCH_SELECTION="$raw"
+        echo "  Note: $raw remains launch-only until it has a registered runtime descriptor."
+        return
+        ;;
+      none)
+        TRACKED_AGENT_SELECTION="none"
+        LAUNCH_SELECTION="none"
+        return
+        ;;
+    esac
+  fi
+
+  if [ "$kind" = "agents" ] && [ "$raw" = "auto" ]; then
+    LAUNCH_SELECTION="auto"
+    return
+  fi
+
+  if ! TRACKED_AGENT_SELECTION=$("$CONTEXTOS_PYTHON_CMD" - "$raw" <<'PY'
+from pathlib import Path
+import sys
+
+from contextos.kernel import ContextOSError, runtime_ids
+from contextos.workspace_schema import WorkspaceConfigError, parse_agent_selection
+
+try:
+    selected = parse_agent_selection(
+        sys.argv[1], known_runtime_ids=runtime_ids(Path.cwd())
+    )
+except (ContextOSError, WorkspaceConfigError) as exc:
+    print(f"context-os: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+print(",".join(selected) or "none")
+PY
+  ); then
+    exit 2
+  fi
+  if [ "$TRACKED_AGENT_SELECTION" = "none" ]; then
+    LAUNCH_SELECTION="none"
+  else
+    REQUESTED_REGISTERED_AGENTS="$TRACKED_AGENT_SELECTION"
+    LAUNCH_SELECTION="$TRACKED_AGENT_SELECTION"
+  fi
+}
+
+if [ -n "$AGENT_SELECTION_KIND" ]; then
+  validate_agent_selection "$AGENT_SELECTION_KIND" "$AGENT_SELECTION_RAW"
+fi
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -52,10 +145,16 @@ prompt_yn() {
   local question="$1" default="${2:-y}"
   local yn
   if [ "$default" = "y" ]; then
-    read -rp "$question [Y/n] " yn
+    printf '%s [Y/n] ' "$question" >&2
+    if ! IFS= read -r yn; then
+      return 1
+    fi
     yn="${yn:-y}"
   else
-    read -rp "$question [y/N] " yn
+    printf '%s [y/N] ' "$question" >&2
+    if ! IFS= read -r yn; then
+      return 1
+    fi
     yn="${yn:-n}"
   fi
   [[ "$yn" =~ ^[Yy] ]]
@@ -88,6 +187,23 @@ echo ""
 if ! prompt_yn "  Continue after reviewing this storage and audience boundary?" "n"; then
   echo "  → Setup stopped before collecting or writing personal context"
   exit 0
+fi
+
+if [ -z "$AGENT_SELECTION_KIND" ] && [ -t 0 ]; then
+  REGISTERED_AGENTS=$("$CONTEXTOS_PYTHON_CMD" - <<'PY'
+from pathlib import Path
+from contextos.kernel import runtime_ids
+
+print(",".join(runtime_ids(Path.cwd())))
+PY
+  )
+  echo ""
+  echo "  Registered runtimes: $REGISTERED_AGENTS"
+  read -rp "  Repository agents (comma-separated, none for core-only, Enter for local auto-detection): " AGENT_SELECTION_RAW
+  if [ -n "$AGENT_SELECTION_RAW" ]; then
+    AGENT_SELECTION_KIND="agents"
+    validate_agent_selection "$AGENT_SELECTION_KIND" "$AGENT_SELECTION_RAW"
+  fi
 fi
 
 # ── 1. Your name ────────────────────────────────────────────────────────────
@@ -265,7 +381,70 @@ else
   exit 1
 fi
 
-# ── 7. Initial commit ───────────────────────────────────────────────────────
+# ── 7. Tracked agent selection ──────────────────────────────────────────────
+
+SETUP_SELECTION_ACTIVATED=false
+if [ -n "$TRACKED_AGENT_SELECTION" ]; then
+  echo ""
+  echo "  Preparing additive tracked agent selection: $TRACKED_AGENT_SELECTION"
+  SETUP_PROPOSAL_JSON=$(bash "$SCRIPT_DIR/contextos.sh" workspace propose-setup \
+    --agents "$TRACKED_AGENT_SELECTION")
+  SETUP_PROPOSAL_ACTION=$(printf '%s' "$SETUP_PROPOSAL_JSON" | \
+    "$CONTEXTOS_PYTHON_CMD" -c 'import json,sys; print(json.load(sys.stdin)["action"])')
+
+  if [ "$SETUP_PROPOSAL_ACTION" = "noop" ]; then
+    SETUP_SELECTION_ACTIVATED=true
+    echo "  → Tracked agent set already contains this selection; nothing to apply"
+  else
+    printf '%s' "$SETUP_PROPOSAL_JSON" | "$CONTEXTOS_PYTHON_CMD" -c '
+import json
+import sys
+
+report = json.load(sys.stdin)
+print("  Proposed tracked workspace changes:")
+for change in report["changes"]:
+    print(change["diff"], end="" if change["diff"].endswith("\n") else "\n")
+print("  Source Git commit: {}".format(report["source_git_head"]))
+print("  Proposal digest: {}".format(report["proposal_digest"]))
+'
+    IFS=$'\t' read -r SETUP_PROPOSAL_PATH SETUP_PROPOSAL_DIGEST < <(
+      printf '%s' "$SETUP_PROPOSAL_JSON" | "$CONTEXTOS_PYTHON_CMD" -c '
+import json
+import sys
+
+report = json.load(sys.stdin)
+print("{}\t{}".format(report["proposal"], report["proposal_digest"]))
+'
+    )
+    SETUP_PROPOSAL_PATH="${SETUP_PROPOSAL_PATH%$'\r'}"
+    SETUP_PROPOSAL_DIGEST="${SETUP_PROPOSAL_DIGEST%$'\r'}"
+    if prompt_yn "  Apply this exact tracked-agent proposal?" "n"; then
+      bash "$SCRIPT_DIR/contextos.sh" apply "$SETUP_PROPOSAL_PATH" \
+        --confirm "$SETUP_PROPOSAL_DIGEST" --runtime generic
+      track_setup_path "contextos.workspace.json"
+      track_setup_path "workspace.yaml"
+      SETUP_SELECTION_ACTIVATED=true
+      echo "  → Applied the exact reviewed tracked-agent proposal"
+    else
+      echo "  → Tracked agent set unchanged; proposal retained locally for review"
+    fi
+  fi
+else
+  echo ""
+  echo "  → Local auto-detection does not create or change tracked agent intent"
+fi
+
+if [ "$SETUP_SELECTION_ACTIVATED" = true ] && [ -n "$REQUESTED_REGISTERED_AGENTS" ]; then
+  IFS=',' read -r -a SETUP_RUNTIME_IDS <<<"$REQUESTED_REGISTERED_AGENTS"
+  for setup_runtime in "${SETUP_RUNTIME_IDS[@]}"; do
+    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime "$setup_runtime" >/dev/null
+  done
+  echo "  Registered selected runtimes on this host: $REQUESTED_REGISTERED_AGENTS"
+elif [ -n "$REQUESTED_REGISTERED_AGENTS" ]; then
+  LAUNCH_SELECTION="none"
+fi
+
+# ── 8. Initial commit ───────────────────────────────────────────────────────
 
 echo ""
 SETUP_STATUS=""
@@ -298,7 +477,7 @@ else
   echo "  → No setup file changes to commit"
 fi
 
-# ── 8. Next steps ───────────────────────────────────────────────────────────
+# ── 9. Next steps ───────────────────────────────────────────────────────────
 
 echo ""
 echo "  ─────────────────────────────"
@@ -309,7 +488,18 @@ echo "  Bringing existing context: review docs/migration-guide.md first."
 echo "  Adding tools later: review references/integrations.md; nothing is enabled automatically."
 echo ""
 
-SELECTED_AGENT="$AGENT_TARGET"
+SELECTED_AGENT="$LAUNCH_SELECTION"
+if [[ "$SELECTED_AGENT" == *,* ]]; then
+  if [[ ",$SELECTED_AGENT," == *,claude,* ]] && [ "$CLAUDE_FOUND" = true ]; then
+    SELECTED_AGENT="claude"
+  elif [[ ",$SELECTED_AGENT," == *,codex,* ]] && [ "$CODEX_FOUND" = true ]; then
+    SELECTED_AGENT="codex"
+  elif [[ ",$SELECTED_AGENT," == *,hermes,* ]] && [ "$HERMES_FOUND" = true ]; then
+    SELECTED_AGENT="hermes"
+  else
+    SELECTED_AGENT="none"
+  fi
+fi
 if [ "$SELECTED_AGENT" = "auto" ]; then
   if [ "$CLAUDE_FOUND" = true ]; then
     SELECTED_AGENT="claude"
@@ -324,7 +514,9 @@ fi
 
 case "$SELECTED_AGENT" in
   claude)
-    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime claude >/dev/null
+    if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
+      "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime claude >/dev/null
+    fi
     echo "  Claude Code auto-memory is enabled by default and may write machine-local memory."
     echo "  Inspect it with /memory; to opt out, set autoMemoryEnabled: false in"
     echo "  .claude/settings.local.json. Setup does not change that host setting."
@@ -334,32 +526,36 @@ case "$SELECTED_AGENT" in
     echo "     Claude will interview you and build your context files."
     echo "     Import and integration choices remain separate, review-gated steps."
     echo ""
-    if [ "$CLAUDE_FOUND" = true ] && prompt_yn "  Launch Claude Code now?" "y"; then
+    if [ -t 0 ] && [ "$CLAUDE_FOUND" = true ] && prompt_yn "  Launch Claude Code now?" "y"; then
       cd "$REPO_ROOT"
       exec claude
     fi
     ;;
   codex)
-    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime codex >/dev/null
+    if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
+      "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime codex >/dev/null
+    fi
     printf '  1. cd %q && codex\n' "$REPO_ROOT"
     echo '  2. Type: $setup'
     echo "     Codex will interview you and build your context files."
     echo "     See docs/getting-started.md for migration, integrations, and host limits."
     echo ""
-    if [ "$CODEX_FOUND" = true ] && prompt_yn "  Launch Codex now?" "y"; then
+    if [ -t 0 ] && [ "$CODEX_FOUND" = true ] && prompt_yn "  Launch Codex now?" "y"; then
       cd "$REPO_ROOT"
       exec codex
     fi
     ;;
   hermes)
-    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime hermes >/dev/null
+    if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
+      "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime hermes >/dev/null
+    fi
     printf '  1. cd %q && hermes\n' "$REPO_ROOT"
     echo "  2. Hermes reads AGENTS.md automatically. Expose .agents/skills/ as an"
     echo "     external skill directory, then type /setup. If you copy skills instead,"
     echo "     install the short aliases and context-* cores together."
     echo "     See adapters/hermes/ and docs/memory-across-agents.md."
     echo ""
-    if [ "$HERMES_FOUND" = true ] && prompt_yn "  Launch Hermes now?" "y"; then
+    if [ -t 0 ] && [ "$HERMES_FOUND" = true ] && prompt_yn "  Launch Hermes now?" "y"; then
       cd "$REPO_ROOT"
       exec hermes
     fi
@@ -370,7 +566,7 @@ case "$SELECTED_AGENT" in
     echo "     repository root. The portable lifecycle skills in .agents/skills/"
     echo "     can be pasted or referenced in Cursor rules as needed."
     echo ""
-    if [ "$CURSOR_FOUND" = true ] && prompt_yn "  Launch Cursor CLI now?" "y"; then
+    if [ -t 0 ] && [ "$CURSOR_FOUND" = true ] && prompt_yn "  Launch Cursor CLI now?" "y"; then
       cd "$REPO_ROOT"
       if command -v cursor-agent &>/dev/null; then exec cursor-agent; else exec cursor; fi
     fi
@@ -380,7 +576,7 @@ case "$SELECTED_AGENT" in
     echo "  2. OpenClaw reads AGENTS.md and agentskills.io-compatible skills from"
     echo "     .agents/skills/. See AGENTS.md for the session loop."
     echo ""
-    if [ "$OPENCLAW_FOUND" = true ] && prompt_yn "  Launch OpenClaw now?" "y"; then
+    if [ -t 0 ] && [ "$OPENCLAW_FOUND" = true ] && prompt_yn "  Launch OpenClaw now?" "y"; then
       cd "$REPO_ROOT"
       exec openclaw
     fi

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -269,7 +269,8 @@ if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$duplica
 fi
 
 help_output=$(bash scripts/setup.sh --help)
-grep -Fq -- '--agent auto|claude|codex|hermes|cursor|openclaw|none' <<<"$help_output" || fail "setup help does not describe agent selection"
+grep -Fq -- '--agents claude,codex|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
+grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"
 fi
@@ -294,6 +295,134 @@ make_setup_fixture() {
   git -C "$destination" commit -qm baseline
   git -C "$destination" remote add origin https://example.invalid/context.git
 }
+
+for invalid_setup_args in \
+  '--agents claude,claude' \
+  '--agents none,claude' \
+  '--agents missing' \
+  '--agent claude,codex' \
+  '--agent claude --agents codex' \
+  '--agents claude --agents codex'; do
+  read -r -a invalid_setup_argv <<<"$invalid_setup_args"
+  if bash scripts/setup.sh "${invalid_setup_argv[@]}" >/dev/null 2>&1; then
+    fail "setup accepted invalid or ambiguous selection: $invalid_setup_args"
+  fi
+done
+
+setup_test_path="$(dirname "$(command -v "$CONTEXTOS_PYTHON_CMD")"):$(dirname "$(command -v git)"):/usr/bin:/bin"
+
+multi_agent_fixture="$portability_tmp/multi-agent-selection"
+make_setup_fixture "$multi_agent_fixture"
+multi_agent_output=$(printf 'y\n\nn\nn\nn\ny\nn\n' | (
+  cd "$multi_agent_fixture" &&
+  PATH="$setup_test_path" bash scripts/setup.sh --agents codex,claude
+) 2>&1)
+"$CONTEXTOS_PYTHON_CMD" - "$multi_agent_fixture/contextos.workspace.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert config["agents"] == ["claude", "codex"], config["agents"]
+PY
+"$CONTEXTOS_PYTHON_CMD" - "$multi_agent_fixture/.context-os/hosts.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+hosts = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["hosts"]
+assert sorted(hosts) == ["claude", "codex"], sorted(hosts)
+PY
+test ! -e "$multi_agent_fixture/workspace.yaml" \
+  || fail "multi-agent setup did not transactionally retire legacy YAML"
+grep -Fq 'Apply this exact tracked-agent proposal?' <<<"$multi_agent_output" \
+  || fail "multi-agent setup did not present an exact proposal approval gate"
+grep -Fq '"runtime_identity": "self-reported"' <<<"$multi_agent_output" \
+  || fail "multi-agent setup did not report its transaction receipt"
+unexpected_setup_paths=$(git -C "$multi_agent_fixture" status --short | \
+  grep -Ev '^( D workspace\.yaml|\?\? contextos\.workspace\.json)$' || true)
+test -z "$unexpected_setup_paths" \
+  || fail "multi-agent setup changed unselected adapter or unrelated paths: $unexpected_setup_paths"
+
+# Subset and none reruns are no-ops; a disjoint selection expands the set.
+subset_output=$(printf 'y\n\nn\nn\nn\n' | (
+  cd "$multi_agent_fixture" &&
+  PATH="$setup_test_path" bash scripts/setup.sh --agents claude
+))
+grep -Fq 'already contains this selection' <<<"$subset_output" \
+  || fail "subset setup rerun did not preserve the configured set"
+printf 'y\n\nn\nn\nn\ny\nn\n' | (
+  cd "$multi_agent_fixture" &&
+  PATH="$setup_test_path" bash scripts/setup.sh --agents hermes
+) >/dev/null
+"$CONTEXTOS_PYTHON_CMD" - "$multi_agent_fixture/contextos.workspace.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert config["agents"] == ["claude", "codex", "hermes"], config["agents"]
+PY
+none_output=$(printf 'y\n\nn\nn\nn\n' | (
+  cd "$multi_agent_fixture" &&
+  PATH="$setup_test_path" bash scripts/setup.sh --agents none
+))
+grep -Fq 'already contains this selection' <<<"$none_output" \
+  || fail "none setup rerun shrank or rewrote a non-empty configured set"
+
+non_tty_fixture="$portability_tmp/non-tty-auto"
+make_setup_fixture "$non_tty_fixture"
+fake_agent_bin="$non_tty_fixture/fake-agent-bin"
+fake_agent_marker="$non_tty_fixture/fake-agent-launched"
+mkdir -p "$fake_agent_bin"
+printf '#!%s\nprintf launched > %q\n' "$resolved_bash" "$fake_agent_marker" > "$fake_agent_bin/claude"
+chmod +x "$fake_agent_bin/claude"
+fake_agent_path="$fake_agent_bin"
+if command -v cygpath >/dev/null 2>&1; then
+  fake_agent_path=$(cygpath -u "$fake_agent_bin")
+fi
+printf 'y\n\nn\nn\nn\n' | (
+  cd "$non_tty_fixture" && PATH="$fake_agent_path:$setup_test_path" bash scripts/setup.sh --agents auto
+) >/dev/null
+test ! -e "$non_tty_fixture/contextos.workspace.json" \
+  || fail "non-TTY auto selection inferred tracked agent intent"
+test ! -e "$fake_agent_marker" \
+  || fail "non-TTY setup launched an installed runtime"
+"$CONTEXTOS_PYTHON_CMD" - "$non_tty_fixture/.context-os/hosts.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+hosts = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["hosts"]
+assert sorted(hosts) == ["claude"], sorted(hosts)
+PY
+
+omitted_non_tty_fixture="$portability_tmp/non-tty-omitted"
+make_setup_fixture "$omitted_non_tty_fixture"
+printf 'y\n\nn\nn\nn\n' | (
+  cd "$omitted_non_tty_fixture" && PATH="$setup_test_path" bash scripts/setup.sh
+) >/dev/null
+test ! -e "$omitted_non_tty_fixture/contextos.workspace.json" \
+  || fail "non-TTY omitted selection inferred tracked agent intent"
+
+if command -v script >/dev/null 2>&1; then
+  tty_fixture="$portability_tmp/tty-selection"
+  make_setup_fixture "$tty_fixture"
+  tty_output=$(printf 'y\nclaude,codex\n\nn\nn\nn\ny\nn\n' | (
+    cd "$tty_fixture" &&
+    script -q -c "env PATH='$setup_test_path' bash scripts/setup.sh" /dev/null
+  ))
+  grep -Fq 'Repository agents (comma-separated' <<<"$tty_output" \
+    || fail "TTY setup did not prompt for repository agents"
+  "$CONTEXTOS_PYTHON_CMD" - "$tty_fixture/contextos.workspace.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert config["agents"] == ["claude", "codex"], config["agents"]
+PY
+fi
 
 # Both inline Python rewrites must preserve an LF checkout on Windows. Without
 # newline="\n", TextIO converts every line to CRLF and turns the reviewed setup
@@ -347,7 +476,7 @@ grep -Fqx "# $special_name — Context" "$setup_fixture/CLAUDE.md" || fail "a se
 commit_fixture="$portability_tmp/commit-scope"
 make_setup_fixture "$commit_fixture"
 printf 'unrelated\n' > "$commit_fixture/unrelated-user-work.txt"
-printf 'y\nAda & Bob\nn\nn\nn\ny\n' | (cd "$commit_fixture" && bash scripts/setup.sh --agent none) >/dev/null
+printf 'y\nAda & Bob\nn\nn\nn\nn\ny\n' | (cd "$commit_fixture" && bash scripts/setup.sh --agent none) >/dev/null
 test "$(git -C "$commit_fixture" rev-list --count HEAD)" -eq 2 || fail "approved setup commit was not created"
 test "$(git -C "$commit_fixture" show --pretty= --name-only HEAD)" = "CLAUDE.md" || fail "setup commit included a path outside its reviewed write set"
 git -C "$commit_fixture" status --short | grep -Fq '?? unrelated-user-work.txt' || fail "setup commit captured unrelated user work"
@@ -370,7 +499,7 @@ git -C "$no_remote_fixture" diff --quiet || fail "no-remote default-no path wrot
 
 memory_notice_fixture="$portability_tmp/claude-memory-notice"
 make_setup_fixture "$memory_notice_fixture"
-memory_notice_output=$(printf 'y\n\nn\nn\nn\n' | (cd "$memory_notice_fixture" && PATH="$(dirname "$(command -v "$CONTEXTOS_PYTHON_CMD")"):$(dirname "$(command -v git)"):/usr/bin:/bin" bash scripts/setup.sh --agent claude))
+memory_notice_output=$(printf 'y\n\nn\nn\nn\ny\nn\n' | (cd "$memory_notice_fixture" && PATH="$(dirname "$(command -v "$CONTEXTOS_PYTHON_CMD")"):$(dirname "$(command -v git)"):/usr/bin:/bin" bash scripts/setup.sh --agent claude))
 grep -Fq 'auto-memory is enabled by default' <<<"$memory_notice_output" || fail "local Claude onboarding omitted auto-memory default"
 grep -Fq 'Inspect it with /memory' <<<"$memory_notice_output" || fail "local Claude onboarding omitted /memory inspection"
 grep -Fq 'autoMemoryEnabled: false' <<<"$memory_notice_output" || fail "local Claude onboarding omitted opt-out setting"

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -34,6 +34,7 @@ from contextos.kernel import (
     canonical_json,
     create_proposal,
     create_workspace_migration_proposal,
+    create_workspace_setup_proposal,
     doctor,
     raw_file_digest,
     read_json,
@@ -41,6 +42,7 @@ from contextos.kernel import (
     sha256_bytes,
     sha256_text,
 )
+from contextos.workspace_schema import WorkspaceConfigError
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -193,6 +195,84 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         )
         self.assertFalse((self.root / "contextos.workspace.json").exists())
         self.assertTrue((self.root / report["proposal"]).is_file())
+
+    def test_setup_proposal_creates_core_only_config_without_legacy_yaml(self) -> None:
+        (self.root / "workspace.yaml").unlink()
+
+        path, proposal = create_workspace_setup_proposal(self.root, (), NOW)
+
+        self.assertIsNotNone(path)
+        self.assertIsNotNone(proposal)
+        assert path is not None and proposal is not None
+        self.assertEqual(["contextos.workspace.json"], [
+            change["path"] for change in proposal["changes"]
+        ])
+        self.assertIsNone(proposal["authorization"]["before_agents"])
+        self.assertEqual([], proposal["authorization"]["after_agents"])
+        self.apply(path, proposal)
+        configured = json.loads(
+            (self.root / "contextos.workspace.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual([], configured["agents"])
+
+    def test_setup_proposal_is_additive_idempotent_and_never_shrinks(self) -> None:
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+
+        for requested in (("claude",), ()):
+            path, proposal = create_workspace_setup_proposal(
+                self.root, requested, NOW.replace(second=1)
+            )
+            self.assertIsNone(path)
+            self.assertIsNone(proposal)
+
+        path, proposal = create_workspace_setup_proposal(
+            self.root, ("codex",), NOW.replace(second=2)
+        )
+        self.assertIsNotNone(path)
+        self.assertIsNotNone(proposal)
+        assert path is not None and proposal is not None
+        self.assertEqual(
+            ["claude", "codex"], proposal["authorization"]["after_agents"]
+        )
+        self.apply(path, proposal)
+
+        path, proposal = create_workspace_setup_proposal(
+            self.root, (), NOW.replace(second=3)
+        )
+        self.assertIsNone(path)
+        self.assertIsNone(proposal)
+        configured = json.loads(
+            (self.root / "contextos.workspace.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(["claude", "codex"], configured["agents"])
+
+    def test_setup_proposal_validates_before_forming_the_additive_union(self) -> None:
+        for requested, message in (
+            (("claude", "claude"), "duplicate"),
+            (("missing",), "unknown"),
+            (("CLAUDE",), "lowercase"),
+        ):
+            with self.subTest(requested=requested), self.assertRaisesRegex(
+                WorkspaceConfigError, message
+            ):
+                create_workspace_setup_proposal(self.root, requested, NOW)
+
+    def test_cli_setup_selection_is_additive_and_alias_is_deprecated(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(
+                0,
+                cli_main([
+                    "--root", str(self.root), "workspace", "propose-setup",
+                    "--agent", "claude", "--now", NOW.isoformat(),
+                ]),
+            )
+        report = json.loads(output.getvalue())
+        self.assertEqual("proposed", report["action"])
+        self.assertIn("deprecated", " ".join(report["notices"]))
+        self.assertEqual(["claude"], report["authorization"]["after_agents"])
+        self.assertFalse((self.root / "contextos.workspace.json").exists())
 
     def test_exact_digest_tamper_and_unowned_path_fail_before_writes(self) -> None:
         path, proposal = self.propose()


### PR DESCRIPTION
Closes #65.

## Summary

- add deterministic additive `scripts/setup.sh --agents` selection with a deprecated singleton `--agent` alias
- keep tracked intent, local host registration, and ephemeral launch choice separate
- apply tracked changes only through the existing exact-digest transaction boundary
- preserve configured agents on subset, `none`, and repeated reruns; register every explicitly selected runtime after an approved apply or valid no-op
- keep omitted/`auto` selection local-only and prevent every non-TTY launch path
- replace `mapfile` with Bash 3.2-compatible proposal parsing and retain Windows CRLF handling
- document the full-template, no-primary, no-deletion contract

## Verification

- native Windows Python 3.13: 372 passed, 25 skipped
- Python 3.10 via uv: 372 passed, 25 skipped
- portability: 93 passed, 10 skipped; hooks: 13 passed
- canonical `scripts/validate-all.sh`: all validation passed
- `git diff --check` and `bash -n scripts/setup.sh`: passed

## Exact-SHA review

Reviewed commit: `886eb71fb334224c5cf333bf0189e3c91df0b422`

- Claude `claude-opus-5`: completed adversarial review. Its proposed CRLF blocker was rejected after first-hand native Git Bash reproduction: raw Python output is CRLF, but command substitution normalizes the captured value used by both comparisons. The end-to-end Windows fixtures also pass multi-agent, `none`, and no-op paths.
- Hermes `thinkingmachines/inkling:free`: completed operational/portability review. Its proposed partial-registration blocker was rejected because tracked repository intent and machine-local availability are deliberately separate dimensions; an install error exits visibly, preserves valid tracked intent, and the additive rerun completes registration idempotently.
- Hermes `stealth/ox-alpha`: setup failure, not review evidence. OpenRouter returned 404 because the testing endpoint was retired during the review window.

Repair budget: 0/3 cycles used. No verified merge-blocking findings.
