### PR TITLE
Add transactional agent activation lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Transactional `agent list`, `agent add`/`enable`, and configuration-only
+  `agent disable` commands with idempotent exact-set proposals and no adapter,
+  host-state, credential, integration, binary, or context-file mutation.
 - Additive multi-agent setup through `scripts/setup.sh --agents`, with TTY
   selection, exact digest-bound approval, local registration of every approved
   runtime, a deprecated singleton alias, and local-only `auto` behavior.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ auto-detection without changing repository intent. The singular `--agent` form
 is a deprecated singleton alias. See [workspace
 configuration](docs/workspace-configuration.md) for the full contract.
 
+After setup, `bash scripts/contextos.sh agent list` shows tracked activation and
+local registration separately. `agent enable` (or `agent add`) creates an
+additive proposal; `agent disable` creates the only proposal allowed to shrink
+the set. Neither operation deletes bundled adapter files.
+
 Then start your agent from the repository root:
 
 | Starting point | Next action |

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from . import __version__
 from .kernel import (
     ContextOSError,
+    agent_list_report,
     apply_proposal,
+    create_agent_activation_proposal,
     create_proposal,
     create_workspace_migration_proposal,
     create_workspace_setup_proposal,
@@ -53,6 +55,27 @@ def parser() -> argparse.ArgumentParser:
         "install", help="Record local onboarding for one runtime and print host setup steps"
     )
     install.add_argument("--runtime", metavar="RUNTIME", required=True)
+
+    agent = commands.add_parser(
+        "agent", help="Inspect or propose changes to tracked agent activation"
+    )
+    agent_commands = agent.add_subparsers(dest="agent_command", required=True)
+    agent_commands.add_parser(
+        "list", help="List registered runtimes and their tracked/local status"
+    )
+    for agent_command in ("add", "enable", "disable"):
+        activation = agent_commands.add_parser(
+            agent_command,
+            help=(
+                "Create an exact proposal to disable one tracked runtime"
+                if agent_command == "disable"
+                else "Create an exact proposal to enable one bundled runtime"
+            ),
+        )
+        activation.add_argument("--runtime", metavar="RUNTIME", required=True)
+        activation.add_argument(
+            "--now", help="ISO-8601 timestamp for deterministic proposal IDs"
+        )
 
     diagnose = commands.add_parser(
         "doctor", help="Check workspace health with tracked agent-set awareness"
@@ -224,6 +247,22 @@ def main(argv: list[str] | None = None) -> int:
             path, manifest = install_runtime(root, args.runtime)
             relative = path.relative_to(root).as_posix()
             emit({"host_state": relative, "runtime_file": relative, **manifest})
+        elif args.command == "agent":
+            if args.agent_command == "list":
+                emit(agent_list_report(root))
+            else:
+                enabled = args.agent_command in {"add", "enable"}
+                path, document = create_agent_activation_proposal(
+                    root, args.runtime, enabled, parse_now(args.now)
+                )
+                notices = [
+                    "agent add is an alias for agent enable"
+                    if args.agent_command == "add"
+                    else "agent disable changes tracked intent only; bundled files remain"
+                    if not enabled
+                    else "agent enable changes tracked intent only",
+                ]
+                emit(workspace_proposal_report(root, path, document, notices))
         elif args.command == "doctor":
             report = doctor(root, args.runtime, all_runtimes=args.all)
             emit(report)

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -935,7 +935,8 @@ def agent_list_report(root: Path) -> dict[str, Any]:
     """Report tracked activation and machine-local registration separately."""
     resolution = resolve_workspace(root)
     configured = set(resolution.agents or ())
-    local_hosts = _read_hosts_state(root)["hosts"]
+    local_state, legacy_runtime = _hosts_with_legacy(root)
+    local_hosts = local_state["hosts"]
     return {
         "schema_version": SCHEMA_VERSION,
         "source": resolution.source,
@@ -949,6 +950,7 @@ def agent_list_report(root: Path) -> dict[str, Any]:
             for runtime in runtime_ids(root)
         ],
         "notices": list(resolution.notices),
+        "legacy_local_runtime": legacy_runtime,
     }
 
 
@@ -1657,6 +1659,11 @@ def _validate_agent_proposal_shape(
             )
         before_set = set(before_agents)
         after_set = set(after_agents)
+        for field in ("schema_version", "mode", "paths", "template"):
+            if after_config[field] != resolution.config[field]:
+                raise ContextOSError(
+                    f"stale or invalid {operation} proposal may change only agents"
+                )
         if operation == AGENT_ENABLE_OPERATION and not (
             before_set < after_set and len(after_set - before_set) == 1
         ):
@@ -2288,12 +2295,13 @@ def _recover_agent_journal(
         if workflow == AGENT_LIFECYCLE_WORKFLOW:
             recovery_policy = {
                 "contextos.workspace.json": ("write", "workspace-config", "managed"),
-                "workspace.yaml": (
+            }
+            if manifest.get("operation") == WORKSPACE_MIGRATION_OPERATION:
+                recovery_policy["workspace.yaml"] = (
                     "delete",
                     "legacy-workspace-config",
                     "migration-only",
-                ),
-            }
+                )
             if relative not in recovery_policy:
                 raise ContextOSError(f"journal path is not recoverable: {relative}")
             allowed_action, allowed_owner, allowed_policy = recovery_policy[relative]

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -56,6 +56,13 @@ HOST_STATE_SCHEMA_VERSION = 1
 EVIDENCE_STALE_AFTER_DAYS = 90
 AGENT_LIFECYCLE_WORKFLOW = "agent-config"
 WORKSPACE_MIGRATION_OPERATION = "workspace-migrate"
+AGENT_ENABLE_OPERATION = "agent-enable"
+AGENT_DISABLE_OPERATION = "agent-disable"
+AGENT_SET_OPERATIONS = {
+    WORKSPACE_MIGRATION_OPERATION,
+    AGENT_ENABLE_OPERATION,
+    AGENT_DISABLE_OPERATION,
+}
 LOCAL_ARTIFACT_MODE = 0o600
 NEW_CONTENT_MODE = 0o666 if os.name == "nt" else 0o644
 PROPOSAL_ID_RE = re.compile(
@@ -658,7 +665,7 @@ def plan_workspace_migration(
 def _agent_lifecycle_authorization(
     root: Path, operation: str, relative: str
 ) -> dict[str, str]:
-    if operation != WORKSPACE_MIGRATION_OPERATION:
+    if operation not in AGENT_SET_OPERATIONS:
         raise ContextOSError(f"unsupported agent lifecycle operation: {operation}")
     expected = {
         "contextos.workspace.json": {
@@ -676,6 +683,8 @@ def _agent_lifecycle_authorization(
         raise ContextOSError(
             f"{operation} cannot mutate unowned or component path: {relative}"
         )
+    if relative == "workspace.yaml" and operation != WORKSPACE_MIGRATION_OPERATION:
+        raise ContextOSError(f"{operation} cannot mutate legacy workspace.yaml")
     _reject_config_aliases(root, relative)
     safe_repo_path(root, relative)
     component_path = safe_repo_path(root, "components/manifest.json")
@@ -920,6 +929,94 @@ def create_workspace_setup_proposal(
         allow_initial=True,
         allow_agent_expansion=True,
     )
+
+
+def agent_list_report(root: Path) -> dict[str, Any]:
+    """Report tracked activation and machine-local registration separately."""
+    resolution = resolve_workspace(root)
+    configured = set(resolution.agents or ())
+    local_hosts = _read_hosts_state(root)["hosts"]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": resolution.source,
+        "mode": resolution.config["mode"] if resolution.config else None,
+        "agents": [
+            {
+                "id": runtime,
+                "enabled": runtime in configured,
+                "locally_registered": runtime in local_hosts,
+            }
+            for runtime in runtime_ids(root)
+        ],
+        "notices": list(resolution.notices),
+    }
+
+
+def create_agent_activation_proposal(
+    root: Path,
+    runtime: str,
+    enabled: bool,
+    now: datetime,
+) -> tuple[Path | None, dict[str, Any] | None]:
+    """Create one exact enable/disable proposal for tracked full-template intent."""
+    runtime_manifest(root, runtime, check_paths=False)
+    resolution = resolve_workspace(root)
+    if resolution.source != "json" or resolution.config is None:
+        raise ContextOSError(
+            "agent activation requires contextos.workspace.json; run setup or migration first"
+        )
+    if not resolution.canonical:
+        raise ContextOSError(
+            "agent activation requires canonical contextos.workspace.json"
+        )
+    before_agents = list(resolution.config["agents"])
+    selected = set(before_agents)
+    operation = AGENT_ENABLE_OPERATION if enabled else AGENT_DISABLE_OPERATION
+    if enabled:
+        selected.add(runtime)
+    else:
+        selected.discard(runtime)
+    after_agents = sorted(selected)
+    if after_agents == before_agents:
+        return None, None
+
+    after_config = {**resolution.config, "agents": after_agents}
+    after_text = render_workspace_config(after_config)
+    change = _agent_change(
+        root,
+        operation,
+        "contextos.workspace.json",
+        action="write",
+        after_text=after_text,
+    )
+    document: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": AGENT_LIFECYCLE_WORKFLOW,
+        "operation": operation,
+        "created_at": now.isoformat(),
+        "proposal_id": proposal_id(AGENT_LIFECYCLE_WORKFLOW, now, [change]),
+        "changes": [change],
+        "authorization": {
+            "policy": "agent-config-v1",
+            "before_agents": before_agents,
+            "after_agents": after_agents,
+            "before_components": _selection_components(root, before_agents),
+            "after_components": _selection_components(root, after_agents),
+        },
+        "source_hashes": _agent_source_hashes(root),
+        "source_git_head": git_head(root),
+        "invariants": list(AGENT_MIGRATION_INVARIANTS),
+    }
+    document["proposal_digest"] = sha256_text(canonical_json(document))
+    proposal_path = (
+        root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
+    )
+    _write_exclusive_text(
+        proposal_path,
+        json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+        root=root,
+    )
+    return proposal_path, document
 
 
 def relative_path(root: Path, path: Path) -> str:
@@ -1451,7 +1548,7 @@ def _validate_agent_proposal_shape(
     if set(document) != required:
         raise ContextOSError("agent-config proposal has an invalid top-level shape")
     operation = document.get("operation")
-    if operation != WORKSPACE_MIGRATION_OPERATION:
+    if operation not in AGENT_SET_OPERATIONS:
         raise ContextOSError(f"unsupported agent lifecycle operation: {operation}")
     created_at = parse_now(ensure_text(document.get("created_at"), "created_at"))
     changes = document.get("changes")
@@ -1533,10 +1630,16 @@ def _validate_agent_proposal_shape(
             or after_mode is not None
         ):
             raise ContextOSError(f"delete action must not carry after content: {relative}")
-    if paths not in (["contextos.workspace.json"], ["workspace.yaml"], [
-        "contextos.workspace.json", "workspace.yaml"
-    ]):
-        raise ContextOSError("workspace migration has an invalid ordered path set")
+    if operation == WORKSPACE_MIGRATION_OPERATION:
+        valid_paths = (
+            ["contextos.workspace.json"],
+            ["workspace.yaml"],
+            ["contextos.workspace.json", "workspace.yaml"],
+        )
+    else:
+        valid_paths = (["contextos.workspace.json"],)
+    if paths not in valid_paths:
+        raise ContextOSError(f"{operation} has an invalid ordered path set")
 
     resolution = resolve_workspace(root)
     if after_config is None:
@@ -1547,6 +1650,25 @@ def _validate_agent_proposal_shape(
         after_config = resolution.config
     before_agents = list(resolution.agents) if resolution.agents is not None else None
     after_agents = list(after_config["agents"])
+    if operation in {AGENT_ENABLE_OPERATION, AGENT_DISABLE_OPERATION}:
+        if before_agents is None:
+            raise ContextOSError(
+                "agent activation requires existing tracked workspace configuration"
+            )
+        before_set = set(before_agents)
+        after_set = set(after_agents)
+        if operation == AGENT_ENABLE_OPERATION and not (
+            before_set < after_set and len(after_set - before_set) == 1
+        ):
+            raise ContextOSError(
+                "stale or invalid agent-enable proposal must add exactly one configured runtime"
+            )
+        if operation == AGENT_DISABLE_OPERATION and not (
+            after_set < before_set and len(before_set - after_set) == 1
+        ):
+            raise ContextOSError(
+                "stale or invalid agent-disable proposal must remove exactly one configured runtime"
+            )
     expected_authorization = {
         "policy": "agent-config-v1",
         "before_agents": before_agents,
@@ -2083,7 +2205,7 @@ def _recover_agent_journal(
         raise ContextOSError(f"invalid transaction journal: {journal}")
     created_at = parse_now(ensure_text(manifest.get("created_at"), "created_at"))
     if workflow == AGENT_LIFECYCLE_WORKFLOW:
-        if manifest.get("operation") != WORKSPACE_MIGRATION_OPERATION:
+        if manifest.get("operation") not in AGENT_SET_OPERATIONS:
             raise ContextOSError(f"invalid agent transaction journal: {journal}")
         evidence = manifest.get("agent_evidence")
         if (
@@ -2374,7 +2496,7 @@ def _recover_agent_journal(
             }
             if (
                 value.get("workflow") != AGENT_LIFECYCLE_WORKFLOW
-                or value.get("operation") != WORKSPACE_MIGRATION_OPERATION
+                or value.get("operation") != manifest.get("operation")
                 or value.get("confirmation")
                 != {"method": "exact-digest-echo", "human_authenticated": False}
                 or value.get("authorization") != expected_authorization

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -56,10 +56,12 @@ HOST_STATE_SCHEMA_VERSION = 1
 EVIDENCE_STALE_AFTER_DAYS = 90
 AGENT_LIFECYCLE_WORKFLOW = "agent-config"
 WORKSPACE_MIGRATION_OPERATION = "workspace-migrate"
+WORKSPACE_SETUP_OPERATION = "workspace-setup"
 AGENT_ENABLE_OPERATION = "agent-enable"
 AGENT_DISABLE_OPERATION = "agent-disable"
 AGENT_SET_OPERATIONS = {
     WORKSPACE_MIGRATION_OPERATION,
+    WORKSPACE_SETUP_OPERATION,
     AGENT_ENABLE_OPERATION,
     AGENT_DISABLE_OPERATION,
 }
@@ -683,7 +685,10 @@ def _agent_lifecycle_authorization(
         raise ContextOSError(
             f"{operation} cannot mutate unowned or component path: {relative}"
         )
-    if relative == "workspace.yaml" and operation != WORKSPACE_MIGRATION_OPERATION:
+    if relative == "workspace.yaml" and operation not in {
+        WORKSPACE_MIGRATION_OPERATION,
+        WORKSPACE_SETUP_OPERATION,
+    }:
         raise ContextOSError(f"{operation} cannot mutate legacy workspace.yaml")
     _reject_config_aliases(root, relative)
     safe_repo_path(root, relative)
@@ -793,6 +798,7 @@ def _create_workspace_config_proposal(
     agents: Sequence[str],
     now: datetime,
     *,
+    operation: str,
     allow_initial: bool,
     allow_agent_expansion: bool,
 ) -> tuple[Path | None, dict[str, Any] | None]:
@@ -828,7 +834,7 @@ def _create_workspace_config_proposal(
         changes.append(
             _agent_change(
                 root,
-                WORKSPACE_MIGRATION_OPERATION,
+                operation,
                 "contextos.workspace.json",
                 action="write",
                 after_text=preview["content"],
@@ -839,7 +845,7 @@ def _create_workspace_config_proposal(
         changes.append(
             _agent_change(
                 root,
-                WORKSPACE_MIGRATION_OPERATION,
+                operation,
                 "workspace.yaml",
                 action="delete",
                 after_text=None,
@@ -855,7 +861,7 @@ def _create_workspace_config_proposal(
     document: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "workflow": workflow,
-        "operation": WORKSPACE_MIGRATION_OPERATION,
+        "operation": operation,
         "created_at": now.isoformat(),
         "proposal_id": proposal_id(workflow, now, changes),
         "changes": changes,
@@ -895,6 +901,7 @@ def create_workspace_migration_proposal(
         root,
         agents,
         now,
+        operation=WORKSPACE_MIGRATION_OPERATION,
         allow_initial=False,
         allow_agent_expansion=False,
     )
@@ -926,6 +933,7 @@ def create_workspace_setup_proposal(
         root,
         selected,
         now,
+        operation=WORKSPACE_SETUP_OPERATION,
         allow_initial=True,
         allow_agent_expansion=True,
     )
@@ -934,7 +942,8 @@ def create_workspace_setup_proposal(
 def agent_list_report(root: Path) -> dict[str, Any]:
     """Report tracked activation and machine-local registration separately."""
     resolution = resolve_workspace(root)
-    configured = set(resolution.agents or ())
+    configured_agents = resolution.agents
+    configured = set(configured_agents or ())
     local_state, legacy_runtime = _hosts_with_legacy(root)
     local_hosts = local_state["hosts"]
     return {
@@ -944,7 +953,9 @@ def agent_list_report(root: Path) -> dict[str, Any]:
         "agents": [
             {
                 "id": runtime,
-                "enabled": runtime in configured,
+                "enabled": (
+                    runtime in configured if configured_agents is not None else None
+                ),
                 "locally_registered": runtime in local_hosts,
             }
             for runtime in runtime_ids(root)
@@ -1632,7 +1643,7 @@ def _validate_agent_proposal_shape(
             or after_mode is not None
         ):
             raise ContextOSError(f"delete action must not carry after content: {relative}")
-    if operation == WORKSPACE_MIGRATION_OPERATION:
+    if operation in {WORKSPACE_MIGRATION_OPERATION, WORKSPACE_SETUP_OPERATION}:
         valid_paths = (
             ["contextos.workspace.json"],
             ["workspace.yaml"],
@@ -1652,6 +1663,29 @@ def _validate_agent_proposal_shape(
         after_config = resolution.config
     before_agents = list(resolution.agents) if resolution.agents is not None else None
     after_agents = list(after_config["agents"])
+    if operation in {WORKSPACE_MIGRATION_OPERATION, WORKSPACE_SETUP_OPERATION}:
+        expected_after = plan_workspace_migration(root, after_agents)["config"]
+        if after_config != expected_after:
+            raise ContextOSError(
+                f"stale or invalid {operation} proposal changes non-agent configuration"
+            )
+    if before_agents is not None and operation == WORKSPACE_MIGRATION_OPERATION:
+        if after_config != resolution.config:
+            raise ContextOSError(
+                "stale or invalid workspace-migrate proposal cannot change tracked configuration"
+            )
+    if before_agents is not None and operation == WORKSPACE_SETUP_OPERATION:
+        before_set = set(before_agents)
+        after_set = set(after_agents)
+        if not before_set.issubset(after_set):
+            raise ContextOSError(
+                "stale or invalid workspace-setup proposal cannot shrink tracked agents"
+            )
+        for field in ("schema_version", "mode", "paths", "template"):
+            if after_config[field] != resolution.config[field]:
+                raise ContextOSError(
+                    "stale or invalid workspace-setup proposal may change only agents"
+                )
     if operation in {AGENT_ENABLE_OPERATION, AGENT_DISABLE_OPERATION}:
         if before_agents is None:
             raise ContextOSError(
@@ -2296,7 +2330,10 @@ def _recover_agent_journal(
             recovery_policy = {
                 "contextos.workspace.json": ("write", "workspace-config", "managed"),
             }
-            if manifest.get("operation") == WORKSPACE_MIGRATION_OPERATION:
+            if manifest.get("operation") in {
+                WORKSPACE_MIGRATION_OPERATION,
+                WORKSPACE_SETUP_OPERATION,
+            }:
                 recovery_policy["workspace.yaml"] = (
                     "delete",
                     "legacy-workspace-config",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,6 +69,10 @@ The script can:
 
 Each optional change is prompted. The script shows setup-file changes before offering a narrowly scoped commit, and that commit defaults to no.
 
+Later, inspect or change the tracked set with `agent list`, `agent enable`, and
+`agent disable`. Each change is an exact proposal that requires a separate
+digest-confirmed `apply`; disabling never deletes the bundled adapter.
+
 ## Choose fresh setup or migration
 
 ### Start from your answers

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -91,8 +91,8 @@ bash scripts/contextos.sh workspace migrate --agents none
 The singular `--agent` form remains a deprecated singleton compatibility alias.
 `--agent` and `--agents` are mutually exclusive. A repeated preview with the
 same set is a no-op; explicit expansion can be previewed; shrinking, replacing,
-or clearing an existing non-empty set is rejected and must use the later
-disable lifecycle. Omitted or `auto` selection never infers intent from binaries
+or clearing an existing non-empty set is rejected and must use `agent disable`.
+Omitted or `auto` selection never infers intent from binaries
 or local state.
 
 Create a local, digest-bound migration proposal after reviewing the preview:
@@ -119,7 +119,7 @@ Legacy-only migration writes JSON and deletes YAML as one recoverable transactio
 under the agent configuration policy. A shadowed YAML file can be deleted when
 canonical JSON already exists and the requested agent set is unchanged. A
 workspace without legacy YAML is setup work, and changing an existing JSON agent
-set belongs to the later agent lifecycle. A repeated completed migration returns
+set belongs to the agent lifecycle. A repeated completed migration returns
 a structured no-op and produces no proposal.
 The transaction authorizer owns only those two exact root paths; ordinary
 setup/update/end proposals cannot use it to widen their path policy.
@@ -136,6 +136,33 @@ shared apply lock; after confirming no apply process is active and removing the
 stale lock, the next agent-configuration apply recovers the journal before
 revalidating and applying its proposal. POSIX mode bits are exact; Windows
 validates only its meaningful writable/read-only behavior.
+
+## Agent activation lifecycle
+
+List every bundled runtime while keeping tracked activation and machine-local
+registration visibly separate:
+
+```bash
+bash scripts/contextos.sh agent list
+```
+
+Create an activation proposal with `agent enable`; `agent add` is an alias.
+`agent disable` is the only operation permitted to shrink tracked intent:
+
+```bash
+bash scripts/contextos.sh agent enable --runtime codex
+bash scripts/contextos.sh agent disable --runtime claude
+bash scripts/contextos.sh apply .context-os/proposals/<proposal-id>.json \
+  --confirm <proposal-digest> --runtime generic
+```
+
+These commands write only an ignored proposal and return the exact config diff,
+authorization evidence, source commit, and digest. Repeating an already-satisfied
+operation is a no-op. Apply revalidates the exact before set and raw config bytes,
+so a stale enable or disable cannot overwrite a newer selection. Activation
+changes only `contextos.workspace.json`: bundled adapters remain in full-template
+mode, and host credentials, local registration, native memory, integrations,
+binaries, and context/state files are outside the transaction.
 
 ## Local scalar runtime migration
 
@@ -182,7 +209,7 @@ intent with these rules:
   configured set;
 - `none` creates an intentional empty set only for a fresh or legacy workspace;
 - subset or `none` reruns against a non-empty set are no-ops;
-- only the explicit disable lifecycle may shrink the configured set;
+- only `agent disable` may shrink the configured set;
 - local launch choice is ephemeral and never creates a stored primary agent;
 - no adapter or component is deleted merely because it was not selected; and
 - Cursor and OpenClaw remain launch/read compatibility names until registered

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -206,6 +206,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertIsNotNone(path)
         self.assertIsNotNone(proposal)
         assert path is not None and proposal is not None
+        self.assertEqual("workspace-setup", proposal["operation"])
         self.assertEqual(["contextos.workspace.json"], [
             change["path"] for change in proposal["changes"]
         ])
@@ -390,6 +391,19 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.resign(path, proposal)
 
         with self.assertRaisesRegex(ContextOSError, "may change only agents"):
+            self.apply(path, proposal)
+
+    def test_crafted_migration_cannot_bypass_disable_or_setup_semantics(self) -> None:
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+        path, proposal = create_workspace_setup_proposal(
+            self.root, ("codex",), NOW.replace(second=1)
+        )
+        assert path is not None and proposal is not None
+        proposal["operation"] = "workspace-migrate"
+        self.resign(path, proposal)
+
+        with self.assertRaisesRegex(ContextOSError, "cannot change tracked configuration"):
             self.apply(path, proposal)
 
     def test_activation_committed_journal_recovers_with_its_exact_operation(self) -> None:

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -31,7 +31,9 @@ from contextos.kernel import (
     _transaction_slot,
     _unlink_readonly_artifact,
     apply_proposal,
+    agent_list_report,
     canonical_json,
+    create_agent_activation_proposal,
     create_proposal,
     create_workspace_migration_proposal,
     create_workspace_setup_proposal,
@@ -273,6 +275,167 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertIn("deprecated", " ".join(report["notices"]))
         self.assertEqual(["claude"], report["authorization"]["after_agents"])
         self.assertFalse((self.root / "contextos.workspace.json").exists())
+
+    def test_agent_enable_disable_are_exact_idempotent_config_only_changes(self) -> None:
+        protected_before = {
+            relative: (self.root / relative).read_bytes()
+            for relative in ("AGENTS.md", "TODO.md", "components/manifest.json")
+        }
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+        local_sentinels = {
+            ".context-os/hosts.json": b'{"schema_version":1,"hosts":{}}\n',
+            ".context-os/native-memory.txt": b"machine-local bytes\r\n",
+        }
+        for relative, content in local_sentinels.items():
+            target = self.root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+            protected_before[relative] = content
+
+        path, proposal = create_agent_activation_proposal(
+            self.root, "codex", True, NOW.replace(second=1)
+        )
+        self.assertIsNotNone(path)
+        self.assertIsNotNone(proposal)
+        assert path is not None and proposal is not None
+        self.assertEqual("agent-enable", proposal["operation"])
+        self.assertEqual(
+            ["contextos.workspace.json"],
+            [change["path"] for change in proposal["changes"]],
+        )
+        self.assertEqual(["claude"], proposal["authorization"]["before_agents"])
+        self.assertEqual(
+            ["claude", "codex"], proposal["authorization"]["after_agents"]
+        )
+        self.apply(path, proposal)
+        self.assertEqual(
+            (None, None),
+            create_agent_activation_proposal(
+                self.root, "codex", True, NOW.replace(second=2)
+            ),
+        )
+
+        path, proposal = create_agent_activation_proposal(
+            self.root, "claude", False, NOW.replace(second=3)
+        )
+        self.assertIsNotNone(path)
+        self.assertIsNotNone(proposal)
+        assert path is not None and proposal is not None
+        self.assertEqual("agent-disable", proposal["operation"])
+        self.assertEqual(
+            ["claude", "codex"], proposal["authorization"]["before_agents"]
+        )
+        self.assertEqual(["codex"], proposal["authorization"]["after_agents"])
+        self.apply(path, proposal)
+        self.assertEqual(
+            (None, None),
+            create_agent_activation_proposal(
+                self.root, "claude", False, NOW.replace(second=4)
+            ),
+        )
+
+        path, proposal = create_agent_activation_proposal(
+            self.root, "codex", False, NOW.replace(second=5)
+        )
+        assert path is not None and proposal is not None
+        self.assertEqual([], proposal["authorization"]["after_agents"])
+        self.apply(path, proposal)
+        configured = json.loads(
+            (self.root / "contextos.workspace.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual([], configured["agents"])
+        for relative, before in protected_before.items():
+            self.assertEqual(before, (self.root / relative).read_bytes(), relative)
+
+    def test_crafted_disable_cannot_remove_more_than_one_runtime(self) -> None:
+        path, proposal = self.propose(("claude", "codex"))
+        self.apply(path, proposal)
+        path, proposal = create_agent_activation_proposal(
+            self.root, "claude", False, NOW.replace(second=1)
+        )
+        assert path is not None and proposal is not None
+        after_config = json.loads(proposal["changes"][0]["after_text"])
+        after_config["agents"] = []
+        after_text = json.dumps(after_config, indent=2) + "\n"
+        proposal["changes"][0] = _agent_change(
+            self.root,
+            "agent-disable",
+            "contextos.workspace.json",
+            action="write",
+            after_text=after_text,
+        )
+        self.resign(path, proposal)
+
+        with self.assertRaisesRegex(ContextOSError, "remove exactly one"):
+            self.apply(path, proposal)
+
+    def test_activation_committed_journal_recovers_with_its_exact_operation(self) -> None:
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+        path, proposal = create_agent_activation_proposal(
+            self.root, "codex", True, NOW.replace(second=1)
+        )
+        assert path is not None and proposal is not None
+        journal = self.root / ".context-os/journals" / proposal["proposal_id"]
+        with mock.patch(
+            "contextos.kernel._discard_agent_journal",
+            side_effect=OSError("retain committed activation journal"),
+        ):
+            receipt, _ = self.apply(path, proposal)
+        self.assertTrue(receipt.exists())
+        self.assertTrue(journal.exists())
+
+        with self.assertRaisesRegex(ContextOSError, "existing receipt"):
+            self.apply(path, proposal)
+        self.assertFalse(journal.exists())
+
+    def test_agent_activation_rejects_unknown_unconfigured_and_stale_state(self) -> None:
+        with self.assertRaisesRegex(ContextOSError, "missing runtime manifest"):
+            create_agent_activation_proposal(self.root, "missing", True, NOW)
+        with self.assertRaisesRegex(ContextOSError, "requires contextos.workspace.json"):
+            create_agent_activation_proposal(self.root, "claude", True, NOW)
+
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+        path, proposal = create_agent_activation_proposal(
+            self.root, "codex", True, NOW.replace(second=1)
+        )
+        assert path is not None and proposal is not None
+        config_path = self.root / "contextos.workspace.json"
+        current = json.loads(config_path.read_text(encoding="utf-8"))
+        current["agents"] = ["claude", "hermes"]
+        config_path.write_text(
+            json.dumps(current, indent=2) + "\n", encoding="utf-8", newline="\n"
+        )
+        with self.assertRaisesRegex(ContextOSError, "stale"):
+            self.apply(path, proposal)
+
+    def test_agent_list_and_cli_alias_report_activation_without_writes(self) -> None:
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+        report = agent_list_report(self.root)
+        statuses = {item["id"]: item for item in report["agents"]}
+        self.assertTrue(statuses["claude"]["enabled"])
+        self.assertFalse(statuses["codex"]["enabled"])
+        self.assertFalse(statuses["claude"]["locally_registered"])
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(
+                0,
+                cli_main([
+                    "--root", str(self.root), "agent", "add",
+                    "--runtime", "codex", "--now", NOW.replace(second=1).isoformat(),
+                ]),
+            )
+        proposal_report = json.loads(output.getvalue())
+        self.assertEqual("agent-enable", proposal_report["operation"])
+        self.assertIn("alias", " ".join(proposal_report["notices"]))
+        configured = json.loads(
+            (self.root / "contextos.workspace.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(["claude"], configured["agents"])
 
     def test_exact_digest_tamper_and_unowned_path_fail_before_writes(self) -> None:
         path, proposal = self.propose()

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -370,6 +370,28 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with self.assertRaisesRegex(ContextOSError, "remove exactly one"):
             self.apply(path, proposal)
 
+    def test_crafted_activation_cannot_rewrite_workspace_paths(self) -> None:
+        path, proposal = self.propose(("claude",))
+        self.apply(path, proposal)
+        path, proposal = create_agent_activation_proposal(
+            self.root, "codex", True, NOW.replace(second=1)
+        )
+        assert path is not None and proposal is not None
+        after_config = json.loads(proposal["changes"][0]["after_text"])
+        after_config["paths"]["state_dir"] = "redirected-state"
+        after_text = json.dumps(after_config, indent=2) + "\n"
+        proposal["changes"][0] = _agent_change(
+            self.root,
+            "agent-enable",
+            "contextos.workspace.json",
+            action="write",
+            after_text=after_text,
+        )
+        self.resign(path, proposal)
+
+        with self.assertRaisesRegex(ContextOSError, "may change only agents"):
+            self.apply(path, proposal)
+
     def test_activation_committed_journal_recovers_with_its_exact_operation(self) -> None:
         path, proposal = self.propose(("claude",))
         self.apply(path, proposal)
@@ -436,6 +458,46 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             (self.root / "contextos.workspace.json").read_text(encoding="utf-8")
         )
         self.assertEqual(["claude"], configured["agents"])
+
+        local = self.root / ".context-os"
+        (local / "runtime.json").write_text(
+            json.dumps({
+                "schema_version": 1,
+                "runtime": "codex",
+                "installed_at": "2026-08-20T12:00:00+00:00",
+                "source_manifest_sha256": "a" * 64,
+            }),
+            encoding="utf-8",
+        )
+        legacy_report = agent_list_report(self.root)
+        legacy_statuses = {item["id"]: item for item in legacy_report["agents"]}
+        self.assertTrue(legacy_statuses["codex"]["locally_registered"])
+        self.assertEqual("codex", legacy_report["legacy_local_runtime"])
+
+    def test_activation_recovery_rejects_legacy_path_under_enable_operation(self) -> None:
+        path, proposal = self.propose()
+        backups = {
+            safe_repo_path(self.root, item["path"]): (
+                safe_repo_path(self.root, item["path"]).read_bytes()
+                if safe_repo_path(self.root, item["path"]).exists()
+                else None
+            )
+            for item in proposal["changes"]
+        }
+        modes = {
+            target: target.stat().st_mode & 0o7777 if target.exists() else None
+            for target in backups
+        }
+        receipt = self.root / ".context-os/receipts" / f"{proposal['proposal_id']}.json"
+        journal = _create_agent_journal(self.root, proposal, backups, modes, receipt)
+        manifest = read_json(journal / "journal.json")
+        manifest["operation"] = "agent-enable"
+        (journal / "journal.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+
+        with self.assertRaisesRegex(ContextOSError, "path is not recoverable"):
+            _recover_pending_agent_journals(self.root)
 
     def test_exact_digest_tamper_and_unowned_path_fail_before_writes(self) -> None:
         path, proposal = self.propose()


### PR DESCRIPTION
Closes #67.

## Summary

- add read-only `agent list` with tracked activation and local registration as separate dimensions
- add idempotent `agent add`/`enable` and configuration-only `agent disable` proposal commands
- enforce exact one-runtime transitions, non-agent field immutability, stale-config rejection, and single-path ownership at apply
- give setup its own `workspace-setup` operation and enforce setup additivity plus migration immutability at apply
- bind crash recovery and committed receipts to the exact operation and operation-specific path policy
- preserve bundled adapters, context/state, host registration, native memory, credentials, integrations, and binaries

## Verification

- canonical `scripts/validate-all.sh`: 380 core passed / 25 skipped; 93 portability passed / 10 skipped; 13 hooks passed; all validators green
- Python 3.10 lifecycle suite: 68 passed / 1 skipped
- focused hostile fixtures cover resigned multi-remove, non-agent path rewrite, migration relabel bypass, stale config, last-agent disable, operation-bound committed-journal recovery, forbidden legacy recovery paths, and legacy local registration
- `git diff --check` and Python compilation passed

## Exact-SHA review

Final reviewed SHA: `78ca9b4a8cec906aeafa68f81d78fded8614c219`

- Claude `claude-opus-5`: NO MERGE-BLOCKING FINDINGS after repair cycles 1 and 2
- Hermes `thinkingmachines/inkling:free`: completed the final review. Its only claimed blocker was rejected first-hand: the model mangled `raise ContextOSError(...)` into Markdown-like text, while both the exact committed file and `git show` contain valid code, `py_compile` passes, and the canonical 380-test gate executes that path successfully. Its prior exact-SHA repair review was clean.

Repair budget: 2/3 cycles used. No verified merge-blocking findings remain.
