### PR TITLE
Separate retained transaction diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,11 +60,11 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
-- `doctor` now distinguishes recoverable transaction journals from inert
-  `.building`/`.discard` cleanup artifacts, preserving recovery advice only for
-  the former and giving path-specific, shared-inode-safe manual cleanup guidance
-  for the latter. Unsupported atomic deletion no longer implies an unchanged
-  retry will self-heal.
+- `doctor` now distinguishes proposal-ID transaction recovery candidates from
+  inert `.building`/`.discard` cleanup artifacts, preserving inspect-and-recover
+  advice only for the former and giving path-specific, shared-inode-safe manual
+  cleanup guidance for the latter. Unsupported atomic deletion no longer implies
+  an unchanged retry will self-heal.
 - Best-effort transaction cleanup now continues across removable siblings after
   retaining a blocked artifact, while strict recovery still surfaces the exact
   cleanup failure. Windows cleanup no longer widens even single-link read-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,10 @@
   files when atomic deletion is unavailable; it fails closed and reports the
   observed artifact kind and link count without implying an unchanged retry can
   self-heal. Retained garbage in incomplete or retired journal namespaces no
-  longer blocks unrelated applies,
-  same-ID journal retries use collision-free retired namespaces, and failure
-  diagnostics now describe incomplete transaction recovery without implying that
-  restored targets necessarily remain incomplete.
+  longer blocks unrelated applies, same-ID journal retries use collision-free
+  retired namespaces, and failure diagnostics now describe incomplete
+  transaction recovery without implying that restored targets necessarily remain
+  incomplete.
 - Windows transaction cleanup now removes read-only hard-link names with
   `FileDispositionInfoEx` instead of temporarily widening the shared inode's
   mode, closing the process-death window that could wedge recovery or silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,15 +60,21 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- `doctor` now distinguishes recoverable transaction journals from inert
+  `.building`/`.discard` cleanup artifacts, preserving recovery advice only for
+  the former and giving path-specific, shared-inode-safe manual cleanup guidance
+  for the latter. Unsupported atomic deletion no longer implies an unchanged
+  retry will self-heal.
 - Best-effort transaction cleanup now continues across removable siblings after
   retaining a blocked artifact, while strict recovery still surfaces the exact
   cleanup failure. Windows cleanup no longer widens even single-link read-only
   files when atomic deletion is unavailable; it fails closed and reports the
-  observed artifact kind and link count for a later retry. Retained garbage in
-  incomplete or retired journal namespaces no longer blocks unrelated applies,
-  same-ID journal retries use collision-free retired namespaces, and dual-failure
-  diagnostics distinguish incomplete transaction recovery from incomplete target
-  rollback.
+  observed artifact kind and link count without implying an unchanged retry can
+  self-heal. Retained garbage in incomplete or retired journal namespaces no
+  longer blocks unrelated applies,
+  same-ID journal retries use collision-free retired namespaces, and failure
+  diagnostics now describe incomplete transaction recovery without implying that
+  restored targets necessarily remain incomplete.
 - Windows transaction cleanup now removes read-only hard-link names with
   `FileDispositionInfoEx` instead of temporarily widening the shared inode's
   mode, closing the process-death window that could wedge recovery or silently

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1999,7 +1999,11 @@ def _unlink_readonly_artifact(path: Path) -> None:
             "filesystem cannot safely remove a read-only transaction artifact "
             "because atomic FileDispositionInfoEx deletion is unavailable: "
             f"{path} ({artifact_kind}, link count {metadata.st_nlink}); "
-            "the artifact was retained for a later cleanup attempt"
+            "the artifact was retained. Automatic retry cannot remove it while "
+            "atomic deletion remains unsupported. Do not change shared-inode "
+            "attributes; resolve filesystem support before retrying, and use "
+            "doctor to determine whether the containing journal is recoverable "
+            "or inert before any manual removal"
         ) from exc
 
 
@@ -2697,6 +2701,12 @@ def _recover_agent_journal(
     )
 
 
+def _is_retired_transaction_namespace(path: Path) -> bool:
+    return path.name.startswith(".") and path.name.endswith(
+        (".building", ".discard")
+    )
+
+
 def _recover_pending_agent_journals(root: Path) -> None:
     journals = root / ".context-os" / "journals"
     _guard_local_artifact_path(root, journals)
@@ -2707,9 +2717,7 @@ def _recover_pending_agent_journals(root: Path) -> None:
     for journal in sorted(journals.iterdir(), key=lambda path: path.name.casefold()):
         if journal.is_symlink() or not journal.is_dir():
             raise ContextOSError(f"invalid agent transaction journal path: {journal}")
-        if journal.name.startswith(".") and journal.name.endswith(
-            (".building", ".discard")
-        ):
+        if _is_retired_transaction_namespace(journal):
             # Repository targets are never touched until a complete journal is
             # atomically promoted out of the build namespace. Discard
             # namespaces are likewise retired recovery evidence, so a blocked
@@ -4547,12 +4555,36 @@ def doctor(
         _guard_local_state_path(root, journals)
         if _is_link_like(journals) or (journals.exists() and not journals.is_dir()):
             raise ContextOSError(f"invalid journal path: {journals}")
-        pending_journals = list(journals.iterdir()) if journals.is_dir() else []
+        journal_artifacts = (
+            sorted(journals.iterdir(), key=lambda path: path.name.casefold())
+            if journals.is_dir()
+            else []
+        )
+        retired_artifacts = [
+            path
+            for path in journal_artifacts
+            if _is_retired_transaction_namespace(path)
+        ]
+        pending_journals = [
+            path
+            for path in journal_artifacts
+            if not _is_retired_transaction_namespace(path)
+        ]
+
+        def artifact_paths(paths: Sequence[Path]) -> str:
+            rendered = [
+                json.dumps(path.relative_to(root).as_posix()) for path in paths[:5]
+            ]
+            if len(paths) > 5:
+                rendered.append(f"and {len(paths) - 5} more")
+            return ", ".join(rendered)
+
         add(
             "transaction-journals",
             "warn" if pending_journals else "pass",
             (
-                f"{len(pending_journals)} pending journal artifact(s); confirm no "
+                f"{len(pending_journals)} recoverable pending journal(s): "
+                f"{artifact_paths(pending_journals)}; confirm no "
                 "apply process is active, remove a stale apply.lock if present, "
                 "then rerun the approved proposal apply to inspect and recover. "
                 "If recovery reports a committed target mismatch, restore the "
@@ -4562,8 +4594,24 @@ def doctor(
             if pending_journals
             else "none",
         )
+        add(
+            "transaction-retired-artifacts",
+            "warn" if retired_artifacts else "pass",
+            (
+                f"{len(retired_artifacts)} inert build/retirement artifact(s): "
+                f"{artifact_paths(retired_artifacts)}; these namespaces contain "
+                "no recoverable workspace state. After confirming no apply "
+                "process is active, remove only the reported paths manually with "
+                "a tool/filesystem that does not change shared-inode attributes; "
+                "an unchanged retry will not self-heal when atomic deletion is "
+                "unsupported"
+            )
+            if retired_artifacts
+            else "none",
+        )
     except (ContextOSError, OSError) as exc:
         add("transaction-journals", "fail", str(exc))
+        add("transaction-retired-artifacts", "fail", str(exc))
     hosts_lock = root / ".context-os" / "hosts.lock"
     try:
         _guard_local_state_path(root, hosts_lock)

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2001,9 +2001,9 @@ def _unlink_readonly_artifact(path: Path) -> None:
             f"{path} ({artifact_kind}, link count {metadata.st_nlink}); "
             "the artifact was retained. Automatic retry cannot remove it while "
             "atomic deletion remains unsupported. Do not change shared-inode "
-            "attributes; resolve filesystem support before retrying. Before any "
-            "manual removal, retain the path unless doctor explicitly classifies "
-            "it as an inert transaction artifact"
+            "attributes; resolve filesystem support before retrying. Retain the "
+            "artifact unless doctor explicitly classifies its containing "
+            "namespace as inert before any manual removal"
         ) from exc
 
 
@@ -4591,7 +4591,7 @@ def doctor(
             "transaction-journals",
             "warn" if pending_journals else "pass",
             (
-                f"{len(pending_journals)} recoverable pending journal(s): "
+                f"{len(pending_journals)} pending recovery candidate(s): "
                 f"{artifact_paths(pending_journals)}; confirm no "
                 "apply process is active, remove a stale apply.lock if present, "
                 "then rerun the approved proposal apply to inspect and recover. "

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -4623,9 +4623,10 @@ def doctor(
             "fail" if invalid_artifacts else "pass",
             (
                 f"{len(invalid_artifacts)} invalid journal entry or entries: "
-                f"{artifact_paths(invalid_artifacts)}; apply rejects symlinks, "
-                "non-directories, and names that are neither proposal IDs nor "
-                "recognized inert namespaces. Confirm no apply is active, inspect "
+                f"{artifact_paths(invalid_artifacts)}; apply does not traverse "
+                "link-like entries and rejects non-directories and names that are "
+                "neither proposal IDs nor recognized inert namespaces. Confirm "
+                "no apply is active, inspect "
                 "and correct or remove only entries explicitly named in this "
                 "report, then rerun doctor to enumerate any remaining paths"
             )

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2001,9 +2001,9 @@ def _unlink_readonly_artifact(path: Path) -> None:
             f"{path} ({artifact_kind}, link count {metadata.st_nlink}); "
             "the artifact was retained. Automatic retry cannot remove it while "
             "atomic deletion remains unsupported. Do not change shared-inode "
-            "attributes; resolve filesystem support before retrying, and use "
-            "doctor to determine whether the containing journal is recoverable "
-            "or inert before any manual removal"
+            "attributes; resolve filesystem support before retrying. Before any "
+            "manual removal, retain the path unless doctor explicitly classifies "
+            "it as an inert transaction artifact"
         ) from exc
 
 
@@ -4563,12 +4563,20 @@ def doctor(
         retired_artifacts = [
             path
             for path in journal_artifacts
-            if _is_retired_transaction_namespace(path)
+            if not _is_link_like(path)
+            and path.is_dir()
+            and _is_retired_transaction_namespace(path)
         ]
         pending_journals = [
             path
             for path in journal_artifacts
-            if not _is_retired_transaction_namespace(path)
+            if not _is_link_like(path)
+            and path.is_dir()
+            and PROPOSAL_ID_RE.fullmatch(path.name) is not None
+        ]
+        classified = {*retired_artifacts, *pending_journals}
+        invalid_artifacts = [
+            path for path in journal_artifacts if path not in classified
         ]
 
         def artifact_paths(paths: Sequence[Path]) -> str:
@@ -4576,7 +4584,7 @@ def doctor(
                 json.dumps(path.relative_to(root).as_posix()) for path in paths[:5]
             ]
             if len(paths) > 5:
-                rendered.append(f"and {len(paths) - 5} more")
+                rendered.append(f"and {len(paths) - 5} more not shown")
             return ", ".join(rendered)
 
         add(
@@ -4600,18 +4608,34 @@ def doctor(
             (
                 f"{len(retired_artifacts)} inert build/retirement artifact(s): "
                 f"{artifact_paths(retired_artifacts)}; these namespaces contain "
-                "no recoverable workspace state. After confirming no apply "
-                "process is active, remove only the reported paths manually with "
-                "a tool/filesystem that does not change shared-inode attributes; "
-                "an unchanged retry will not self-heal when atomic deletion is "
-                "unsupported"
+                "no recoverable workspace state. Future applies retry best-effort "
+                "cleanup, but unsupported atomic deletion will not self-heal. If "
+                "a path remains, confirm no apply is active, remove only paths "
+                "explicitly named in this report with a tool/filesystem that does "
+                "not change shared-inode attributes, then rerun doctor to enumerate "
+                "any remaining paths"
             )
             if retired_artifacts
+            else "none",
+        )
+        add(
+            "transaction-invalid-artifacts",
+            "fail" if invalid_artifacts else "pass",
+            (
+                f"{len(invalid_artifacts)} invalid journal entry or entries: "
+                f"{artifact_paths(invalid_artifacts)}; apply rejects symlinks, "
+                "non-directories, and names that are neither proposal IDs nor "
+                "recognized inert namespaces. Confirm no apply is active, inspect "
+                "and correct or remove only entries explicitly named in this "
+                "report, then rerun doctor to enumerate any remaining paths"
+            )
+            if invalid_artifacts
             else "none",
         )
     except (ContextOSError, OSError) as exc:
         add("transaction-journals", "fail", str(exc))
         add("transaction-retired-artifacts", "fail", str(exc))
+        add("transaction-invalid-artifacts", "fail", str(exc))
     hosts_lock = root / ".context-os" / "hosts.lock"
     try:
         _guard_local_state_path(root, hosts_lock)

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -142,9 +142,10 @@ Windows, read-only file names are removed atomically with
 `FileDispositionInfoEx`. If that API is unavailable, strict recovery fails
 closed and best-effort cleanup retains the blocked file while continuing with
 other removable siblings; the diagnostic reports the observed file kind and
-link count for a later retry. This policy avoids a check-then-`chmod` window even
-when metadata reports a single link, because another link can be created after
-that observation. Cleanup may temporarily add write permission to a directory,
+link count without promising an unchanged retry can remove it. This policy
+avoids a check-then-`chmod` window even when metadata reports a single link,
+because another link can be created after that observation. Cleanup may
+temporarily add write permission to a directory,
 which Windows does not permit to be hard-linked, and restores the original mode
 if the directory operation fails. Incomplete `.building` and retired `.discard`
 journal namespaces contain no recoverable workspace state; their cleanup is
@@ -154,7 +155,9 @@ intact and the new build or retirement uses a collision-free numbered sibling.
 `doctor` reports recoverable journals separately from those inert namespaces:
 pending journals must be recovered rather than deleted, while an inert path may
 be removed manually after confirming no apply is active and using a method that
-does not change shared-inode attributes.
+does not change shared-inode attributes. Symlinks, non-directories, and names
+outside both contracts are a third invalid category that blocks apply until each
+reported path is inspected and corrected or removed.
 
 ## Agent activation lifecycle
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -152,12 +152,13 @@ journal namespaces contain no recoverable workspace state; their cleanup is
 best-effort and a retained artifact there does not block unrelated applies or a
 new journal with the same proposal ID. A colliding retained namespace is left
 intact and the new build or retirement uses a collision-free numbered sibling.
-`doctor` reports recoverable journals separately from those inert namespaces:
-pending journals must be recovered rather than deleted, while an inert path may
-be removed manually after confirming no apply is active and using a method that
-does not change shared-inode attributes. Symlinks, non-directories, and names
-outside both contracts are a third invalid category that blocks apply until each
-reported path is inspected and corrected or removed.
+`doctor` reports proposal-ID recovery candidates separately from those inert
+namespaces. A candidate's manifest is validated only when apply inspects it, so
+the candidate must be recovered or diagnosed rather than deleted. An inert path
+may be removed manually after confirming no apply is active and using a method
+that does not change shared-inode attributes. Symlinks, non-directories, and
+names outside both contracts are a third invalid category that blocks apply
+until each reported path is inspected and corrected or removed.
 
 ## Agent activation lifecycle
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -151,6 +151,10 @@ journal namespaces contain no recoverable workspace state; their cleanup is
 best-effort and a retained artifact there does not block unrelated applies or a
 new journal with the same proposal ID. A colliding retained namespace is left
 intact and the new build or retirement uses a collision-free numbered sibling.
+`doctor` reports recoverable journals separately from those inert namespaces:
+pending journals must be recovered rather than deleted, while an inert path may
+be removed manually after confirming no apply is active and using a method that
+does not change shared-inode attributes.
 
 ## Agent activation lifecycle
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -156,9 +156,10 @@ intact and the new build or retirement uses a collision-free numbered sibling.
 namespaces. A candidate's manifest is validated only when apply inspects it, so
 the candidate must be recovered or diagnosed rather than deleted. An inert path
 may be removed manually after confirming no apply is active and using a method
-that does not change shared-inode attributes. Symlinks, non-directories, and
-names outside both contracts are a third invalid category that blocks apply
-until each reported path is inspected and corrected or removed.
+that does not change shared-inode attributes. Link-like entries, non-directories,
+and names outside both contracts are a third invalid category. Apply does not
+traverse link-like entries and rejects the other invalid forms; inspect and
+correct or remove each reported path before retrying.
 
 ## Agent activation lifecycle
 

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -1342,7 +1342,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             if check["name"] == "transaction-journals"
         )
         self.assertEqual("warn", journal_check["status"])
-        self.assertIn("recoverable pending journal", journal_check["detail"])
+        self.assertIn("pending recovery candidate", journal_check["detail"])
         retired_check = next(
             check
             for check in doctor(self.root)["checks"]
@@ -1411,7 +1411,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertIn('".context-os/journals/.DS_Store"', invalid["detail"])
         self.assertIn('".context-os/journals/.gitkeep"', invalid["detail"])
         self.assertIn("apply rejects", invalid["detail"])
-        self.assertNotIn("recoverable", invalid["detail"])
+        self.assertNotIn("recovery candidate", invalid["detail"])
         self.assertNotIn("rerun the approved proposal", invalid["detail"])
 
     def test_doctor_bounds_retired_paths_with_repeatable_batch_advice(self) -> None:
@@ -1751,7 +1751,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             _unlink_readonly_artifact(artifact)
 
         self.assertIn("Automatic retry cannot remove it", str(raised.exception))
-        self.assertIn("doctor explicitly classifies", str(raised.exception))
+        self.assertIn("containing namespace as inert", str(raised.exception))
         self.assertNotIn("later cleanup attempt", str(raised.exception))
         self.assertEqual(b"retained\n", artifact.read_bytes())
 

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -1410,7 +1410,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertEqual("fail", invalid["status"])
         self.assertIn('".context-os/journals/.DS_Store"', invalid["detail"])
         self.assertIn('".context-os/journals/.gitkeep"', invalid["detail"])
-        self.assertIn("apply rejects", invalid["detail"])
+        self.assertIn("apply does not traverse link-like entries", invalid["detail"])
         self.assertNotIn("recovery candidate", invalid["detail"])
         self.assertNotIn("rerun the approved proposal", invalid["detail"])
 

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -1355,8 +1355,9 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
 
     def test_doctor_separates_pending_and_retired_transaction_artifacts(self) -> None:
         journals = self.root / ".context-os/journals"
-        pending = journals / "pending-proposal"
-        retired = journals / ".pending-proposal.discard"
+        proposal_id = "20260827T120000-agent-config-0123456789"
+        pending = journals / proposal_id
+        retired = journals / f".{proposal_id}.discard"
         building = journals / ".other.1.building"
         pending.mkdir(parents=True)
         retired.mkdir()
@@ -1368,28 +1369,92 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
 
         self.assertEqual("warn", pending_check["status"])
         self.assertIn(
-            '".context-os/journals/pending-proposal"', pending_check["detail"]
+            f'".context-os/journals/{proposal_id}"', pending_check["detail"]
         )
         self.assertIn("do not delete the journal", pending_check["detail"])
-        self.assertNotIn(".pending-proposal.discard", pending_check["detail"])
+        self.assertNotIn(f".{proposal_id}.discard", pending_check["detail"])
 
         self.assertEqual("warn", retired_check["status"])
         self.assertIn(
-            '".context-os/journals/.pending-proposal.discard"',
+            f'".context-os/journals/.{proposal_id}.discard"',
             retired_check["detail"],
         )
         self.assertIn(
             '".context-os/journals/.other.1.building"', retired_check["detail"]
         )
         self.assertIn("no recoverable workspace state", retired_check["detail"])
-        self.assertIn("remove only the reported paths manually", retired_check["detail"])
+        self.assertIn("remove only paths explicitly named", retired_check["detail"])
         self.assertIn("will not self-heal", retired_check["detail"])
         self.assertNotIn("rerun the approved proposal", retired_check["detail"])
+        self.assertEqual("pass", checks["transaction-invalid-artifacts"]["status"])
 
         shutil.rmtree(pending)
         checks = {item["name"]: item for item in doctor(self.root)["checks"]}
         self.assertEqual("pass", checks["transaction-journals"]["status"])
         self.assertEqual("warn", checks["transaction-retired-artifacts"]["status"])
+        self.assertEqual("pass", checks["transaction-invalid-artifacts"]["status"])
+
+    def test_doctor_rejects_non_journal_entries_without_recovery_advice(self) -> None:
+        journals = self.root / ".context-os/journals"
+        stray_file = journals / ".DS_Store"
+        stray_directory = journals / ".gitkeep"
+        journals.mkdir(parents=True)
+        stray_file.write_bytes(b"not a journal\n")
+        stray_directory.mkdir()
+
+        checks = {item["name"]: item for item in doctor(self.root)["checks"]}
+        invalid = checks["transaction-invalid-artifacts"]
+
+        self.assertEqual("pass", checks["transaction-journals"]["status"])
+        self.assertEqual("pass", checks["transaction-retired-artifacts"]["status"])
+        self.assertEqual("fail", invalid["status"])
+        self.assertIn('".context-os/journals/.DS_Store"', invalid["detail"])
+        self.assertIn('".context-os/journals/.gitkeep"', invalid["detail"])
+        self.assertIn("apply rejects", invalid["detail"])
+        self.assertNotIn("recoverable", invalid["detail"])
+        self.assertNotIn("rerun the approved proposal", invalid["detail"])
+
+    def test_doctor_bounds_retired_paths_with_repeatable_batch_advice(self) -> None:
+        journals = self.root / ".context-os/journals"
+        for ordinal in range(7):
+            (journals / f".proposal-{ordinal}.discard").mkdir(parents=True)
+
+        check = next(
+            item
+            for item in doctor(self.root)["checks"]
+            if item["name"] == "transaction-retired-artifacts"
+        )
+
+        self.assertEqual("warn", check["status"])
+        self.assertIn("and 2 more not shown", check["detail"])
+        self.assertIn("remove only paths explicitly named", check["detail"])
+        self.assertIn("rerun doctor to enumerate any remaining paths", check["detail"])
+        self.assertNotIn('".context-os/journals/.proposal-5.discard"', check["detail"])
+
+    def test_doctor_rejects_linked_retired_name_instead_of_calling_it_inert(self) -> None:
+        journals = self.root / ".context-os/journals"
+        outside = self.root / "outside-retired"
+        journals.mkdir(parents=True)
+        outside.mkdir()
+        linked = journals / ".proposal.discard"
+        try:
+            linked.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            self.skipTest("directory symlink creation is unavailable")
+
+        checks = {item["name"]: item for item in doctor(self.root)["checks"]}
+
+        self.assertEqual("pass", checks["transaction-journals"]["status"])
+        self.assertEqual("pass", checks["transaction-retired-artifacts"]["status"])
+        self.assertEqual("fail", checks["transaction-invalid-artifacts"]["status"])
+        self.assertIn(
+            '".context-os/journals/.proposal.discard"',
+            checks["transaction-invalid-artifacts"]["detail"],
+        )
+        with self.assertRaisesRegex(
+            ContextOSError, "invalid agent transaction journal path"
+        ):
+            _recover_pending_agent_journals(self.root)
 
     def test_publication_preserves_existing_modes_and_uses_safe_defaults(self) -> None:
         target = self.root / "sessions/2026-08-25.md"
@@ -1686,7 +1751,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             _unlink_readonly_artifact(artifact)
 
         self.assertIn("Automatic retry cannot remove it", str(raised.exception))
-        self.assertIn("use doctor", str(raised.exception))
+        self.assertIn("doctor explicitly classifies", str(raised.exception))
         self.assertNotIn("later cleanup attempt", str(raised.exception))
         self.assertEqual(b"retained\n", artifact.read_bytes())
 

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -1342,9 +1342,54 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             if check["name"] == "transaction-journals"
         )
         self.assertEqual("warn", journal_check["status"])
+        self.assertIn("recoverable pending journal", journal_check["detail"])
+        retired_check = next(
+            check
+            for check in doctor(self.root)["checks"]
+            if check["name"] == "transaction-retired-artifacts"
+        )
+        self.assertEqual("pass", retired_check["status"])
         with self.assertRaisesRegex(ContextOSError, "existing receipt"):
             self.apply(path, proposal)
         self.assertFalse(journal.exists())
+
+    def test_doctor_separates_pending_and_retired_transaction_artifacts(self) -> None:
+        journals = self.root / ".context-os/journals"
+        pending = journals / "pending-proposal"
+        retired = journals / ".pending-proposal.discard"
+        building = journals / ".other.1.building"
+        pending.mkdir(parents=True)
+        retired.mkdir()
+        building.mkdir()
+
+        checks = {item["name"]: item for item in doctor(self.root)["checks"]}
+        pending_check = checks["transaction-journals"]
+        retired_check = checks["transaction-retired-artifacts"]
+
+        self.assertEqual("warn", pending_check["status"])
+        self.assertIn(
+            '".context-os/journals/pending-proposal"', pending_check["detail"]
+        )
+        self.assertIn("do not delete the journal", pending_check["detail"])
+        self.assertNotIn(".pending-proposal.discard", pending_check["detail"])
+
+        self.assertEqual("warn", retired_check["status"])
+        self.assertIn(
+            '".context-os/journals/.pending-proposal.discard"',
+            retired_check["detail"],
+        )
+        self.assertIn(
+            '".context-os/journals/.other.1.building"', retired_check["detail"]
+        )
+        self.assertIn("no recoverable workspace state", retired_check["detail"])
+        self.assertIn("remove only the reported paths manually", retired_check["detail"])
+        self.assertIn("will not self-heal", retired_check["detail"])
+        self.assertNotIn("rerun the approved proposal", retired_check["detail"])
+
+        shutil.rmtree(pending)
+        checks = {item["name"]: item for item in doctor(self.root)["checks"]}
+        self.assertEqual("pass", checks["transaction-journals"]["status"])
+        self.assertEqual("warn", checks["transaction-retired-artifacts"]["status"])
 
     def test_publication_preserves_existing_modes_and_uses_safe_defaults(self) -> None:
         target = self.root / "sessions/2026-08-25.md"
@@ -1637,9 +1682,12 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         ), mock.patch.object(Path, "lstat", return_value=metadata), mock.patch(
             "contextos.kernel.os.chmod",
             side_effect=AssertionError("zero-link cleanup must not chmod"),
-        ), self.assertRaisesRegex(ContextOSError, "link count 0"):
+        ), self.assertRaisesRegex(ContextOSError, "link count 0") as raised:
             _unlink_readonly_artifact(artifact)
 
+        self.assertIn("Automatic retry cannot remove it", str(raised.exception))
+        self.assertIn("use doctor", str(raised.exception))
+        self.assertNotIn("later cleanup attempt", str(raised.exception))
         self.assertEqual(b"retained\n", artifact.read_bytes())
 
     def test_readonly_hardlink_tree_cleanup_preserves_workspace_mode(self) -> None:

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1814,6 +1814,7 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         checks = {item["name"]: item for item in report["checks"]}
         self.assertEqual("fail", checks["local-host-state"]["status"])
         self.assertEqual("fail", checks["transaction-journals"]["status"])
+        self.assertEqual("fail", checks["transaction-retired-artifacts"]["status"])
         self.assertEqual("fail", checks["host-state-lock"]["status"])
 
     def test_bare_doctor_fails_when_registry_is_empty(self) -> None:

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1815,6 +1815,7 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         self.assertEqual("fail", checks["local-host-state"]["status"])
         self.assertEqual("fail", checks["transaction-journals"]["status"])
         self.assertEqual("fail", checks["transaction-retired-artifacts"]["status"])
+        self.assertEqual("fail", checks["transaction-invalid-artifacts"]["status"])
         self.assertEqual("fail", checks["host-state-lock"]["status"])
 
     def test_bare_doctor_fails_when_registry_is_empty(self) -> None:


### PR DESCRIPTION
## What's in this PR

Closes #94 by separating transaction recovery evidence from inert cleanup garbage in `doctor`:

- `transaction-journals` reports proposal-ID recovery candidates and preserves inspect-and-recover advice without claiming their manifests are already valid;
- `transaction-retired-artifacts` reports inert `.building` / `.discard` namespaces with exact escaped paths and shared-inode-safe, bounded cleanup guidance;
- `transaction-invalid-artifacts` fails on link-like entries, non-directories, and invalid names without assigning recovery advice;
- unsupported Windows atomic deletion no longer promises an unchanged retry will self-heal;
- the diagnostic accurately says apply does not traverse link-like entries, including Windows junctions.

Controls cover mixed pending/retired state, retired-only must-not-fire behavior for the pending check, invalid files and directories, bounded path batches, linked retired names, linked local state, and unsupported zero-link deletion.

## Verification

Final exact SHA: `3066d37f8b1092f9addaf52260268a4cccb0bfa4`.

- Focused transactions: 79 tests, 2 skipped.
- Focused kernel: 93 tests, 10 skipped.
- Canonical validation: 391 tests, 26 skipped; all link, reachability, portability, hook, manifest, registry, workspace, and JSON gates passed.
- Python 3.10 floor: 391 tests, 26 skipped.
- Hosted `validate`, `tests-minimum-python`, and `tests-windows`: passed on the exact SHA.
- Final Claude Opus 5 review: no merge-blocking findings.
- Final Hermes `thinkingmachines/inkling:free` review: `NO MERGE-BLOCKING FINDINGS` (98/100).

Three repair cycles were used. The final Opus pass found one non-blocking staging diagnostic dead end after the repair budget was exhausted; #97 tracks it explicitly. Execution-based verification disproved the earlier junction-traversal concern, so #96 was closed with the verified guard behavior.

Closes #94
Related to #60

## Checklist

### Skills & commands
- [x] No skills or commands added or changed.

### Repo hygiene
- [x] No sensitive data committed (passwords, API keys, tokens)
- [x] `CHANGELOG.md` updated
- [x] CI passes
