### PR TITLE
Make retained staging cleanup guidance actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@
   inert `.building`/`.discard` cleanup artifacts, preserving inspect-and-recover
   advice only for the former and giving path-specific, shared-inode-safe manual
   cleanup guidance for the latter. Unsupported atomic deletion no longer implies
-  an unchanged retry will self-heal.
+  an unchanged retry will self-heal, and retained staging artifacts now receive
+  actionable cleanup guidance without depending on journal-only classification.
 - Best-effort transaction cleanup now continues across removable siblings after
   retaining a blocked artifact, while strict recovery still surfaces the exact
   cleanup failure. Windows cleanup no longer widens even single-link read-only

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -2001,9 +2001,13 @@ def _unlink_readonly_artifact(path: Path) -> None:
             f"{path} ({artifact_kind}, link count {metadata.st_nlink}); "
             "the artifact was retained. Automatic retry cannot remove it while "
             "atomic deletion remains unsupported. Do not change shared-inode "
-            "attributes; resolve filesystem support before retrying. Retain the "
-            "artifact unless doctor explicitly classifies its containing "
-            "namespace as inert before any manual removal"
+            "attributes; resolve filesystem support before retrying. Confirm no "
+            "apply is active before any manual removal. For an artifact under "
+            ".context-os/journals/, use doctor to classify its containing journal "
+            "namespace and do not remove a recovery candidate. A containing "
+            ".context-os/staging/<proposal-id> namespace is disposable after the "
+            "activity check, but remove it only with a tool/filesystem that does "
+            "not change shared-inode attributes"
         ) from exc
 
 

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -161,6 +161,12 @@ and names outside both contracts are a third invalid category. Apply does not
 traverse link-like entries and rejects the other invalid forms; inspect and
 correct or remove each reported path before retrying.
 
+`doctor` does not enumerate `.context-os/staging/`. If unsupported atomic
+deletion retains a staging artifact, first confirm no apply is active. The
+containing `.context-os/staging/<proposal-id>` namespace is then disposable, but
+remove it only with a tool or filesystem that does not change shared-inode
+attributes. Journal paths remain subject to the recovery classifications above.
+
 ## Agent activation lifecycle
 
 List every bundled runtime while keeping tracked activation and machine-local

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -1731,8 +1731,8 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         self.assertFalse(removable.exists())
 
     def test_zero_link_metadata_fails_closed_without_chmod(self) -> None:
-        artifact = self.root / ".context-os/zero-link-artifact"
-        artifact.parent.mkdir()
+        artifact = self.root / ".context-os/staging/proposal-id/zero-link-artifact"
+        artifact.parent.mkdir(parents=True)
         artifact.write_bytes(b"retained\n")
         metadata = mock.Mock(st_mode=stat.S_IFREG | 0o444, st_nlink=0)
 
@@ -1751,9 +1751,28 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             _unlink_readonly_artifact(artifact)
 
         self.assertIn("Automatic retry cannot remove it", str(raised.exception))
-        self.assertIn("containing namespace as inert", str(raised.exception))
+        self.assertIn(
+            ".context-os/staging/<proposal-id> namespace is disposable",
+            str(raised.exception),
+        )
+        self.assertIn("confirm no apply is active", str(raised.exception).lower())
+        self.assertIn("do not remove a recovery candidate", str(raised.exception))
         self.assertNotIn("later cleanup attempt", str(raised.exception))
         self.assertEqual(b"retained\n", artifact.read_bytes())
+        transaction_checks = {
+            check["name"]: check
+            for check in doctor(self.root)["checks"]
+            if check["name"].startswith("transaction-")
+        }
+        self.assertEqual(
+            {"pass"}, {check["status"] for check in transaction_checks.values()}
+        )
+        self.assertTrue(
+            all(
+                ".context-os/staging" not in check["detail"]
+                for check in transaction_checks.values()
+            )
+        )
 
     def test_readonly_hardlink_tree_cleanup_preserves_workspace_mode(self) -> None:
         survivor = self.root / "state/current.md"


### PR DESCRIPTION
## What's in this PR

Closes #97 by making unsupported atomic-deletion guidance actionable for both transaction storage classes:

- journal artifacts still route through `doctor` and must not be removed when they are recovery candidates;
- `.context-os/staging/<proposal-id>` namespaces are explicitly described as disposable only after confirming no apply is active;
- both paths retain the shared-inode safety rule: manual cleanup must not change inode attributes;
- the workspace guide and changelog describe the staging boundary without pretending `doctor` enumerates staging.

The hostile zero-link fixture now reproduces the staging case, proves the error contains staging-specific guidance, and proves all journal transaction checks can legitimately remain `pass`.

## Verification

Final exact SHA: `6af32534c701d412a52baad2f226b5c8fc914fef`.

- Focused transactions: 79 tests, 2 skipped.
- Canonical validation: 391 tests, 26 skipped; all auxiliary gates passed.
- Hosted `validate`, `tests-minimum-python`, and `tests-windows`: passed on the exact SHA.
- Claude Opus 5 exact-SHA review: approve, ready to merge; no correctness defects.
- Hermes free endpoint `thinkingmachines/inkling:free` (reported model `reasoning/inkling`): `NO MERGE-BLOCKING FINDINGS`.

Closes #97
Related to #60 and #95

## Checklist

### Skills & commands
- [x] No skills or commands added or changed.

### Repo hygiene
- [x] No sensitive data committed (passwords, API keys, tokens)
- [x] `CHANGELOG.md` updated
- [x] CI passes
