### PR TITLE
Add experimental OpenClaw runtime support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ remain supported.
 - `.claude/` contains Claude Code commands, hooks, settings, and memory adapters.
 - `.codex/hooks.json` maps Codex events to the same read-only policy checks.
 - `adapters/hermes/` documents optional Hermes hooks and skill installation.
+- `adapters/openclaw/` documents experimental skills-first OpenClaw support.
 - Runtime manifests under `runtimes/` declare support instead of implying parity.
 - Kernel proposal/apply is the enforcement boundary on every host; hooks are
   defense in depth and host-local memory is never shared automatically.
@@ -62,6 +63,17 @@ remain supported.
   `docs/memory-across-agents.md`.
 - `.claude/hooks/` does not run under Hermes. The optional Hermes adapter maps
   supported events to portable checks; kernel enforcement does not depend on it.
+
+## OpenClaw
+
+- Keep OpenClaw's private workspace and native memory outside this repository.
+- Copy all four short lifecycle aliases and all four `context-*` cores into the
+  private workspace's `.agents/skills/`; refresh copied skills after changes.
+- Run OpenClaw from the repository directory so root `AGENTS.md` is included,
+  then invoke `/skill setup`, `/skill start`, `/skill update`, or `/skill end`.
+- This experimental adapter installs no OpenClaw hook or plugin. Skill
+  allowlists do not replace separate shell-execution authorization.
+- See `adapters/openclaw/README.md` for the tested version and diagnostics.
 
 ## Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Experimental OpenClaw onboarding with a machine-readable runtime descriptor,
+  separate private-workspace boundary, copied lifecycle skills, explicit
+  `/skill` invocations, honest no-hook claims, and opt-in installed-version
+  conformance for discovery, precedence, allowlists, diagnostics, and memory
+  isolation against `OpenClaw 2026.7.1-2 (0790d9f)`.
 - Transactional `agent list`, `agent add`/`enable`, and configuration-only
   `agent disable` commands with idempotent exact-set proposals and no adapter,
   host-state, credential, integration, binary, or context-file mutation.
@@ -60,6 +65,10 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- Skill validation now prunes ignored Context OS state and dependency
+  `node_modules` trees while retaining strict checks for repository skill
+  directories, so installed-runtime conformance cannot poison the contributor
+  validation gate.
 - `doctor` now distinguishes proposal-ID transaction recovery candidates from
   inert `.building`/`.discard` cleanup artifacts, preserving inspect-and-recover
   advice only for the former and giving path-specific, shared-inode-safe manual

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Context OS
 
-A portable Git-backed context and workflow layer for agents like Claude Code, Codex, and Hermes. Evolves alongside you and your agents. 
+A portable Git-backed context and workflow layer for agents like Claude Code, Codex, Hermes, and OpenClaw. Evolves alongside you and your agents.
 
 [![GitHub stars](https://img.shields.io/github/stars/conorbronsdon/agent-context-os?style=social)](https://github.com/conorbronsdon/agent-context-os/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -15,7 +15,8 @@ A portable Git-backed context and workflow layer for agents like Claude Code, Co
 
 Chat history, project instructions, and copied prompts drift apart. Context OS puts the durable parts in plain Markdown: who you are, what you are working on, decisions already made, and the workflows you want an agent to follow.
 
-Claude Code, Codex, and Hermes read the same repository state. A deterministic
+Claude Code, Codex, Hermes, and experimental OpenClaw support read the same
+repository state. A deterministic
 lifecycle kernel turns reviewed setup, checkpoint, and close requests into
 hash-checked proposals and receipts, without treating native memory as the
 source of truth.
@@ -23,7 +24,7 @@ source of truth.
 | What you need | How Context OS handles it |
 |---|---|
 | Bring useful context forward | A source-neutral [migration workflow](docs/migration-guide.md) turns selected chats, project instructions, memory exports, and documents into reviewable files. |
-| Work across coding agents | Provider-neutral state, skills, and lifecycle transitions live outside host adapters. Claude Code, Codex, and Hermes share the same kernel. |
+| Work across coding agents | Provider-neutral state, skills, and lifecycle transitions live outside host adapters. Registered runtimes share the same kernel. |
 | Add the tools that fit | A generated [integration catalog](references/integrations.md) documents install scope, data access, side effects, and confirmation gates. Nothing is enabled automatically. |
 | Keep context useful | Session handoffs, staleness checks, decision logs, and reviewable memory proposals make maintenance part of the normal workflow. |
 
@@ -44,6 +45,7 @@ git remote add origin <YOUR_PRIVATE_REPO_URL>
 # Select every agent this repository will use:
 bash scripts/setup.sh --agents claude,codex
 # bash scripts/setup.sh --agents hermes
+# bash scripts/setup.sh --agents openclaw
 # bash scripts/setup.sh --agents none  # core-only
 ```
 
@@ -66,6 +68,7 @@ Then start your agent from the repository root:
 | New workspace in Claude Code | Run `/setup` |
 | New workspace in Codex | Run `$setup` |
 | New workspace in Hermes | Run `/setup` after exposing the repository skills |
+| New workspace in OpenClaw | Follow the [experimental adapter](adapters/openclaw/README.md), then run `/skill setup` |
 | Existing context in another assistant | Follow the [migration guide](docs/migration-guide.md), then use the selected material during setup |
 | claude.ai only | Use [SETUP-PROMPTS.md](SETUP-PROMPTS.md) and copy the approved output into the repository |
 
@@ -75,7 +78,8 @@ The setup interview fills the identity, first project, workflows, and weekly sta
 
 ![A start session in Claude Code: state files load and a session briefing comes back, using sample data from the included example musician project](docs/assets/start-demo.gif)
 
-`/start` in Claude Code or Hermes and `$start` in Codex read your state,
+`/start` in Claude Code or Hermes, `$start` in Codex, and `/skill start` in
+OpenClaw read your state,
 priorities, decisions, blockers, and recent handoff. The result is grounded in
 files rather than reconstructed from chat.
 
@@ -87,12 +91,12 @@ At the end, `/end` or `$end` proposes a handoff for review before it updates `se
 
 Start small. Use the core loop for a week, add one active project, then turn a repeated task into a skill when the repetition is clear.
 
-| Moment | Claude Code | Codex | Hermes | Shared result |
-|---|---|---|---|---|
-| First run or major refresh | `/setup` | `$setup` | `/setup` | Reviewed context proposal |
-| Start work | `/start` | `$start` | `/start` | Read-only continuity inventory and briefing |
-| Save a checkpoint | `/update` | `$update` | `/update` | Hash-checked update and receipt |
-| Finish work | `/end` | `$end` | `/end` | Hash-checked handoff, decisions, and receipt |
+| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Shared result |
+|---|---|---|---|---|---|
+| First run or major refresh | `/setup` | `$setup` | `/setup` | `/skill setup` | Reviewed context proposal |
+| Start work | `/start` | `$start` | `/start` | `/skill start` | Read-only continuity inventory and briefing |
+| Save a checkpoint | `/update` | `$update` | `/update` | `/skill update` | Hash-checked update and receipt |
+| Finish work | `/end` | `$end` | `/end` | `/skill end` | Hash-checked handoff, decisions, and receipt |
 
 The namespaced `$context-setup`, `$context-start`, `$context-update`, and
 `$context-end` invocations remain available for compatibility.
@@ -119,6 +123,7 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 | Claude Code | first-class | Shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation |
 | Codex | first-class | Shared lifecycle, native skills, project instructions, hooks, and reviewed proposal/apply writes |
 | Hermes Agent | first-class | Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory |
+| OpenClaw | experimental | Skills-first lifecycle support with copied portable skills, separate private memory, and no project-hook claim |
 <!-- runtime-support:end -->
 
 Compatibility paths that are not registered runtime adapters:
@@ -126,19 +131,19 @@ Compatibility paths that are not registered runtime adapters:
 | Host | Compatibility path |
 |---|---|
 | Gemini CLI / Antigravity CLI | Migration tooling plus portable-skill discovery for continuing enterprise/API-key Gemini CLI; no complete workspace adapter, and no Antigravity discovery or permission parity is claimed |
-| Cursor / OpenClaw | Read `AGENTS.md` from the repository root; portable skills usable where their Agent Skills support allows |
+| Cursor | Read `AGENTS.md` from the repository root; portable skills usable where its Agent Skills support allows |
 | claude.ai | Manual consumer of selected knowledge files; no repository writes, hooks, or slash-command parity |
 | Other agents | Can use the Markdown state and portable skills only when their file and Agent Skills support is compatible |
 
 ## One source, explicit host adapters
 
-| Capability | Shared | Claude Code | Codex | Hermes |
-|---|---:|---:|---:|---:|
-| Identity, project, state, and session files | Yes | Reads | Reads | Reads |
-| Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls |
-| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. |
-| Project hooks | Event contract only | `.claude/` | `.codex/` | Optional adapter |
-| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` |
+| Capability | Shared | Claude Code | Codex | Hermes | OpenClaw (experimental) |
+|---|---:|---:|---:|---:|---:|
+| Identity, project, state, and session files | Yes | Reads | Reads | Reads | Reads |
+| Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls | Copied skill calls |
+| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. | `/skill setup` etc. |
+| Project hooks | Event contract only | `.claude/` | `.codex/` | Optional adapter | Not claimed |
+| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` | Private workspace |
 
 The shared layer is intentionally plain files. Provider-specific tool names, hooks, permissions, and memory features stay in their adapter directories.
 
@@ -168,6 +173,7 @@ contextos/                 Deterministic lifecycle kernel
 .claude/hooks/             Claude Code-only safety and session hooks
 .codex/hooks.json          Codex lifecycle advisory adapter
 adapters/hermes/           Hermes installation and optional hook adapter
+adapters/openclaw/         Experimental OpenClaw skills-first adapter
 runtimes/                  Machine-readable capability manifests
 components/                Component ownership and dependency manifest
 workspace/                 Schema and inactive canonical config example
@@ -228,6 +234,7 @@ behavior of an installed agent version or an external service.
 | Import useful context from another system | [Migration guide](docs/migration-guide.md) |
 | Use the repository in Codex | [Codex onboarding](docs/codex-onboarding.md) |
 | Use the repository in Hermes Agent | [Memory across agents](docs/memory-across-agents.md) and the Hermes section of [AGENTS.md](AGENTS.md) |
+| Use the repository in OpenClaw | [Experimental OpenClaw adapter](adapters/openclaw/README.md) |
 | Keep claude.ai projects aligned | [Claude projects sync](docs/claude-projects-sync.md) |
 | See every command and portable skill | [Commands and skills](docs/commands-and-skills.md) |
 | Understand component ownership and future clean composition | [Component model](docs/component-model.md) |

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -1,0 +1,76 @@
+# OpenClaw experimental adapter
+
+This adapter has been tested against `OpenClaw 2026.7.1-2 (0790d9f)`. It
+provides skills-first lifecycle support. It does not claim OpenClaw project
+hooks, automatic memory synchronization, or messaging/gateway conformance.
+
+## Keep the two workspaces separate
+
+Use this repository as the execution directory and a different, private
+directory as OpenClaw's workspace. OpenClaw treats its workspace as private
+memory, not as a sandbox. `SOUL.md`, `USER.md`, `MEMORY.md`, and `memory/`
+belong there; do not add them to this repository merely to make OpenClaw work.
+
+When OpenClaw executes from the repository, it appends the repository-root
+`AGENTS.md` to its instructions. It does not load execution-directory
+`SOUL.md`, `USER.md`, or `MEMORY.md` as workspace memory.
+
+## Install the lifecycle skills
+
+Copy these eight directories from the repository's `.agents/skills/` directory
+to `<private-workspace>/.agents/skills/`:
+
+- `setup` and `context-setup`
+- `start` and `context-start`
+- `update` and `context-update`
+- `end` and `context-end`
+
+Copy all eight together. The short names are aliases for the `context-*` cores,
+and copied skills must be refreshed after their repository sources change.
+The stable version tested here did not discover the same skills reliably via
+`skills.load.extraDirs`, so this adapter does not recommend that shortcut.
+
+OpenClaw's skill precedence puts `<workspace>/skills` ahead of
+`<workspace>/.agents/skills`. A same-named skill in `skills/` can therefore
+shadow a copied Context OS skill. Check the effective inventory after copying:
+
+```bash
+openclaw skills list --json
+openclaw skills check --json
+```
+
+All eight lifecycle skills should report source `agents-skills-project`.
+
+## Run the lifecycle
+
+Start OpenClaw with the repository as its execution directory, while the
+OpenClaw configuration still points at the separate private workspace. Invoke
+the lifecycle explicitly:
+
+```text
+/skill setup
+/skill start
+/skill update
+/skill end
+```
+
+Context OS proposal/apply remains the write-safety boundary. Review the exact
+proposal and approve that digest before applying it.
+
+## Boundaries and diagnostics
+
+- OpenClaw skill allowlists control model and command visibility. They are not
+  shell-execution authorization. Configure execution approvals separately.
+- Workspace hooks are disabled until explicitly enabled. This experimental
+  adapter installs no hook or plugin and makes no blocking-hook claim.
+- Native OpenClaw memory is private host state and is not synchronized with
+  repository state automatically.
+- Use `openclaw doctor --lint --json` for a read-only native diagnostic. Exit 1
+  can mean lint findings. Do not use `--fix` as a validation step because it can
+  modify host state.
+- Context OS `doctor` resolves descriptor probe binaries but never executes
+  them. Native OpenClaw diagnostics remain an explicit operator action.
+
+The executable conformance fixture is opt-in because it requires the exact
+tested OpenClaw binary. Set `CONTEXTOS_OPENCLAW_BIN` to that executable and run
+`python -m unittest tests.test_openclaw_conformance`.

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -39,7 +39,9 @@ openclaw skills list --json
 openclaw skills check --json
 ```
 
-All eight lifecycle skills should report source `agents-skills-project`.
+Run those inventory commands from the private workspace, not from the source
+repository. All eight lifecycle skills should report source
+`agents-skills-project`.
 
 ## Run the lifecycle
 
@@ -60,7 +62,9 @@ proposal and approve that digest before applying it.
 ## Boundaries and diagnostics
 
 - OpenClaw skill allowlists control model and command visibility. They are not
-  shell-execution authorization. Configure execution approvals separately.
+  shell-execution authorization. Configure execution approvals separately. If
+  an agent skill allowlist is present, include all eight lifecycle skill names
+  or the omitted commands will not be visible to that agent.
 - Workspace hooks are disabled until explicitly enabled. This experimental
   adapter installs no hook or plugin and makes no blocking-hook claim.
 - Native OpenClaw memory is private host state and is not synchronized with

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -770,6 +770,29 @@
             ]
         },
         {
+            "id": "openclaw-adapter",
+            "description": "Experimental OpenClaw onboarding, runtime descriptor, and installed-version conformance controls.",
+            "depends_on": [
+                "core",
+                "portable-skills",
+                "agents-instructions"
+            ],
+            "paths": [
+                {
+                    "path": "adapters/openclaw/README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "runtimes/openclaw.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "tests/test_openclaw_conformance.py",
+                    "policy": "development"
+                }
+            ]
+        },
+        {
             "id": "example-project",
             "description": "Optional removable example project and workflow seeds.",
             "depends_on": [

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -6,12 +6,12 @@ dates, append behavior, optimistic hashes, locking, and receipts.
 
 ## Shared lifecycle
 
-| Job | Claude Code | Codex | Hermes | Deterministic operation |
-|---|---|---|---|---|
-| Initialize context | `/setup` | `$setup` | `/setup` | `contextos propose setup` then `apply` |
-| Start a session | `/start` | `$start` | `/start` | read-only `contextos start` |
-| Checkpoint | `/update` | `$update` | `/update` | `contextos propose update` then `apply` |
-| Close a session | `/end` | `$end` | `/end` | `contextos propose end` then `apply` |
+| Job | Claude Code | Codex | Hermes | OpenClaw (experimental) | Deterministic operation |
+|---|---|---|---|---|---|
+| Initialize context | `/setup` | `$setup` | `/setup` | `/skill setup` | `contextos propose setup` then `apply` |
+| Start a session | `/start` | `$start` | `/start` | `/skill start` | read-only `contextos start` |
+| Checkpoint | `/update` | `$update` | `/update` | `/skill update` | `contextos propose update` then `apply` |
+| Close a session | `/end` | `$end` | `/end` | `/skill end` | `contextos propose end` then `apply` |
 
 The portable cores are `.agents/skills/context-setup`, `context-start`,
 `context-update`, and `context-end`. Short skill directories are thin aliases;
@@ -28,13 +28,13 @@ The mutation protocol is always:
 
 ## Runtime boundary
 
-| Capability | Claude Code | Codex | Hermes |
-|---|---|---|---|
-| Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` |
-| Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills |
-| Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter |
-| Lifecycle enforcement | Kernel | Kernel | Kernel |
-| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` |
+| Capability | Claude Code | Codex | Hermes | OpenClaw (experimental) |
+|---|---|---|---|---|
+| Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | Execution-directory `AGENTS.md` |
+| Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills | Copied into private workspace `.agents/skills/` |
+| Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter | Not claimed |
+| Lifecycle enforcement | Kernel | Kernel | Kernel | Kernel |
+| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` | Private OpenClaw workspace |
 
 Runtime manifests in `runtimes/` are machine-readable claims. Hooks are defense
 in depth: the kernel repeats mutation invariants during every proposal and apply.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,12 +2,12 @@
 
 Context OS can begin with a blank interview or selected context from another
 assistant. The result is a small, reviewable repository that Claude Code,
-Codex, and Hermes can use as shared state.
+Codex, Hermes, and experimental OpenClaw support can use as shared state.
 
 ## Before you clone
 
 You need Git, Bash, Python 3.10 or newer, and at least one supported local
-agent: Claude Code, Codex, or Hermes. claude.ai can help produce files but
+agent: Claude Code, Codex, Hermes, or OpenClaw. claude.ai can help produce files but
 cannot maintain a local checkout directly.
 
 Python may be installed as either `python3` or `python`; the repository resolves
@@ -45,6 +45,8 @@ Choose every registered agent you expect to use with this repository:
 bash scripts/setup.sh --agents claude,codex
 # or
 bash scripts/setup.sh --agents hermes
+# or
+bash scripts/setup.sh --agents openclaw
 # or, for the provider-neutral core only
 bash scripts/setup.sh --agents none
 ```
@@ -85,9 +87,13 @@ claude
 codex
 # or
 hermes
+# or, after following adapters/openclaw/README.md
+openclaw
 ```
 
-Run `/setup` in Claude Code or Hermes, or `$setup` in Codex. The guided
+Run `/setup` in Claude Code or Hermes, `$setup` in Codex, or `/skill setup` in
+OpenClaw. OpenClaw first requires the separate private-workspace and copied-skill
+steps in its [experimental adapter guide](../adapters/openclaw/README.md). The guided
 interview asks one question at a time, builds a deterministic proposal, and
 waits before applying the exact reviewed diff.
 
@@ -130,11 +136,11 @@ Commit and push only after the diff matches what you intend to preserve.
 
 ## Run the daily loop
 
-| Moment | Claude Code | Codex | Hermes |
-|---|---|---|---|
-| Start work | `/start` | `$start` | `/start` |
-| Save progress without closing | `/update` | `$update` | `/update` |
-| End with a reviewed handoff | `/end` | `$end` | `/end` |
+| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) |
+|---|---|---|---|---|
+| Start work | `/start` | `$start` | `/start` | `/skill start` |
+| Save progress without closing | `/update` | `$update` | `/update` | `/skill update` |
+| End with a reviewed handoff | `/end` | `$end` | `/end` | `/skill end` |
 
 The lifecycle kernel writes shared continuity to `state/` and `sessions/` only
 after exact-proposal approval, then emits a local receipt. Each host retains

--- a/docs/memory-across-agents.md
+++ b/docs/memory-across-agents.md
@@ -34,9 +34,21 @@ repository proposal. Do not run multiple writers against one Hermes home, and
 do not duplicate the same fact in native memory and repository state without a
 declared canonical home.
 
+## OpenClaw
+
+OpenClaw's workspace is private memory, not a sandbox. Keep its `SOUL.md`,
+`USER.md`, `MEMORY.md`, and `memory/` directory in a private workspace outside
+this repository. Run OpenClaw from the repository directory so it receives the
+root `AGENTS.md`, but do not make the repository itself the OpenClaw workspace.
+
+The experimental adapter copies lifecycle skills into that private workspace.
+It does not synchronize native memory into Context OS. Promote a durable fact
+across runtimes only through the same reviewed repository proposal used by the
+other hosts.
+
 ## Proposal/apply boundary
 
-All three runtimes use the same repository transaction:
+All registered runtimes use the same repository transaction:
 
 1. reviewed structured input;
 2. exact proposed diffs and digest;

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -242,8 +242,10 @@ intent with these rules:
 - only `agent disable` may shrink the configured set;
 - local launch choice is ephemeral and never creates a stored primary agent;
 - no adapter or component is deleted merely because it was not selected; and
-- Cursor and OpenClaw remain launch/read compatibility names until registered
-  runtime descriptors exist, so they cannot be stored in `agents` yet.
+- Cursor remains a launch/read compatibility name until a registered runtime
+  descriptor exists, so it cannot be stored in `agents` yet. OpenClaw is a
+  registered experimental runtime and can be selected, but its private
+  workspace and copied-skill onboarding remain separate host-local steps.
 
 ## Root discovery
 

--- a/runtimes/openclaw.json
+++ b/runtimes/openclaw.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 2,
+  "runtime": "openclaw",
+  "display_name": "OpenClaw",
+  "support_tier": "experimental",
+  "support_summary": "Skills-first lifecycle support with copied portable skills, separate private memory, and no project-hook claim",
+  "components": ["core", "portable-skills", "agents-instructions", "openclaw-adapter"],
+  "install": {
+    "mode": "skill-copy-to-private-workspace",
+    "next_steps": [
+      "Create or choose a private OpenClaw workspace outside this repository.",
+      "Copy all eight lifecycle skill directories from this repository's .agents/skills directory into the private workspace's .agents/skills directory.",
+      "Run OpenClaw from the repository directory and invoke lifecycle skills explicitly with /skill setup, /skill start, /skill update, or /skill end."
+    ]
+  },
+  "onboarding_doc": "adapters/openclaw/README.md",
+  "surfaces": {
+    "cli": {
+      "kind": "cli",
+      "support_tier": "experimental",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100},
+        {"scope": "workspace", "role": "persona", "path": "SOUL.md", "precedence": 90},
+        {"scope": "workspace", "role": "persona", "path": "USER.md", "precedence": 80},
+        {"scope": "workspace", "role": "memory", "path": "MEMORY.md", "precedence": 70}
+      ],
+      "skill_sources": [
+        {"scope": "workspace", "role": "skills", "path": "skills", "precedence": 100},
+        {"scope": "workspace", "role": "skills", "path": ".agents/skills", "precedence": 90}
+      ],
+      "invocation": {
+        "setup": "/skill setup",
+        "start": "/skill start",
+        "update": "/skill update",
+        "end": "/skill end"
+      },
+      "capabilities": {
+        "agent_skills": "native",
+        "explicit_invocation": "native",
+        "project_hooks": "unsupported",
+        "blocking_pre_tool_hook": "unsupported",
+        "mcp": "native",
+        "native_memory": "native",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "native",
+        "execution_authorization": "native"
+      },
+      "hook_output": null,
+      "binary_probes": [
+        {"purpose": "availability", "candidates": ["openclaw"]},
+        {"purpose": "version", "candidates": ["openclaw"]},
+        {"purpose": "native-doctor", "candidates": ["openclaw"]}
+      ],
+      "conformance_tests": [
+        "tests/test_openclaw_conformance.py",
+        "tests/test_contextos_kernel.py"
+      ],
+      "evidence": [
+        "openclaw-skills",
+        "openclaw-workspace",
+        "openclaw-system-prompt",
+        "openclaw-exec-approvals",
+        "openclaw-doctor",
+        "openclaw-mcp",
+        "openclaw-kernel",
+        "openclaw-conformance"
+      ]
+    }
+  },
+  "evidence": {
+    "checked_on": "2026-08-27",
+    "tested_versions": [
+      {"surface": "cli", "version": "OpenClaw 2026.7.1-2 (0790d9f)"}
+    ],
+    "sources": [
+      {
+        "id": "openclaw-skills",
+        "type": "official",
+        "location": "https://docs.openclaw.ai/tools/skills",
+        "claims": ["agent_skills", "explicit_invocation", "skill_allowlists", "skill_sources", "invocation"]
+      },
+      {
+        "id": "openclaw-workspace",
+        "type": "official",
+        "location": "https://docs.openclaw.ai/agent-workspace",
+        "claims": ["native_memory", "instruction_sources"]
+      },
+      {
+        "id": "openclaw-system-prompt",
+        "type": "official",
+        "location": "https://docs.openclaw.ai/concepts/system-prompt",
+        "claims": ["instruction_sources"]
+      },
+      {
+        "id": "openclaw-exec-approvals",
+        "type": "official",
+        "location": "https://docs.openclaw.ai/tools/exec-approvals",
+        "claims": ["execution_authorization"]
+      },
+      {
+        "id": "openclaw-doctor",
+        "type": "official",
+        "location": "https://docs.openclaw.ai/cli/doctor",
+        "claims": ["support"]
+      },
+      {
+        "id": "openclaw-mcp",
+        "type": "official",
+        "location": "https://docs.openclaw.ai/cli/mcp",
+        "claims": ["mcp"]
+      },
+      {
+        "id": "openclaw-kernel",
+        "type": "conformance",
+        "location": "tests/test_contextos_kernel.py",
+        "claims": ["proposal_apply"]
+      },
+      {
+        "id": "openclaw-conformance",
+        "type": "conformance",
+        "location": "tests/test_openclaw_conformance.py",
+        "claims": ["support", "skill_sources", "instruction_sources", "invocation"]
+      }
+    ]
+  }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
-SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex|auto|none] [--agent auto|RUNTIME|none]"
+SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex,openclaw|auto|none] [--agent auto|RUNTIME|none]"
 AGENT_SELECTION_KIND=""
 AGENT_SELECTION_RAW=""
 while [ "$#" -gt 0 ]; do
@@ -60,7 +60,7 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       echo "$SETUP_USAGE"
       echo "  --agents records an additive tracked runtime set; it never removes agents."
-      echo "  --agent is the deprecated singleton alias and retains auto/Cursor/OpenClaw launch compatibility."
+      echo "  --agent is the deprecated singleton alias and retains auto/Cursor launch compatibility."
       exit 0
       ;;
     *)
@@ -90,7 +90,7 @@ validate_agent_selection() {
         LAUNCH_SELECTION="auto"
         return
         ;;
-      cursor|openclaw)
+      cursor)
         LAUNCH_SELECTION="$raw"
         echo "  Note: $raw remains launch-only until it has a registered runtime descriptor."
         return
@@ -496,6 +496,8 @@ if [[ "$SELECTED_AGENT" == *,* ]]; then
     SELECTED_AGENT="codex"
   elif [[ ",$SELECTED_AGENT," == *,hermes,* ]] && [ "$HERMES_FOUND" = true ]; then
     SELECTED_AGENT="hermes"
+  elif [[ ",$SELECTED_AGENT," == *,openclaw,* ]] && [ "$OPENCLAW_FOUND" = true ]; then
+    SELECTED_AGENT="openclaw"
   else
     SELECTED_AGENT="none"
   fi
@@ -507,6 +509,8 @@ if [ "$SELECTED_AGENT" = "auto" ]; then
     SELECTED_AGENT="codex"
   elif [ "$HERMES_FOUND" = true ]; then
     SELECTED_AGENT="hermes"
+  elif [ "$OPENCLAW_FOUND" = true ]; then
+    SELECTED_AGENT="openclaw"
   else
     SELECTED_AGENT="none"
   fi
@@ -572,9 +576,16 @@ case "$SELECTED_AGENT" in
     fi
     ;;
   openclaw)
-    printf '  1. cd %q && openclaw\n' "$REPO_ROOT"
-    echo "  2. OpenClaw reads AGENTS.md and agentskills.io-compatible skills from"
-    echo "     .agents/skills/. See AGENTS.md for the session loop."
+    if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
+      "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime openclaw >/dev/null
+    fi
+    echo "  1. Create or choose a private OpenClaw workspace outside this repository."
+    echo "  2. Copy all eight lifecycle skills from .agents/skills/ into that"
+    echo "     workspace's .agents/skills/ directory."
+    printf '  3. cd %q && openclaw\n' "$REPO_ROOT"
+    echo "  4. Type: /skill setup"
+    echo "     Native OpenClaw memory stays in the private workspace."
+    echo "     See adapters/openclaw/README.md for configuration and limits."
     echo ""
     if [ -t 0 ] && [ "$OPENCLAW_FOUND" = true ] && prompt_yn "  Launch OpenClaw now?" "y"; then
       cd "$REPO_ROOT"
@@ -586,7 +597,7 @@ case "$SELECTED_AGENT" in
     printf '  Codex:       cd %q && codex, then run $setup\n' "$REPO_ROOT"
     printf '  Hermes:      cd %q && hermes (reads AGENTS.md; see AGENTS.md Hermes section)\n' "$REPO_ROOT"
     printf '  Cursor:      cd %q and open in Cursor (reads AGENTS.md)\n' "$REPO_ROOT"
-    printf '  OpenClaw:    cd %q && openclaw (reads AGENTS.md + .agents/skills/)\n' "$REPO_ROOT"
+    echo "  OpenClaw:    see adapters/openclaw/README.md (private workspace + copied skills)"
     echo "  claude.ai:   open SETUP-PROMPTS.md and paste the prompts there"
     echo "  Guide:       docs/getting-started.md"
     echo ""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -586,11 +586,9 @@ case "$SELECTED_AGENT" in
     echo "  4. Type: /skill setup"
     echo "     Native OpenClaw memory stays in the private workspace."
     echo "     See adapters/openclaw/README.md for configuration and limits."
+    echo "     Setup does not launch OpenClaw because it cannot verify that private"
+    echo "     workspace configuration without reading or changing host state."
     echo ""
-    if [ -t 0 ] && [ "$OPENCLAW_FOUND" = true ] && prompt_yn "  Launch OpenClaw now?" "y"; then
-      cd "$REPO_ROOT"
-      exec openclaw
-    fi
     ;;
   none)
     printf '  Claude Code: cd %q && claude, then run /setup\n' "$REPO_ROOT"

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -36,7 +36,7 @@ check_frontmatter() {
 # ── Check 1: All skill directories have a SKILL.md ──────────────────────────
 
 SKILL_DIRS=$(find . \
-  -path './.git' -prune -o \
+  \( -path './.git' -o -path './.context-os' -o -name node_modules \) -prune -o \
   -type d -name 'skills' -print | \
   xargs -I{} find {} -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
 
@@ -50,7 +50,9 @@ done
 
 while IFS= read -r -d '' skill; do
   check_frontmatter "$skill" 60
-done < <(find . -path './.git' -prune -o -name 'SKILL.md' -print0)
+done < <(find . \
+  \( -path './.git' -o -path './.context-os' -o -name node_modules \) -prune -o \
+  -name 'SKILL.md' -print0)
 
 # ── Check 3: All command .md files have valid frontmatter ───────────────────
 

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -271,6 +271,11 @@ fi
 help_output=$(bash scripts/setup.sh --help)
 grep -Fq -- '--agents claude,codex,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
 grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"
+grep -Fq 'Setup does not launch OpenClaw' scripts/setup.sh \
+  || fail "OpenClaw setup omits the private-workspace launch boundary"
+if grep -Fq 'Launch OpenClaw now?' scripts/setup.sh; then
+  fail "setup offers to launch OpenClaw before private-workspace configuration is verified"
+fi
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"
 fi

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -274,6 +274,8 @@ grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help om
 grep -Fq 'Setup does not launch OpenClaw' scripts/setup.sh \
   || fail "OpenClaw setup omits the private-workspace launch boundary"
 openclaw_setup_case=$(sed -n '/^  openclaw)/,/^    ;;/p' scripts/setup.sh)
+test -n "$openclaw_setup_case" \
+  || fail "OpenClaw setup case could not be inspected for launch behavior"
 if grep -Eq '(^|[[:space:]])exec[[:space:]]+openclaw([[:space:]]|$)' <<<"$openclaw_setup_case"; then
   fail "setup can launch OpenClaw before private-workspace configuration is verified"
 fi
@@ -305,7 +307,7 @@ make_setup_fixture() {
   local destination="$1"
   mkdir -p "$destination"
   tar --exclude='.git' --exclude='.context-os' --exclude='node_modules' \
-    --exclude='bash.exe.stackdump' -cf - . | tar -xf - -C "$destination"
+    -cf - . | tar -xf - -C "$destination"
   # Setup's prompt sequence must remain stable after a user removes the optional
   # seed project from their own workspace. An empty fixture directory is enough
   # to exercise the removal prompt without fabricating tracked source content.

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -269,7 +269,7 @@ if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$duplica
 fi
 
 help_output=$(bash scripts/setup.sh --help)
-grep -Fq -- '--agents claude,codex|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
+grep -Fq -- '--agents claude,codex,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
 grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"
@@ -279,10 +279,27 @@ setup_lf_count=$(grep -Fc 'newline="\n",' scripts/setup.sh)
 test "$setup_write_count" -eq "$setup_lf_count" \
   || fail "every setup Python rewrite must explicitly preserve LF line endings"
 
+skill_validator_fixture="$portability_tmp/skill-validator-pruning"
+mkdir -p "$skill_validator_fixture/scripts" \
+  "$skill_validator_fixture/.context-os/skills/ignored-local" \
+  "$skill_validator_fixture/node_modules/package/skills/ignored-dependency"
+cp scripts/validate-skills.sh "$skill_validator_fixture/scripts/"
+cp CLAUDE.md "$skill_validator_fixture/"
+git -C "$skill_validator_fixture" init -q
+git -C "$skill_validator_fixture" add CLAUDE.md scripts/validate-skills.sh
+git -C "$skill_validator_fixture" -c user.name=Test -c user.email=test@example.invalid commit -qm baseline
+(cd "$skill_validator_fixture" && bash scripts/validate-skills.sh) >/dev/null \
+  || fail "skill validation inspected ignored local or dependency trees"
+mkdir -p "$skill_validator_fixture/.agents/skills/missing-skill-file"
+if (cd "$skill_validator_fixture" && bash scripts/validate-skills.sh) >/dev/null 2>&1; then
+  fail "skill validation stopped enforcing repository skill directories"
+fi
+
 make_setup_fixture() {
   local destination="$1"
   mkdir -p "$destination"
-  tar --exclude='.git' -cf - . | tar -xf - -C "$destination"
+  tar --exclude='.git' --exclude='.context-os' --exclude='node_modules' \
+    --exclude='bash.exe.stackdump' -cf - . | tar -xf - -C "$destination"
   # Setup's prompt sequence must remain stable after a user removes the optional
   # seed project from their own workspace. An empty fixture directory is enough
   # to exercise the removal prompt without fabricating tracked source content.
@@ -353,7 +370,7 @@ grep -Fq 'already contains this selection' <<<"$subset_output" \
   || fail "subset setup rerun did not preserve the configured set"
 printf 'y\n\nn\nn\nn\ny\nn\n' | (
   cd "$multi_agent_fixture" &&
-  PATH="$setup_test_path" bash scripts/setup.sh --agents hermes
+  PATH="$setup_test_path" bash scripts/setup.sh --agents hermes,openclaw
 ) >/dev/null
 "$CONTEXTOS_PYTHON_CMD" - "$multi_agent_fixture/contextos.workspace.json" <<'PY'
 from pathlib import Path
@@ -361,7 +378,7 @@ import json
 import sys
 
 config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-assert config["agents"] == ["claude", "codex", "hermes"], config["agents"]
+assert config["agents"] == ["claude", "codex", "hermes", "openclaw"], config["agents"]
 PY
 none_output=$(printf 'y\n\nn\nn\nn\n' | (
   cd "$multi_agent_fixture" &&

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -273,8 +273,9 @@ grep -Fq -- '--agents claude,codex,openclaw|auto|none' <<<"$help_output" || fail
 grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"
 grep -Fq 'Setup does not launch OpenClaw' scripts/setup.sh \
   || fail "OpenClaw setup omits the private-workspace launch boundary"
-if grep -Fq 'Launch OpenClaw now?' scripts/setup.sh; then
-  fail "setup offers to launch OpenClaw before private-workspace configuration is verified"
+openclaw_setup_case=$(sed -n '/^  openclaw)/,/^    ;;/p' scripts/setup.sh)
+if grep -Eq '(^|[[:space:]])exec[[:space:]]+openclaw([[:space:]]|$)' <<<"$openclaw_setup_case"; then
+  fail "setup can launch OpenClaw before private-workspace configuration is verified"
 fi
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -333,7 +333,7 @@ class KernelTest(unittest.TestCase):
             (self.root / "state" / name).write_text(
                 f"# {name}\n\n**Last Updated:** 2026-08-20\n", encoding="utf-8"
             )
-        for runtime in ("claude", "codex", "hermes"):
+        for runtime in ("claude", "codex", "hermes", "openclaw"):
             source = ROOT / "runtimes" / f"{runtime}.json"
             (self.root / "runtimes" / f"{runtime}.json").write_bytes(source.read_bytes())
         for directory in (
@@ -1551,7 +1551,7 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         hosts_path.write_text(json.dumps(hosts), encoding="utf-8")
 
         report = doctor(self.root, all_runtimes=True)
-        self.assertEqual({"claude", "codex", "hermes"}, set(report["runtimes"]))
+        self.assertEqual({"claude", "codex", "hermes", "openclaw"}, set(report["runtimes"]))
 
     def test_bare_doctor_validates_all_manifests_during_setup(self) -> None:
         manifest = json.loads((self.root / "runtimes/claude.json").read_text(encoding="utf-8"))

--- a/tests/test_openclaw_conformance.py
+++ b/tests/test_openclaw_conformance.py
@@ -52,7 +52,8 @@ class OpenClawDescriptorTest(unittest.TestCase):
         for required in (
             "private workspace", "Copy all eight together", "skills.load.extraDirs",
             "shell-execution authorization", "installs no hook or plugin",
-            "not synchronized", "doctor --lint --json", "Do not use `--fix`",
+            "include all eight lifecycle skill names", "not synchronized",
+            "doctor --lint --json", "Do not use `--fix`",
         ):
             with self.subTest(required=required):
                 self.assertIn(required, guide)
@@ -119,6 +120,15 @@ class InstalledOpenClawTest(unittest.TestCase):
                 self.assertTrue(skill["modelVisible"])
                 self.assertTrue(skill["userInvocable"])
                 self.assertTrue(skill["commandVisible"])
+
+    def test_repository_cwd_does_not_substitute_for_missing_workspace_copies(self) -> None:
+        shutil.rmtree(self.workspace / ".agents/skills")
+        (self.workspace / ".agents/skills").mkdir(parents=True)
+        skills = self._skills()
+        self.assertTrue(
+            LIFECYCLE_SKILLS.isdisjoint(skills),
+            sorted(LIFECYCLE_SKILLS & skills.keys()),
+        )
 
     def test_workspace_skill_shadows_project_agent_skill_and_fallback_fires(self) -> None:
         project = self.workspace / ".agents/skills/collision-probe"

--- a/tests/test_openclaw_conformance.py
+++ b/tests/test_openclaw_conformance.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DESCRIPTOR = json.loads((ROOT / "runtimes/openclaw.json").read_text(encoding="utf-8"))
+LIFECYCLE_SKILLS = {
+    "setup", "context-setup", "start", "context-start",
+    "update", "context-update", "end", "context-end",
+}
+
+
+class OpenClawDescriptorTest(unittest.TestCase):
+    def test_support_claims_stay_experimental_and_hook_free(self) -> None:
+        surface = DESCRIPTOR["surfaces"]["cli"]
+        self.assertEqual("experimental", DESCRIPTOR["support_tier"])
+        self.assertEqual("experimental", surface["support_tier"])
+        self.assertEqual("unsupported", surface["capabilities"]["project_hooks"])
+        self.assertEqual("unsupported", surface["capabilities"]["blocking_pre_tool_hook"])
+        self.assertIsNone(surface["hook_output"])
+
+    def test_lifecycle_uses_stable_explicit_skill_invocation(self) -> None:
+        invocation = DESCRIPTOR["surfaces"]["cli"]["invocation"]
+        self.assertEqual(
+            {name: f"/skill {name}" for name in ("setup", "start", "update", "end")},
+            invocation,
+        )
+
+    def test_repository_and_private_workspace_roles_are_distinct(self) -> None:
+        sources = DESCRIPTOR["surfaces"]["cli"]["instruction_sources"]
+        repository = [source for source in sources if source["scope"] == "repository"]
+        workspace = [source for source in sources if source["scope"] == "workspace"]
+        self.assertEqual(["AGENTS.md"], [source["path"] for source in repository])
+        self.assertEqual(
+            {"SOUL.md", "USER.md", "MEMORY.md"},
+            {source["path"] for source in workspace},
+        )
+        self.assertEqual(len(sources), len({source["precedence"] for source in sources}))
+        skill_sources = DESCRIPTOR["surfaces"]["cli"]["skill_sources"]
+        self.assertTrue(skill_sources)
+        self.assertEqual({"workspace"}, {source["scope"] for source in skill_sources})
+
+    def test_guide_preserves_security_and_memory_boundaries(self) -> None:
+        guide = (ROOT / "adapters/openclaw/README.md").read_text(encoding="utf-8")
+        for required in (
+            "private workspace", "Copy all eight together", "skills.load.extraDirs",
+            "shell-execution authorization", "installs no hook or plugin",
+            "not synchronized", "doctor --lint --json", "Do not use `--fix`",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, guide)
+
+
+@unittest.skipUnless(
+    os.environ.get("CONTEXTOS_OPENCLAW_BIN"),
+    "set CONTEXTOS_OPENCLAW_BIN to the exact tested OpenClaw executable",
+)
+class InstalledOpenClawTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.binary = os.environ["CONTEXTOS_OPENCLAW_BIN"]
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.scratch = Path(self.temporary.name).resolve()
+        self.state = self.scratch / "state"
+        self.workspace = self.scratch / "private-workspace"
+        (self.workspace / ".agents/skills").mkdir(parents=True)
+        for skill in LIFECYCLE_SKILLS:
+            shutil.copytree(ROOT / ".agents/skills" / skill, self.workspace / ".agents/skills" / skill)
+        self._write_config()
+
+    def _write_config(self, *, allowed_skills: list[str] | None = None) -> None:
+        self.state.mkdir(parents=True, exist_ok=True)
+        defaults: dict[str, object] = {
+            "workspace": str(self.workspace),
+            "skipBootstrap": True,
+        }
+        if allowed_skills is not None:
+            defaults["skills"] = allowed_skills
+        (self.state / "openclaw.json").write_text(
+            json.dumps({"agents": {"defaults": defaults}}),
+            encoding="utf-8",
+        )
+
+    def _run(self, *args: str, allowed_codes: tuple[int, ...] = (0,)) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["OPENCLAW_STATE_DIR"] = str(self.state)
+        result = subprocess.run(
+            [self.binary, *args], cwd=ROOT, env=env, text=True,
+            encoding="utf-8", errors="replace", capture_output=True,
+            check=False, timeout=60,
+        )
+        self.assertIn(result.returncode, allowed_codes, result.stderr or result.stdout)
+        return result
+
+    def _skills(self) -> dict[str, dict]:
+        report = json.loads(self._run("skills", "list", "--json").stdout)
+        return {skill["name"]: skill for skill in report["skills"]}
+
+    def test_exact_version_and_copied_lifecycle_inventory(self) -> None:
+        expected = DESCRIPTOR["evidence"]["tested_versions"][0]["version"]
+        self.assertEqual(expected, self._run("--version").stdout.strip())
+        skills = self._skills()
+        self.assertTrue(LIFECYCLE_SKILLS <= set(skills))
+        for name in LIFECYCLE_SKILLS:
+            with self.subTest(name=name):
+                skill = skills[name]
+                self.assertEqual("agents-skills-project", skill["source"])
+                self.assertTrue(skill["eligible"])
+                self.assertTrue(skill["modelVisible"])
+                self.assertTrue(skill["userInvocable"])
+                self.assertTrue(skill["commandVisible"])
+
+    def test_workspace_skill_shadows_project_agent_skill_and_fallback_fires(self) -> None:
+        project = self.workspace / ".agents/skills/collision-probe"
+        workspace = self.workspace / "skills/collision-probe"
+        project.mkdir(parents=True)
+        workspace.mkdir(parents=True)
+        (project / "SKILL.md").write_text(
+            "---\nname: collision-probe\ndescription: Project-agent sentinel.\n---\nProject.\n",
+            encoding="utf-8",
+        )
+        (workspace / "SKILL.md").write_text(
+            "---\nname: collision-probe\ndescription: Workspace sentinel.\n---\nWorkspace.\n",
+            encoding="utf-8",
+        )
+        winner = self._skills()["collision-probe"]
+        self.assertEqual("openclaw-workspace", winner["source"])
+        self.assertEqual("Workspace sentinel.", winner["description"])
+        shutil.rmtree(workspace)
+        fallback = self._skills()["collision-probe"]
+        self.assertEqual("agents-skills-project", fallback["source"])
+        self.assertEqual("Project-agent sentinel.", fallback["description"])
+
+    def test_empty_agent_allowlist_hides_but_does_not_relabel_skills(self) -> None:
+        self._write_config(allowed_skills=[])
+        skill = self._skills()["setup"]
+        self.assertTrue(skill["eligible"])
+        self.assertTrue(skill["blockedByAgentFilter"])
+        self.assertFalse(skill["modelVisible"])
+        self.assertTrue(skill["userInvocable"])
+        self.assertFalse(skill["commandVisible"])
+
+    def test_native_lint_is_machine_readable_without_writing_repo_memory(self) -> None:
+        before = {name: (ROOT / name).exists() for name in ("SOUL.md", "USER.md", "MEMORY.md", "memory")}
+        report = json.loads(self._run("doctor", "--lint", "--json", allowed_codes=(0, 1)).stdout)
+        self.assertGreater(report["checksRun"], 0)
+        self.assertEqual(before, {name: (ROOT / name).exists() for name in before})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openclaw_conformance.py
+++ b/tests/test_openclaw_conformance.py
@@ -92,25 +92,28 @@ class InstalledOpenClawTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def _run(self, *args: str, allowed_codes: tuple[int, ...] = (0,)) -> subprocess.CompletedProcess[str]:
+    def _run(
+        self, *args: str, allowed_codes: tuple[int, ...] = (0,),
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["OPENCLAW_STATE_DIR"] = str(self.state)
         result = subprocess.run(
-            [self.binary, *args], cwd=ROOT, env=env, text=True,
+            [self.binary, *args], cwd=cwd or ROOT, env=env, text=True,
             encoding="utf-8", errors="replace", capture_output=True,
             check=False, timeout=60,
         )
         self.assertIn(result.returncode, allowed_codes, result.stderr or result.stdout)
         return result
 
-    def _skills(self) -> dict[str, dict]:
-        report = json.loads(self._run("skills", "list", "--json").stdout)
+    def _skills(self, *, cwd: Path | None = None) -> dict[str, dict]:
+        report = json.loads(self._run("skills", "list", "--json", cwd=cwd).stdout)
         return {skill["name"]: skill for skill in report["skills"]}
 
     def test_exact_version_and_copied_lifecycle_inventory(self) -> None:
         expected = DESCRIPTOR["evidence"]["tested_versions"][0]["version"]
         self.assertEqual(expected, self._run("--version").stdout.strip())
-        skills = self._skills()
+        skills = self._skills(cwd=self.workspace)
         self.assertTrue(LIFECYCLE_SKILLS <= set(skills))
         for name in LIFECYCLE_SKILLS:
             with self.subTest(name=name):
@@ -122,9 +125,18 @@ class InstalledOpenClawTest(unittest.TestCase):
                 self.assertTrue(skill["commandVisible"])
 
     def test_repository_cwd_does_not_substitute_for_missing_workspace_copies(self) -> None:
+        sentinel = self.workspace / "skills/inventory-sentinel"
+        sentinel.mkdir(parents=True)
+        (sentinel / "SKILL.md").write_text(
+            "---\nname: inventory-sentinel\n"
+            "description: Proves that the negative-control inventory is live.\n"
+            "---\nSentinel.\n",
+            encoding="utf-8",
+        )
         shutil.rmtree(self.workspace / ".agents/skills")
         (self.workspace / ".agents/skills").mkdir(parents=True)
         skills = self._skills()
+        self.assertEqual("openclaw-workspace", skills["inventory-sentinel"]["source"])
         self.assertTrue(
             LIFECYCLE_SKILLS.isdisjoint(skills),
             sorted(LIFECYCLE_SKILLS & skills.keys()),

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -29,9 +29,9 @@ def load(runtime: str) -> dict:
 
 class RuntimeManifestTest(unittest.TestCase):
     def test_registry_discovers_and_validates_every_descriptor(self) -> None:
-        self.assertEqual(["claude", "codex", "hermes"], runtime_ids(ROOT))
+        self.assertEqual(["claude", "codex", "hermes", "openclaw"], runtime_ids(ROOT))
         registry = runtime_registry(ROOT)
-        self.assertEqual({"claude", "codex", "hermes"}, set(registry))
+        self.assertEqual({"claude", "codex", "hermes", "openclaw"}, set(registry))
         self.assertNotIn("generic", registry)
         for runtime, manifest in registry.items():
             with self.subTest(runtime=runtime):
@@ -45,6 +45,11 @@ class RuntimeManifestTest(unittest.TestCase):
             invocation = load(runtime)["surfaces"]["cli"]["invocation"]
             for name in ("setup", "start", "update", "end"):
                 self.assertEqual(f"{prefix}{name}", invocation[name])
+        openclaw = load("openclaw")["surfaces"]["cli"]["invocation"]
+        self.assertEqual(
+            {name: f"/skill {name}" for name in ("setup", "start", "update", "end")},
+            openclaw,
+        )
 
     def test_checked_in_schema_matches_authoritative_contract(self) -> None:
         actual = json.loads((ROOT / "runtimes/schema.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- register OpenClaw as an experimental, skills-first runtime
- keep OpenClaw's private workspace and native memory outside the repository
- copy all eight lifecycle skills into the private workspace and use explicit `/skill` invocations
- add exact installed-version conformance for discovery, precedence, allowlists, lint diagnostics, and memory isolation
- keep hooks, plugins, and messaging/gateway parity explicitly out of scope
- stop skill validation and portability fixtures from traversing ignored runtime state and dependency trees

Related to #70. This does not close or promote OpenClaw to first-class support; authenticated lifecycle and broader surface conformance remain gated work.

## Evidence

- official OpenClaw skills, workspace, system-prompt, execution-approval, doctor, and MCP documentation checked 2026-08-27
- installed `OpenClaw 2026.7.1-2 (0790d9f)` in an ignored, package-local fixture without global install, credentials, onboarding, gateway, or user-state changes
- verified all eight copied lifecycle skills as `agents-skills-project`
- verified `<workspace>/skills` shadows `<workspace>/.agents/skills` and the lower-precedence skill becomes active when the shadow is removed
- verified an empty agent skill allowlist sets `blockedByAgentFilter`, hides model/command visibility, and does not falsely change `userInvocable`
- verified `doctor --lint --json` is machine-readable, read-only for repository memory, and may exit 1 with findings
- observed `skills.load.extraDirs` did not reliably discover the Context OS skills in the tested stable version, so onboarding uses an honest copy model

## Validation

- `bash scripts/validate-all.sh`: 400 tests, 31 skipped; all validation passed
- `CONTEXTOS_OPENCLAW_BIN=<exact binary> python -m unittest -v tests.test_openclaw_conformance`: 9 tests passed
- `tests/test-portability.sh`: 93 tests, 10 skipped; 13 runtime-manifest tests; passed
- `git diff --check`: passed

## Review

- final reviewed SHA: `53536cff9c37d7bfd73eebff3b22c901670ade11`
- Claude: `claude-opus-5` — no merge-blocking findings
- Hermes: `thinkingmachines/inkling:free` through OpenRouter, verified zero prompt/completion pricing — no verified merge-blocking findings
- three repair cycles completed; false/stale re-flags were checked against the files and rejected
- hosted `validate`, `tests-minimum-python`, and `tests-windows` jobs passed

## Boundaries

- support tier remains `experimental`
- no OpenClaw project hook, blocking hook, plugin, or messaging/gateway conformance claim
- native memory is not synchronized with repository state
- skill allowlists are documented separately from shell-execution authorization
- `openclaw doctor --fix` is not used by validation
