### PR TITLE
Harden transaction cleanup diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,10 @@
   retaining a blocked artifact, while strict recovery still surfaces the exact
   cleanup failure. Windows cleanup no longer widens even single-link read-only
   files when atomic deletion is unavailable; it fails closed and reports the
-  observed artifact kind and link count for a later retry.
+  observed artifact kind and link count for a later retry. Retained garbage in
+  incomplete or retired journal namespaces no longer blocks unrelated applies,
+  and dual-failure diagnostics distinguish incomplete transaction recovery from
+  incomplete target rollback.
 - Windows transaction cleanup now removes read-only hard-link names with
   `FileDispositionInfoEx` instead of temporarily widening the shared inode's
   mode, closing the process-death window that could wedge recovery or silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- Best-effort transaction cleanup now continues across removable siblings after
+  retaining a blocked artifact, while strict recovery still surfaces the exact
+  cleanup failure. Windows cleanup no longer widens even single-link read-only
+  files when atomic deletion is unavailable; it fails closed and reports the
+  observed artifact kind and link count for a later retry.
 - Windows transaction cleanup now removes read-only hard-link names with
   `FileDispositionInfoEx` instead of temporarily widening the shared inode's
   mode, closing the process-death window that could wedge recovery or silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,9 @@
   files when atomic deletion is unavailable; it fails closed and reports the
   observed artifact kind and link count for a later retry. Retained garbage in
   incomplete or retired journal namespaces no longer blocks unrelated applies,
-  and dual-failure diagnostics distinguish incomplete transaction recovery from
-  incomplete target rollback.
+  same-ID journal retries use collision-free retired namespaces, and dual-failure
+  diagnostics distinguish incomplete transaction recovery from incomplete target
+  rollback.
 - Windows transaction cleanup now removes read-only hard-link names with
   `FileDispositionInfoEx` instead of temporarily widening the shared inode's
   mode, closing the process-death window that could wedge recovery or silently

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2097,6 +2097,31 @@ def _transaction_slot(ordinal: int, relative: str) -> str:
     return f"{ordinal:04d}-{sha256_text(identity)[:16]}"
 
 
+def _available_transaction_namespace(
+    root: Path,
+    preferred: Path,
+    *,
+    suffix: str,
+) -> Path:
+    """Choose a non-existing sibling without reusing retained garbage."""
+    if not suffix or not preferred.name.endswith(suffix):
+        raise ContextOSError(
+            f"invalid transaction namespace suffix for {preferred}: {suffix!r}"
+        )
+    _guard_local_artifact_path(root, preferred)
+    if not preferred.exists() and not preferred.is_symlink():
+        return preferred
+    stem = preferred.name[: -len(suffix)]
+    for ordinal in range(1, 10_000):
+        candidate = preferred.with_name(f"{stem}.{ordinal}{suffix}")
+        _guard_local_artifact_path(root, candidate)
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise ContextOSError(
+        f"cannot allocate a collision-free transaction namespace beside {preferred}"
+    )
+
+
 def _create_agent_journal(
     root: Path,
     document: dict[str, Any],
@@ -2111,7 +2136,16 @@ def _create_agent_journal(
     building = journal.with_name(f".{journal.name}.building")
     _guard_local_artifact_path(root, building)
     if building.exists() or building.is_symlink():
-        raise ContextOSError(f"agent transaction journal build already exists: {building}")
+        if building.is_symlink() or not building.is_dir():
+            raise ContextOSError(
+                f"invalid agent transaction journal build path: {building}"
+            )
+        _rmtree_readonly_artifacts(building, ignore_errors=True)
+    building = _available_transaction_namespace(
+        root,
+        building,
+        suffix=".building",
+    )
     workflow = document["workflow"]
     entries: list[dict[str, Any]] = []
     for index, change in enumerate(document["changes"]):
@@ -2695,7 +2729,12 @@ def _discard_agent_journal(root: Path, journal: Path) -> None:
     if disposable.exists():
         if disposable.is_symlink() or not disposable.is_dir():
             raise ContextOSError(f"invalid disposable journal path: {disposable}")
-        _rmtree_readonly_artifacts(disposable)
+        _rmtree_readonly_artifacts(disposable, ignore_errors=True)
+    disposable = _available_transaction_namespace(
+        root,
+        disposable,
+        suffix=".discard",
+    )
     journal.rename(disposable)
     _fsync_directory(journal.parent)
     _rmtree_readonly_artifacts(

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2677,8 +2677,10 @@ def _recover_pending_agent_journals(root: Path) -> None:
             (".building", ".discard")
         ):
             # Repository targets are never touched until a complete journal is
-            # atomically promoted out of the build namespace.
-            _rmtree_readonly_artifacts(journal)
+            # atomically promoted out of the build namespace. Discard
+            # namespaces are likewise retired recovery evidence, so a blocked
+            # cleanup artifact must not wedge unrelated future applies.
+            _rmtree_readonly_artifacts(journal, ignore_errors=True)
             continue
         _recover_agent_journal(root, journal)
 
@@ -3432,7 +3434,8 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                     rollback_errors.append(str(rollback_exc))
             if rollback_errors:
                 raise ContextOSError(
-                    f"apply failed and rollback was incomplete ({'; '.join(rollback_errors)}): {exc}"
+                    "apply failed and transaction recovery was incomplete "
+                    f"({'; '.join(rollback_errors)}): {exc}"
                 ) from exc
             if journal_path is not None and journal_path.exists():
                 _discard_agent_journal(root, journal_path)

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1988,26 +1988,19 @@ def _unlink_readonly_artifact(path: Path) -> None:
             raise ContextOSError(
                 f"cannot inspect read-only transaction artifact {path}: {inspect_exc}"
             ) from inspect_exc
-        if (
-            _is_link_like(path)
-            or not stat.S_ISREG(metadata.st_mode)
-            or metadata.st_nlink != 1
-        ):
-            raise ContextOSError(
-                "filesystem cannot safely remove a read-only transaction artifact "
-                f"without changing a shared inode: {path}; use a Windows NTFS "
-                "workspace with FileDispositionInfoEx support"
-            ) from exc
-        original_mode = metadata.st_mode & 0o7777
-        os.chmod(path, original_mode | stat.S_IWRITE)
-        try:
-            path.unlink()
-        except OSError as unlink_exc:
-            if path.exists() and not _is_link_like(path):
-                os.chmod(path, original_mode)
-            raise ContextOSError(
-                f"cannot remove read-only transaction artifact {path}: {unlink_exc}"
-            ) from unlink_exc
+        artifact_kind = (
+            "link-like"
+            if _is_link_like(path)
+            else "regular"
+            if stat.S_ISREG(metadata.st_mode)
+            else "non-regular"
+        )
+        raise ContextOSError(
+            "filesystem cannot safely remove a read-only transaction artifact "
+            "because atomic FileDispositionInfoEx deletion is unavailable: "
+            f"{path} ({artifact_kind}, link count {metadata.st_nlink}); "
+            "the artifact was retained for a later cleanup attempt"
+        ) from exc
 
 
 def _rmtree_readonly_artifacts(
@@ -2045,17 +2038,22 @@ def _rmtree_readonly_artifacts(
                 os.chmod(failed, original_mode)
             raise
 
-    def handle_error(function: Any, failed_path: str, error: Any) -> None:
-        handle_exception(function, failed_path, error[1])
+    def dispatch_exception(
+        function: Any, failed_path: str, exception: BaseException
+    ) -> None:
+        try:
+            handle_exception(function, failed_path, exception)
+        except (OSError, ContextOSError):
+            if not ignore_errors:
+                raise
 
-    try:
-        if sys.version_info >= (3, 12):
-            shutil.rmtree(path, onexc=handle_exception)
-        else:
-            shutil.rmtree(path, onerror=handle_error)
-    except (OSError, ContextOSError):
-        if not ignore_errors:
-            raise
+    def handle_error(function: Any, failed_path: str, error: Any) -> None:
+        dispatch_exception(function, failed_path, error[1])
+
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(path, onexc=dispatch_exception)
+    else:
+        shutil.rmtree(path, onerror=handle_error)
 
 
 def _write_exclusive_bytes(

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -146,7 +146,9 @@ link count for a later retry. This policy avoids a check-then-`chmod` window eve
 when metadata reports a single link, because another link can be created after
 that observation. Cleanup may temporarily add write permission to a directory,
 which Windows does not permit to be hard-linked, and restores the original mode
-if the directory operation fails.
+if the directory operation fails. Incomplete `.building` and retired `.discard`
+journal namespaces contain no recoverable workspace state; their cleanup is
+best-effort and a retained artifact there does not block unrelated applies.
 
 ## Agent activation lifecycle
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -137,6 +137,14 @@ stale lock, the next agent-configuration apply recovers the journal before
 revalidating and applying its proposal. POSIX mode bits are exact; Windows
 validates only its meaningful writable/read-only behavior.
 
+Cleanup never makes a transaction artifact writable merely to delete it. On
+Windows, read-only names are removed atomically with `FileDispositionInfoEx`.
+If that API is unavailable, strict recovery fails closed and best-effort cleanup
+retains the blocked artifact while continuing with other removable siblings;
+the diagnostic reports the observed file kind and link count for a later retry.
+This policy avoids a check-then-`chmod` window even when metadata reports a
+single link, because another link can be created after that observation.
+
 ## Agent activation lifecycle
 
 List every bundled runtime while keeping tracked activation and machine-local

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -148,7 +148,9 @@ that observation. Cleanup may temporarily add write permission to a directory,
 which Windows does not permit to be hard-linked, and restores the original mode
 if the directory operation fails. Incomplete `.building` and retired `.discard`
 journal namespaces contain no recoverable workspace state; their cleanup is
-best-effort and a retained artifact there does not block unrelated applies.
+best-effort and a retained artifact there does not block unrelated applies or a
+new journal with the same proposal ID. A colliding retained namespace is left
+intact and the new build or retirement uses a collision-free numbered sibling.
 
 ## Agent activation lifecycle
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -137,13 +137,16 @@ stale lock, the next agent-configuration apply recovers the journal before
 revalidating and applying its proposal. POSIX mode bits are exact; Windows
 validates only its meaningful writable/read-only behavior.
 
-Cleanup never makes a transaction artifact writable merely to delete it. On
-Windows, read-only names are removed atomically with `FileDispositionInfoEx`.
-If that API is unavailable, strict recovery fails closed and best-effort cleanup
-retains the blocked artifact while continuing with other removable siblings;
-the diagnostic reports the observed file kind and link count for a later retry.
-This policy avoids a check-then-`chmod` window even when metadata reports a
-single link, because another link can be created after that observation.
+Cleanup never makes a transaction *file* writable merely to delete it. On
+Windows, read-only file names are removed atomically with
+`FileDispositionInfoEx`. If that API is unavailable, strict recovery fails
+closed and best-effort cleanup retains the blocked file while continuing with
+other removable siblings; the diagnostic reports the observed file kind and
+link count for a later retry. This policy avoids a check-then-`chmod` window even
+when metadata reports a single link, because another link can be created after
+that observation. Cleanup may temporarily add write permission to a directory,
+which Windows does not permit to be hard-linked, and restores the original mode
+if the directory operation fails.
 
 ## Agent activation lifecycle
 

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -632,7 +632,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             return original_replace(source, destination, *args, **kwargs)
 
         with mock.patch("contextos.kernel.os.replace", side_effect=race_then_fail):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self.apply(path, proposal)
         self.assertEqual(concurrent, target.read_bytes())
         self.assertTrue(legacy.exists())
@@ -661,7 +663,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch("contextos.kernel.os.replace", side_effect=fail_legacy), mock.patch(
             "pathlib.Path.read_bytes", autospec=True, side_effect=race_after_capture_read
         ):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self.apply(path, proposal)
         self.assertEqual(concurrent, target.read_bytes())
         self.assertTrue(legacy.exists())
@@ -686,7 +690,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel.os.replace", side_effect=install_directory_racer
         ):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self.apply(path, proposal)
         journal = self.root / ".context-os/journals" / proposal["proposal_id"]
         self.assertEqual(
@@ -728,7 +734,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel.os.replace", side_effect=race_during_capture
         ):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self.apply(path, proposal)
         journal = self.root / ".context-os/journals" / proposal["proposal_id"]
         capture_dir = next((journal / "rollback").glob("*.current"))
@@ -1168,7 +1176,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel.os.link", side_effect=fail_forward_and_first_restore
         ):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self.apply(path, proposal)
         journal = self.root / ".context-os/journals" / proposal["proposal_id"]
         self.assertFalse(target.exists())
@@ -1211,7 +1221,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             return original(source, destination, *args, **kwargs)
 
         with mock.patch("contextos.kernel.os.link", side_effect=race_target):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self.apply(path, proposal)
         metadata = target.stat()
         self.assertEqual(raced_identity, (metadata.st_dev, metadata.st_ino))
@@ -1451,7 +1463,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertTrue(artifact.exists())
         self.assertFalse(artifact.stat().st_mode & 0o200)
 
-    @unittest.skipUnless(os.name == "nt", "Windows read-only fallback")
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
     def test_readonly_tree_best_effort_suppresses_sharing_violation(self) -> None:
         tree = self.root / ".context-os/staging/held-tree"
         artifact = tree / "artifact"
@@ -1497,6 +1509,38 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertFalse(removable.exists())
         self.assertFalse(nested.exists())
         self.assertFalse((tree / "sub").exists())
+        self.assertFalse(retained.stat().st_mode & 0o200)
+
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
+    def test_retained_discard_artifact_does_not_block_unrelated_apply(self) -> None:
+        discard = self.root / ".context-os/journals/.stale.discard"
+        retained = discard / "aaa-retained"
+        removable = discard / "bbb-removable"
+        discard.mkdir(parents=True)
+        retained.write_bytes(b"retain me\n")
+        removable.write_bytes(b"remove me\n")
+        os.chmod(retained, 0o444)
+        path, proposal = self.propose()
+        original_chmod = os.chmod
+
+        def reject_retained_chmod(candidate, mode, *args, **kwargs):
+            if Path(candidate).resolve() == retained.resolve():
+                raise AssertionError("blocked file cleanup must not chmod")
+            return original_chmod(candidate, mode, *args, **kwargs)
+
+        with mock.patch(
+            "contextos.kernel._windows_unlink_readonly",
+            side_effect=ctypes.WinError(87),
+        ), mock.patch(
+            "contextos.kernel.os.chmod",
+            side_effect=reject_retained_chmod,
+        ):
+            receipt, _ = self.apply(path, proposal)
+
+        self.assertTrue(receipt.exists())
+        self.assertTrue((self.root / "contextos.workspace.json").exists())
+        self.assertTrue(retained.exists())
+        self.assertFalse(removable.exists())
         self.assertFalse(retained.stat().st_mode & 0o200)
 
     def test_strict_recursive_cleanup_reraises_contextos_error(self) -> None:

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -20,6 +20,7 @@ from unittest import mock
 from contextos.cli import main as cli_main
 from contextos.kernel import (
     ContextOSError,
+    _available_transaction_namespace,
     _agent_change,
     _create_agent_journal,
     _discard_agent_journal,
@@ -1273,6 +1274,23 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertFalse(building.exists())
         self.assertTrue((self.root / "contextos.workspace.json").exists())
 
+    def test_transaction_namespace_skips_every_retained_collision(self) -> None:
+        journals = self.root / ".context-os/journals"
+        preferred = journals / ".proposal.discard"
+        first_alternate = journals / ".proposal.1.discard"
+        preferred.mkdir(parents=True)
+        first_alternate.mkdir()
+
+        selected = _available_transaction_namespace(
+            self.root,
+            preferred,
+            suffix=".discard",
+        )
+
+        self.assertEqual(journals / ".proposal.2.discard", selected)
+        self.assertTrue(preferred.is_dir())
+        self.assertTrue(first_alternate.is_dir())
+
     def test_proposal_json_rejects_duplicates_constants_and_boolean_version(self) -> None:
         path, proposal = self.propose()
         raw = path.read_text(encoding="utf-8")
@@ -1512,19 +1530,29 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertFalse(retained.stat().st_mode & 0o200)
 
     @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
-    def test_retained_discard_artifact_does_not_block_unrelated_apply(self) -> None:
-        discard = self.root / ".context-os/journals/.stale.discard"
+    def test_retained_same_id_discard_does_not_block_later_applies(self) -> None:
+        path, proposal = self.propose()
+        discard = (
+            self.root
+            / ".context-os/journals"
+            / f".{proposal['proposal_id']}.discard"
+        )
+        building = discard.with_name(f".{proposal['proposal_id']}.building")
         retained = discard / "aaa-retained"
+        retained_build = building / "aaa-retained"
         removable = discard / "bbb-removable"
         discard.mkdir(parents=True)
+        building.mkdir()
         retained.write_bytes(b"retain me\n")
+        retained_build.write_bytes(b"retain build too\n")
         removable.write_bytes(b"remove me\n")
         os.chmod(retained, 0o444)
-        path, proposal = self.propose()
+        os.chmod(retained_build, 0o444)
         original_chmod = os.chmod
+        protected = {retained.resolve(), retained_build.resolve()}
 
         def reject_retained_chmod(candidate, mode, *args, **kwargs):
-            if Path(candidate).resolve() == retained.resolve():
+            if Path(candidate).resolve() in protected:
                 raise AssertionError("blocked file cleanup must not chmod")
             return original_chmod(candidate, mode, *args, **kwargs)
 
@@ -1536,12 +1564,28 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             side_effect=reject_retained_chmod,
         ):
             receipt, _ = self.apply(path, proposal)
+            next_path, next_proposal = create_agent_activation_proposal(
+                self.root,
+                "codex",
+                True,
+                NOW,
+            )
+            self.assertIsNotNone(next_path)
+            self.assertIsNotNone(next_proposal)
+            next_receipt, _ = self.apply(next_path, next_proposal)
 
         self.assertTrue(receipt.exists())
         self.assertTrue((self.root / "contextos.workspace.json").exists())
         self.assertTrue(retained.exists())
+        self.assertTrue(retained_build.exists())
         self.assertFalse(removable.exists())
         self.assertFalse(retained.stat().st_mode & 0o200)
+        self.assertFalse(retained_build.stat().st_mode & 0o200)
+        self.assertTrue(next_receipt.exists())
+        self.assertEqual(
+            ["claude", "codex"],
+            read_json(self.root / "contextos.workspace.json")["agents"],
+        )
 
     def test_strict_recursive_cleanup_reraises_contextos_error(self) -> None:
         tree = self.root / ".context-os/staging/strict-tree"

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -1471,6 +1471,34 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertTrue(artifact.exists())
         self.assertFalse(artifact.stat().st_mode & 0o200)
 
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
+    def test_readonly_tree_best_effort_removes_real_siblings(self) -> None:
+        tree = self.root / ".context-os/staging/partial-tree"
+        retained = tree / "aaa-retained"
+        removable = tree / "bbb-removable"
+        nested = tree / "sub/ccc-removable"
+        retained.parent.mkdir(parents=True)
+        nested.parent.mkdir()
+        retained.write_bytes(b"retain me\n")
+        removable.write_bytes(b"remove me\n")
+        nested.write_bytes(b"remove me too\n")
+        os.chmod(retained, 0o444)
+
+        with mock.patch(
+            "contextos.kernel._windows_unlink_readonly",
+            side_effect=ctypes.WinError(87),
+        ), mock.patch(
+            "contextos.kernel.os.chmod",
+            side_effect=AssertionError("blocked file cleanup must not chmod"),
+        ):
+            _rmtree_readonly_artifacts(tree, ignore_errors=True)
+
+        self.assertTrue(retained.exists())
+        self.assertFalse(removable.exists())
+        self.assertFalse(nested.exists())
+        self.assertFalse((tree / "sub").exists())
+        self.assertFalse(retained.stat().st_mode & 0o200)
+
     def test_strict_recursive_cleanup_reraises_contextos_error(self) -> None:
         tree = self.root / ".context-os/staging/strict-tree"
         tree.mkdir(parents=True)
@@ -1510,11 +1538,14 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         artifact.write_bytes(b"retained\n")
         metadata = mock.Mock(st_mode=stat.S_IFREG | 0o444, st_nlink=0)
 
+        class UnsupportedDispositionError(OSError):
+            winerror = 87
+
         with mock.patch.object(
             Path, "unlink", side_effect=PermissionError("read-only")
         ), mock.patch("contextos.kernel.os.name", "nt"), mock.patch(
             "contextos.kernel._windows_unlink_readonly",
-            side_effect=ctypes.WinError(87),
+            side_effect=UnsupportedDispositionError("unsupported"),
         ), mock.patch.object(Path, "lstat", return_value=metadata), mock.patch(
             "contextos.kernel.os.chmod",
             side_effect=AssertionError("zero-link cleanup must not chmod"),

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -5,6 +5,7 @@ import json
 import io
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -893,6 +894,32 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertEqual(original, legacy.read_bytes())
         self.assert_no_transaction_artifacts()
 
+    def test_primary_apply_failure_is_reported_with_strict_cleanup_failure(self) -> None:
+        legacy = self.root / "workspace.yaml"
+        original = legacy.read_bytes()
+        path, proposal = self.propose()
+        original_link = os.link
+
+        def fail_receipt(source, destination, *args, **kwargs):
+            if Path(destination).parent.name == "receipts":
+                raise OSError("primary receipt failure")
+            return original_link(source, destination, *args, **kwargs)
+
+        with mock.patch(
+            "contextos.kernel.os.link", side_effect=fail_receipt
+        ), mock.patch(
+            "contextos.kernel._discard_agent_journal",
+            side_effect=ContextOSError("strict journal cleanup failure"),
+        ):
+            with self.assertRaises(ContextOSError) as raised:
+                self.apply(path, proposal)
+
+        diagnostic = str(raised.exception)
+        self.assertIn("primary receipt failure", diagnostic)
+        self.assertIn("strict journal cleanup failure", diagnostic)
+        self.assertEqual(original, legacy.read_bytes())
+        self.assertFalse((self.root / "contextos.workspace.json").exists())
+
     def test_durable_journal_recovers_partial_crash_before_reapply(self) -> None:
         legacy = self.root / "workspace.yaml"
         legacy_bytes = b"state_dir: state\n"
@@ -1343,8 +1370,10 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         else:
             self.assertEqual(0o444, survivor.stat().st_mode & 0o7777)
 
-    @unittest.skipUnless(os.name == "nt", "Windows read-only fallback")
-    def test_readonly_single_link_uses_safe_unsupported_api_fallback(self) -> None:
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
+    def test_readonly_single_link_is_retained_when_atomic_api_is_unsupported(
+        self,
+    ) -> None:
         artifact = self.root / ".context-os/single-readonly-artifact"
         artifact.parent.mkdir()
         artifact.write_bytes(b"single inode\n")
@@ -1353,12 +1382,16 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel._windows_unlink_readonly",
             side_effect=ctypes.WinError(87),
-        ):
+        ), mock.patch(
+            "contextos.kernel.os.chmod",
+            side_effect=AssertionError("unsupported atomic deletion must not chmod"),
+        ), self.assertRaisesRegex(ContextOSError, "artifact was retained"):
             _unlink_readonly_artifact(artifact)
 
-        self.assertFalse(artifact.exists())
+        self.assertTrue(artifact.exists())
+        self.assertFalse(artifact.stat().st_mode & 0o200)
 
-    @unittest.skipUnless(os.name == "nt", "Windows read-only fallback")
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
     def test_readonly_shared_inode_fails_cleanly_when_api_is_unsupported(self) -> None:
         survivor = self.root / "state/current.md"
         survivor.write_bytes(b"shared fallback inode\n")
@@ -1370,14 +1403,14 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel._windows_unlink_readonly",
             side_effect=ctypes.WinError(87),
-        ), self.assertRaisesRegex(ContextOSError, "shared inode"):
+        ), self.assertRaisesRegex(ContextOSError, "link count 2"):
             _unlink_readonly_artifact(artifact)
 
         self.assertTrue(artifact.exists())
         self.assertEqual(b"shared fallback inode\n", survivor.read_bytes())
         self.assertFalse(survivor.stat().st_mode & 0o200)
 
-    @unittest.skipUnless(os.name == "nt", "Windows read-only fallback")
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
     def test_readonly_sharing_violation_never_enters_chmod_fallback(self) -> None:
         artifact = self.root / ".context-os/sharing-violation-artifact"
         artifact.parent.mkdir()
@@ -1396,8 +1429,10 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertTrue(artifact.exists())
         self.assertFalse(artifact.stat().st_mode & 0o200)
 
-    @unittest.skipUnless(os.name == "nt", "Windows read-only fallback")
-    def test_readonly_tree_uses_safe_single_link_unsupported_api_fallback(self) -> None:
+    @unittest.skipUnless(os.name == "nt", "Windows read-only cleanup")
+    def test_readonly_tree_retains_single_link_when_atomic_api_is_unsupported(
+        self,
+    ) -> None:
         tree = self.root / ".context-os/staging/unsupported-tree"
         artifact = tree / "artifact"
         artifact.parent.mkdir(parents=True)
@@ -1407,10 +1442,14 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel._windows_unlink_readonly",
             side_effect=ctypes.WinError(87),
-        ):
+        ), mock.patch(
+            "contextos.kernel.os.chmod",
+            side_effect=AssertionError("unsupported atomic deletion must not chmod"),
+        ), self.assertRaisesRegex(ContextOSError, "artifact was retained"):
             _rmtree_readonly_artifacts(tree)
 
-        self.assertFalse(tree.exists())
+        self.assertTrue(artifact.exists())
+        self.assertFalse(artifact.stat().st_mode & 0o200)
 
     @unittest.skipUnless(os.name == "nt", "Windows read-only fallback")
     def test_readonly_tree_best_effort_suppresses_sharing_violation(self) -> None:
@@ -1431,6 +1470,58 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
 
         self.assertTrue(artifact.exists())
         self.assertFalse(artifact.stat().st_mode & 0o200)
+
+    def test_strict_recursive_cleanup_reraises_contextos_error(self) -> None:
+        tree = self.root / ".context-os/staging/strict-tree"
+        tree.mkdir(parents=True)
+        delegated = ContextOSError("delegated cleanup failure")
+
+        def fail_tree(path, **kwargs):
+            callback = kwargs.get("onexc") or kwargs.get("onerror")
+            error = delegated if "onexc" in kwargs else (None, delegated, None)
+            callback(os.unlink, str(tree / "blocked"), error)
+
+        with mock.patch(
+            "contextos.kernel.shutil.rmtree", side_effect=fail_tree
+        ), self.assertRaisesRegex(ContextOSError, "delegated cleanup failure"):
+            _rmtree_readonly_artifacts(tree)
+
+    def test_best_effort_recursive_cleanup_continues_after_retained_sibling(self) -> None:
+        tree = self.root / ".context-os/staging/best-effort-tree"
+        tree.mkdir(parents=True)
+        removable = tree / "removable"
+        removable.write_bytes(b"remove me\n")
+        delegated = ContextOSError("retained sibling")
+
+        def partial_tree(path, **kwargs):
+            callback = kwargs.get("onexc") or kwargs.get("onerror")
+            error = delegated if "onexc" in kwargs else (None, delegated, None)
+            callback(os.unlink, str(tree / "blocked"), error)
+            removable.unlink()
+
+        with mock.patch("contextos.kernel.shutil.rmtree", side_effect=partial_tree):
+            _rmtree_readonly_artifacts(tree, ignore_errors=True)
+
+        self.assertFalse(removable.exists())
+
+    def test_zero_link_metadata_fails_closed_without_chmod(self) -> None:
+        artifact = self.root / ".context-os/zero-link-artifact"
+        artifact.parent.mkdir()
+        artifact.write_bytes(b"retained\n")
+        metadata = mock.Mock(st_mode=stat.S_IFREG | 0o444, st_nlink=0)
+
+        with mock.patch.object(
+            Path, "unlink", side_effect=PermissionError("read-only")
+        ), mock.patch("contextos.kernel.os.name", "nt"), mock.patch(
+            "contextos.kernel._windows_unlink_readonly",
+            side_effect=ctypes.WinError(87),
+        ), mock.patch.object(Path, "lstat", return_value=metadata), mock.patch(
+            "contextos.kernel.os.chmod",
+            side_effect=AssertionError("zero-link cleanup must not chmod"),
+        ), self.assertRaisesRegex(ContextOSError, "link count 0"):
+            _unlink_readonly_artifact(artifact)
+
+        self.assertEqual(b"retained\n", artifact.read_bytes())
 
     def test_readonly_hardlink_tree_cleanup_preserves_workspace_mode(self) -> None:
         survivor = self.root / "state/current.md"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -554,7 +554,9 @@ class KernelTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel.os.replace", side_effect=race_before_capture
         ):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self._apply(proposal_path, proposal)
         self.assertEqual(concurrent, current.read_bytes())
         self.assertFalse((self.root / "sessions/2026-08-23.md").exists())
@@ -588,7 +590,9 @@ class KernelTest(unittest.TestCase):
         with mock.patch(
             "contextos.kernel._publish_exclusive", side_effect=race_after_publish
         ):
-            with self.assertRaisesRegex(ContextOSError, "rollback was incomplete"):
+            with self.assertRaisesRegex(
+                ContextOSError, "transaction recovery was incomplete"
+            ):
                 self._apply(proposal_path, proposal)
         self.assertEqual(concurrent, current.read_bytes())
         self.assertTrue(


### PR DESCRIPTION
## What's in this PR

Closes the remaining transaction-cleanup follow-up from #89:

- best-effort recursive cleanup now continues attempting siblings after one artifact must be retained;
- strict cleanup directly propagates delegated `ContextOSError` failures;
- Windows no longer falls back to `chmod` when atomic `FileDispositionInfoEx` deletion is unavailable, even for an observed single-link file;
- diagnostics report the retained artifact kind and link count, including `st_nlink == 0`;
- regression coverage proves primary apply failures remain visible alongside strict cleanup failures.

The no-fallback policy removes the link-count check-to-`chmod` race entirely. A blocked artifact remains recoverable and is retried later rather than having its inode permissions widened.

## Verification

- Final SHA: `74b51d712d3215a681fcde4b1a2978775f54e95b`.
- Focused transaction suite: 75 tests passed (1 skipped).
- `bash scripts/validate-all.sh` through Git for Windows: 387 Python tests passed (25 skipped), 93 portability tests passed (10 skipped), 13 hook tests passed; all other validators passed.
- Python 3.10: 387 tests passed (25 skipped).
- Hosted `validate`, `tests-minimum-python`, and `tests-windows`: passed on the final SHA.

## Exact-SHA review

- Claude `claude-opus-5`: **NO MERGE-BLOCKING FINDINGS** after three repair cycles.
- Hermes/OpenRouter `thinkingmachines/inkling:free` (live prompt/completion price `0`): **NO MERGE-BLOCKING FINDINGS**.
- Verified repairs: portable Linux exception construction, accurate file/directory policy, real sibling continuation, non-blocking inert namespace sweeps, and same-ID collision-free build/retirement namespaces.
- Rejected Hermes lesser claims: Python 3.10 and Windows are directly exercised, and the suite already covers the actual atomic deletion function with a real read-only hard link.
- Remaining low-severity diagnostic-honesty observations are filed in #94 and do not affect transaction correctness.

Repair budget: 3/3 cycles used.

Closes #89
Related to #60

## Checklist

### Skills & commands
- [x] No skills or commands added or changed.

### Repo hygiene
- [x] No sensitive data committed (passwords, API keys, tokens)
- [x] `CHANGELOG.md` updated
- [x] CI passes
