### PR TITLE
Add experimental Cursor runtime support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ remain supported.
 - `.codex/hooks.json` maps Codex events to the same read-only policy checks.
 - `adapters/hermes/` documents optional Hermes hooks and skill installation.
 - `adapters/openclaw/` documents experimental skills-first OpenClaw support.
+- `adapters/cursor/` documents separate experimental Cursor IDE and CLI support.
 - Runtime manifests under `runtimes/` declare support instead of implying parity.
 - Kernel proposal/apply is the enforcement boundary on every host; hooks are
   defense in depth and host-local memory is never shared automatically.
@@ -74,6 +75,17 @@ remain supported.
 - This experimental adapter installs no OpenClaw hook or plugin. Skill
   allowlists do not replace separate shell-execution authorization.
 - See `adapters/openclaw/README.md` for the tested version and diagnostics.
+
+## Cursor
+
+- Open the repository as the IDE workspace or start the Agent CLI from its root;
+  both discover `AGENTS.md` and `.agents/skills/` natively.
+- Invoke `/context-setup`, `/context-start`, `/context-update`, and
+  `/context-end` explicitly; Cursor CLI reserves `/update` for self-updates.
+- Keep `.cursor/rules` non-overlapping with this file because Cursor does not
+  document their conflict order. IDE and CLI permissions remain separate.
+- This experimental adapter ships no Cursor hook or native-memory bridge. See
+  `adapters/cursor/README.md` for authorization and conformance boundaries.
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ remain supported.
   `/context-end` explicitly; Cursor CLI reserves `/update` for self-updates.
 - Keep `.cursor/rules` non-overlapping with this file because Cursor does not
   document their conflict order. IDE and CLI permissions remain separate.
+- Cursor CLI also reads the removable root `CLAUDE.md` when present. Treat its
+  short lifecycle commands as Claude adapters, not Cursor invocations.
 - This experimental adapter ships no Cursor hook or native-memory bridge. See
   `adapters/cursor/README.md` for authorization and conformance boundaries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Experimental Cursor onboarding with separate IDE and Agent CLI surfaces,
+  native root-instruction and project-skill discovery, explicit lifecycle
+  invocation, separate authorization guidance, no hook or memory claim, and
+  opt-in exact-version CLI controls without unsafe generic-binary detection.
 - Experimental OpenClaw onboarding with a machine-readable runtime descriptor,
   separate private-workspace boundary, copied lifecycle skills, explicit
   `/skill` invocations, honest no-hook claims, and opt-in installed-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Experimental Cursor onboarding with separate IDE and Agent CLI surfaces,
   native root-instruction and project-skill discovery, explicit lifecycle
   invocation, separate authorization guidance, no hook or memory claim, and
-  opt-in exact-version CLI controls without unsafe generic-binary detection.
+  an opt-in exact-version/flag CLI smoke without unsafe generic-binary detection.
 - Experimental OpenClaw onboarding with a machine-readable runtime descriptor,
   separate private-workspace boundary, copied lifecycle skills, explicit
   `/skill` invocations, honest no-hook claims, and opt-in installed-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Changed
+- Workspace validation treats `.cursor/` as user-extensible while strict
+  maintainer validation still requires ownership for every shipped path.
 - `doctor` is set-aware when tracked workspace configuration exists. It reports
   support, component materialization, customization limits, local availability,
   onboarding, descriptor drift, declared conformance, and evidence freshness

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Context OS
 
-A portable Git-backed context and workflow layer for agents like Claude Code, Codex, Hermes, and OpenClaw. Evolves alongside you and your agents.
+A portable Git-backed context and workflow layer for agents like Claude Code, Codex, Hermes, OpenClaw, and Cursor. Evolves alongside you and your agents.
 
 [![GitHub stars](https://img.shields.io/github/stars/conorbronsdon/agent-context-os?style=social)](https://github.com/conorbronsdon/agent-context-os/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -15,8 +15,8 @@ A portable Git-backed context and workflow layer for agents like Claude Code, Co
 
 Chat history, project instructions, and copied prompts drift apart. Context OS puts the durable parts in plain Markdown: who you are, what you are working on, decisions already made, and the workflows you want an agent to follow.
 
-Claude Code, Codex, Hermes, and experimental OpenClaw support read the same
-repository state. A deterministic
+Claude Code, Codex, Hermes, and the experimental OpenClaw and Cursor adapters
+read the same repository state. A deterministic
 lifecycle kernel turns reviewed setup, checkpoint, and close requests into
 hash-checked proposals and receipts, without treating native memory as the
 source of truth.
@@ -46,6 +46,7 @@ git remote add origin <YOUR_PRIVATE_REPO_URL>
 bash scripts/setup.sh --agents claude,codex
 # bash scripts/setup.sh --agents hermes
 # bash scripts/setup.sh --agents openclaw
+# bash scripts/setup.sh --agents cursor
 # bash scripts/setup.sh --agents none  # core-only
 ```
 
@@ -69,6 +70,7 @@ Then start your agent from the repository root:
 | New workspace in Codex | Run `$setup` |
 | New workspace in Hermes | Run `/setup` after exposing the repository skills |
 | New workspace in OpenClaw | Follow the [experimental adapter](adapters/openclaw/README.md), then run `/skill setup` |
+| New workspace in Cursor | Follow the separate [experimental IDE and CLI paths](adapters/cursor/README.md), then run `/context-setup` |
 | Existing context in another assistant | Follow the [migration guide](docs/migration-guide.md), then use the selected material during setup |
 | claude.ai only | Use [SETUP-PROMPTS.md](SETUP-PROMPTS.md) and copy the approved output into the repository |
 
@@ -78,8 +80,8 @@ The setup interview fills the identity, first project, workflows, and weekly sta
 
 ![A start session in Claude Code: state files load and a session briefing comes back, using sample data from the included example musician project](docs/assets/start-demo.gif)
 
-`/start` in Claude Code or Hermes, `$start` in Codex, and `/skill start` in
-OpenClaw read your state,
+`/start` in Claude Code or Hermes, `/context-start` in Cursor, `$start` in Codex,
+and `/skill start` in OpenClaw read your state,
 priorities, decisions, blockers, and recent handoff. The result is grounded in
 files rather than reconstructed from chat.
 
@@ -91,12 +93,12 @@ At the end, `/end` or `$end` proposes a handoff for review before it updates `se
 
 Start small. Use the core loop for a week, add one active project, then turn a repeated task into a skill when the repetition is clear.
 
-| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Shared result |
-|---|---|---|---|---|---|
-| First run or major refresh | `/setup` | `$setup` | `/setup` | `/skill setup` | Reviewed context proposal |
-| Start work | `/start` | `$start` | `/start` | `/skill start` | Read-only continuity inventory and briefing |
-| Save a checkpoint | `/update` | `$update` | `/update` | `/skill update` | Hash-checked update and receipt |
-| Finish work | `/end` | `$end` | `/end` | `/skill end` | Hash-checked handoff, decisions, and receipt |
+| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) | Shared result |
+|---|---|---|---|---|---|---|---|
+| First run or major refresh | `/setup` | `$setup` | `/setup` | `/skill setup` | `/context-setup` | `/context-setup` | Reviewed context proposal |
+| Start work | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `/context-start` | Read-only continuity inventory and briefing |
+| Save a checkpoint | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `/context-update` | Hash-checked update and receipt |
+| Finish work | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `/context-end` | Hash-checked handoff, decisions, and receipt |
 
 The namespaced `$context-setup`, `$context-start`, `$context-update`, and
 `$context-end` invocations remain available for compatibility.
@@ -122,6 +124,7 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 |---|---|---|
 | Claude Code | first-class | Shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation |
 | Codex | first-class | Shared lifecycle, native skills, project instructions, hooks, and reviewed proposal/apply writes |
+| Cursor | experimental | Separate IDE and CLI onboarding through root AGENTS.md and project Agent Skills, without hook, memory, or rule-conflict claims |
 | Hermes Agent | first-class | Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory |
 | OpenClaw | experimental | Skills-first lifecycle support with copied portable skills, separate private memory, and no project-hook claim |
 <!-- runtime-support:end -->
@@ -131,19 +134,18 @@ Compatibility paths that are not registered runtime adapters:
 | Host | Compatibility path |
 |---|---|
 | Gemini CLI / Antigravity CLI | Migration tooling plus portable-skill discovery for continuing enterprise/API-key Gemini CLI; no complete workspace adapter, and no Antigravity discovery or permission parity is claimed |
-| Cursor | Read `AGENTS.md` from the repository root; portable skills usable where its Agent Skills support allows |
 | claude.ai | Manual consumer of selected knowledge files; no repository writes, hooks, or slash-command parity |
 | Other agents | Can use the Markdown state and portable skills only when their file and Agent Skills support is compatible |
 
 ## One source, explicit host adapters
 
-| Capability | Shared | Claude Code | Codex | Hermes | OpenClaw (experimental) |
-|---|---:|---:|---:|---:|---:|
-| Identity, project, state, and session files | Yes | Reads | Reads | Reads | Reads |
-| Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls | Copied skill calls |
-| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. | `/skill setup` etc. |
-| Project hooks | Event contract only | `.claude/` | `.codex/` | Optional adapter | Not claimed |
-| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` | Private workspace |
+| Capability | Shared | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Identity, project, state, and session files | Yes | Reads | Reads | Reads | Reads | Reads | Reads |
+| Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls | Copied skill calls | Native skill calls | Native skill calls |
+| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. | `/skill setup` etc. | `/context-setup` etc. | `/context-setup` etc. |
+| Project hooks | Event contract only | `.claude/` | `.codex/` | Optional adapter | Not claimed | Not claimed | Not claimed |
+| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` | Private workspace | Outside contract | Outside contract |
 
 The shared layer is intentionally plain files. Provider-specific tool names, hooks, permissions, and memory features stay in their adapter directories.
 
@@ -174,6 +176,7 @@ contextos/                 Deterministic lifecycle kernel
 .codex/hooks.json          Codex lifecycle advisory adapter
 adapters/hermes/           Hermes installation and optional hook adapter
 adapters/openclaw/         Experimental OpenClaw skills-first adapter
+adapters/cursor/           Experimental Cursor IDE and CLI adapter
 runtimes/                  Machine-readable capability manifests
 components/                Component ownership and dependency manifest
 workspace/                 Schema and inactive canonical config example
@@ -235,6 +238,7 @@ behavior of an installed agent version or an external service.
 | Use the repository in Codex | [Codex onboarding](docs/codex-onboarding.md) |
 | Use the repository in Hermes Agent | [Memory across agents](docs/memory-across-agents.md) and the Hermes section of [AGENTS.md](AGENTS.md) |
 | Use the repository in OpenClaw | [Experimental OpenClaw adapter](adapters/openclaw/README.md) |
+| Use the repository in Cursor | [Experimental Cursor IDE and CLI adapter](adapters/cursor/README.md) |
 | Keep claude.ai projects aligned | [Claude projects sync](docs/claude-projects-sync.md) |
 | See every command and portable skill | [Commands and skills](docs/commands-and-skills.md) |
 | Understand component ownership and future clean composition | [Component model](docs/component-model.md) |

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -52,8 +52,17 @@ this adapter documents only the namespaced commands. Cursor does not document
 whether its built-in `/update` or the discovered `update` skill wins. Do not use
 the short aliases in Cursor, and do not duplicate these names in another Cursor
 skill root. `disable-model-invocation: true` can make a Cursor skill
-explicit-only; the checked-in lifecycle skills already require explicit use by
-contract.
+explicit-only. The repository contract instructs explicit lifecycle use, but
+the portable skill frontmatter does not currently enforce that Cursor-specific
+setting; model-initiated selection is another promotion-gate control.
+
+Cursor CLI also reads a root `CLAUDE.md`, when present, alongside `AGENTS.md`
+and `.cursor/rules`. This template ships `CLAUDE.md` as a removable seed, so the
+runtime descriptor cannot declare it as a required repository source. Its
+Claude command table includes the short lifecycle names; Cursor users should
+still use only the namespaced `context-*` skills. Cursor also scans compatible
+`.claude/skills/` and `.codex/skills/` roots. No lifecycle skill is shipped in
+those roots today, but same-name additions create another unresolved collision.
 
 ## Authorization boundaries
 
@@ -103,10 +112,14 @@ The current opt-in CLI control is an exact-version and required-flag smoke test,
 not installed lifecycle conformance. It runs from a disposable directory and
 does not authenticate, trust a workspace, call a model, or exercise writes.
 
+Project-owned `.cursor/` configuration is permitted by workspace validation.
+Strict maintainer validation still requires every template-owned path to have
+an explicit component owner.
+
 First-class promotion requires exact-version conformance for both surfaces,
 including root and nested instruction discovery, `.cursor/rules` conflict
 controls, short-alias versus built-in resolution, explicit skill invocation,
-interactive must-fire and must-not-fire approval controls, headless
-no-`--force` and `--force` behavior, deny precedence, MCP scope, native-state
-isolation, and either a tested Cursor-specific hook adapter or a continuing
-explicit no-hook claim.
+implicit-invocation controls, interactive must-fire and must-not-fire approval
+controls, headless no-`--force` and `--force` behavior, deny precedence, MCP
+scope, native-state isolation, and either a tested Cursor-specific hook adapter
+or a continuing explicit no-hook claim.

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -1,0 +1,100 @@
+# Cursor experimental adapter
+
+Context OS supports Cursor as two separate experimental surfaces: the desktop
+IDE and the Agent CLI. Both discover the repository-root `AGENTS.md` and project
+skills under `.agents/skills/`, but they have different binaries, permissions,
+configuration, and conformance gates. A green CLI check is not IDE evidence.
+
+No installed Cursor version was available for this release. The descriptor is
+therefore capability-gated, has no tested version, and must not be promoted to
+first-class until the opt-in controls pass against exact IDE and CLI versions.
+
+## Setup
+
+Select Cursor alongside any other agents during repository setup:
+
+```bash
+bash scripts/setup.sh --agents cursor
+# or
+bash scripts/setup.sh --agents claude,codex,cursor
+```
+
+For the IDE, open this repository as the workspace. For the CLI, install the
+Cursor Agent CLI separately, start `agent` from the repository root, and verify
+the exact executable with `agent --version`. The executable name `agent` is too
+generic for safe automatic detection, so the experimental descriptor does not
+use it as a resolution-only availability probe. Setup registers the adapter but
+does not launch either surface, authenticate Cursor, trust the workspace, or
+change account, user, project, MCP, hook, sandbox, or permission settings.
+
+Invoke `/context-setup`, `/context-start`, `/context-update`, and `/context-end`
+explicitly. Cursor CLI owns the built-in `/update` command for updating Cursor
+itself, so this adapter deliberately avoids the short lifecycle aliases. The
+namespaced skills route mutations through the deterministic proposal/apply
+kernel. Even in an IDE run mode or `agent -p --force`, an agent instruction is
+not approval of a Context OS proposal: inspect the exact diff and approve its
+digest separately.
+
+## Rules and skills
+
+Cursor also supports project rules in `.cursor/rules/**/*.mdc`; plain Markdown
+files in that directory are ignored. Cursor documents Team, Project, then User
+rule priority, but does not document which source wins when root `AGENTS.md`
+conflicts with a project `.mdc` rule. Context OS therefore ships no Cursor rule
+file and makes no conflict-precedence claim. Keep the shared lifecycle contract
+in `AGENTS.md`; make Cursor rules narrow and non-overlapping.
+
+Cursor discovers skills in both `.agents/skills/` and `.cursor/skills/`, but its
+documentation does not define a same-name collision winner. Context OS ships
+only `.agents/skills/`. Do not duplicate these names in another Cursor skill
+root. `disable-model-invocation: true` can make a Cursor skill explicit-only;
+the checked-in lifecycle skills already require explicit use by contract.
+
+## Authorization boundaries
+
+The IDE and CLI authorization controls are not interchangeable:
+
+- IDE Run Modes and project/user `permissions.json` govern IDE shell, MCP, and
+  fetch behavior. Cursor says Auto-review is not a security boundary.
+- CLI permissions live in user `~/.cursor/cli-config.json` and project
+  `.cursor/cli.json`. An explicit deny wins an allow.
+- Current headless documentation says `agent -p` proposes without applying file
+  changes, while `agent -p --force` may write without confirmation except where
+  explicitly denied. Older usage text is less precise, so this behavior remains
+  an installed-version conformance gate.
+- `--trust`, `--force`, and broad shell, write, MCP, or absolute-path grants are
+  opt-in permission expansions. Setup never supplies them.
+
+Use a disposable fixture to test unattended modes. Never run a `--force`
+conformance check against a real context repository.
+
+## Hooks, memory, and MCP
+
+Cursor project hooks use `.cursor/hooks.json` and can fail open unless configured
+otherwise. Context OS ships no Cursor hook adapter because its current generic
+hook envelope cannot represent Cursor's event, exit-code, and `failClosed`
+semantics. Project hooks and blocking pre-tool hooks are therefore unsupported,
+not silently inherited from Claude or Codex.
+
+Cursor loads project MCP configuration from `.cursor/mcp.json`; MCP remains a
+separate trust and authorization boundary. Setup does not install, authenticate,
+approve, or enable a server.
+
+Cursor rules, account settings, chat/session history, Cloud Agents, Automations,
+and any host-native memories are outside Context OS state. No Cursor-native
+memory is synchronized into `state/` or `sessions/`; portable continuity changes
+only through a reviewed Context OS proposal.
+
+## Diagnostics and promotion gates
+
+Run `bash scripts/contextos.sh doctor --runtime cursor` for descriptor,
+registration, materialization, and local binary checks. Cursor has no documented
+all-up native doctor. For the CLI, record `agent --version`, `agent about`,
+`agent status`, and `agent mcp list` separately from IDE diagnostics.
+
+First-class promotion requires exact-version conformance for both surfaces,
+including root and nested instruction discovery, `.cursor/rules` conflict
+controls, explicit skill invocation, interactive must-fire and must-not-fire
+approval controls, headless no-`--force` and `--force` behavior, deny precedence,
+MCP scope, native-state isolation, and either a tested Cursor-specific hook
+adapter or a continuing explicit no-hook claim.

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -29,11 +29,11 @@ change account, user, project, MCP, hook, sandbox, or permission settings.
 
 Invoke `/context-setup`, `/context-start`, `/context-update`, and `/context-end`
 explicitly. Cursor CLI owns the built-in `/update` command for updating Cursor
-itself, so this adapter deliberately avoids the short lifecycle aliases. The
-namespaced skills route mutations through the deterministic proposal/apply
-kernel. Even in an IDE run mode or `agent -p --force`, an agent instruction is
-not approval of a Context OS proposal: inspect the exact diff and approve its
-digest separately.
+itself, so the documented Cursor lifecycle deliberately avoids the short
+aliases. The namespaced skills route mutations through the deterministic
+proposal/apply kernel. Even in an IDE run mode or `agent -p --force`, an agent
+instruction is not approval of a Context OS proposal: inspect the exact diff
+and approve its digest separately.
 
 ## Rules and skills
 
@@ -46,9 +46,14 @@ in `AGENTS.md`; make Cursor rules narrow and non-overlapping.
 
 Cursor discovers skills in both `.agents/skills/` and `.cursor/skills/`, but its
 documentation does not define a same-name collision winner. Context OS ships
-only `.agents/skills/`. Do not duplicate these names in another Cursor skill
-root. `disable-model-invocation: true` can make a Cursor skill explicit-only;
-the checked-in lifecycle skills already require explicit use by contract.
+only `.agents/skills/`. That shared directory includes the four short aliases
+as well as the four `context-*` cores, so Cursor discovers both sets even though
+this adapter documents only the namespaced commands. Cursor does not document
+whether its built-in `/update` or the discovered `update` skill wins. Do not use
+the short aliases in Cursor, and do not duplicate these names in another Cursor
+skill root. `disable-model-invocation: true` can make a Cursor skill
+explicit-only; the checked-in lifecycle skills already require explicit use by
+contract.
 
 ## Authorization boundaries
 
@@ -88,13 +93,20 @@ only through a reviewed Context OS proposal.
 ## Diagnostics and promotion gates
 
 Run `bash scripts/contextos.sh doctor --runtime cursor` for descriptor,
-registration, materialization, and local binary checks. Cursor has no documented
-all-up native doctor. For the CLI, record `agent --version`, `agent about`,
-`agent status`, and `agent mcp list` separately from IDE diagnostics.
+registration, materialization, and local binary checks. Its aggregate
+availability status reflects only the safely identifiable `cursor` IDE launcher;
+the generic `agent` CLI name has no resolution-only probe. Cursor has no
+documented all-up native doctor. For the CLI, record `agent --version`, `agent
+about`, `agent status`, and `agent mcp list` separately from IDE diagnostics.
+
+The current opt-in CLI control is an exact-version and required-flag smoke test,
+not installed lifecycle conformance. It runs from a disposable directory and
+does not authenticate, trust a workspace, call a model, or exercise writes.
 
 First-class promotion requires exact-version conformance for both surfaces,
 including root and nested instruction discovery, `.cursor/rules` conflict
-controls, explicit skill invocation, interactive must-fire and must-not-fire
-approval controls, headless no-`--force` and `--force` behavior, deny precedence,
-MCP scope, native-state isolation, and either a tested Cursor-specific hook
-adapter or a continuing explicit no-hook claim.
+controls, short-alias versus built-in resolution, explicit skill invocation,
+interactive must-fire and must-not-fire approval controls, headless
+no-`--force` and `--force` behavior, deny precedence, MCP scope, native-state
+isolation, and either a tested Cursor-specific hook adapter or a continuing
+explicit no-hook claim.

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -7,6 +7,7 @@
     "extensible_roots": [
         ".agents/skills",
         ".claude/commands",
+        ".cursor",
         "content",
         "identity",
         "inbox",

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -793,6 +793,29 @@
             ]
         },
         {
+            "id": "cursor-adapter",
+            "description": "Experimental Cursor IDE and CLI onboarding, runtime descriptor, and capability-gated conformance controls.",
+            "depends_on": [
+                "core",
+                "portable-skills",
+                "agents-instructions"
+            ],
+            "paths": [
+                {
+                    "path": "adapters/cursor/README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "runtimes/cursor.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "tests/test_cursor_conformance.py",
+                    "policy": "development"
+                }
+            ]
+        },
+        {
             "id": "example-project",
             "description": "Optional removable example project and workflow seeds.",
             "depends_on": [

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -6,12 +6,12 @@ dates, append behavior, optimistic hashes, locking, and receipts.
 
 ## Shared lifecycle
 
-| Job | Claude Code | Codex | Hermes | OpenClaw (experimental) | Deterministic operation |
-|---|---|---|---|---|---|
-| Initialize context | `/setup` | `$setup` | `/setup` | `/skill setup` | `contextos propose setup` then `apply` |
-| Start a session | `/start` | `$start` | `/start` | `/skill start` | read-only `contextos start` |
-| Checkpoint | `/update` | `$update` | `/update` | `/skill update` | `contextos propose update` then `apply` |
-| Close a session | `/end` | `$end` | `/end` | `/skill end` | `contextos propose end` then `apply` |
+| Job | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) | Deterministic operation |
+|---|---|---|---|---|---|---|---|
+| Initialize context | `/setup` | `$setup` | `/setup` | `/skill setup` | `/context-setup` | `/context-setup` | `contextos propose setup` then `apply` |
+| Start a session | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `/context-start` | read-only `contextos start` |
+| Checkpoint | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `/context-update` | `contextos propose update` then `apply` |
+| Close a session | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `/context-end` | `contextos propose end` then `apply` |
 
 The portable cores are `.agents/skills/context-setup`, `context-start`,
 `context-update`, and `context-end`. Short skill directories are thin aliases;
@@ -28,13 +28,14 @@ The mutation protocol is always:
 
 ## Runtime boundary
 
-| Capability | Claude Code | Codex | Hermes | OpenClaw (experimental) |
-|---|---|---|---|---|
-| Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | Execution-directory `AGENTS.md` |
-| Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills | Copied into private workspace `.agents/skills/` |
-| Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter | Not claimed |
-| Lifecycle enforcement | Kernel | Kernel | Kernel | Kernel |
-| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` | Private OpenClaw workspace |
+| Capability | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) |
+|---|---|---|---|---|---|---|
+| Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | Execution-directory `AGENTS.md` | Root `AGENTS.md` | Root `AGENTS.md` |
+| Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills | Copied into private workspace `.agents/skills/` | `.agents/skills/` | `.agents/skills/` |
+| Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter | Not claimed | Not claimed | Not claimed |
+| Authorization | Host settings | Host settings | Outside contract | Separate execution approvals | IDE Run Modes and permissions | CLI permissions and `--force` |
+| Lifecycle enforcement | Kernel | Kernel | Kernel | Kernel | Kernel | Kernel |
+| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` | Private OpenClaw workspace | Outside contract | Outside contract |
 
 Runtime manifests in `runtimes/` are machine-readable claims. Hooks are defense
 in depth: the kernel repeats mutation invariants during every proposal and apply.

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -21,9 +21,11 @@ Every currently tracked file has exactly one component owner and one policy:
 - `development`: repository maintenance, tests, CI, or contribution files.
   These prove or build the product but are not runtime workspace outputs.
 
-The roots `.agents/skills/`, `.claude/commands/`, `content/`, `identity/`,
-`inbox/`, `projects/`, `references/`, `sessions/`, `state/`, and `writing/` are
-extensible. The legacy root configuration file `workspace.yaml` is an exact
+The roots `.agents/skills/`, `.claude/commands/`, `.cursor/`, `content/`,
+`identity/`, `inbox/`, `projects/`, `references/`, `sessions/`, `state/`, and
+`writing/` are extensible. This lets a configured Cursor workspace track its
+own rules, permissions, skills, hooks, or MCP settings without weakening the
+strict maintainer inventory. The legacy root configuration file `workspace.yaml` is an exact
 extensible path rather than a directory root. The canonical tracked
 `contextos.workspace.json` created by reviewed setup transactions is the other
 exact extensible path.

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -53,6 +53,8 @@ other repository-root paths extensible or writable.
 | `claude-adapter` | `core`, `portable-skills` | Claude Code instructions, commands, hooks, memory tooling, and descriptor |
 | `codex-adapter` | `core`, `portable-skills`, `agents-instructions`, `openai-skill-metadata` | Codex hooks, onboarding, metadata, and descriptor |
 | `hermes-adapter` | `core`, `portable-skills`, `agents-instructions` | Hermes guidance, optional hooks, and descriptor |
+| `openclaw-adapter` | `core`, `portable-skills`, `agents-instructions` | Experimental OpenClaw guidance, descriptor, and conformance |
+| `cursor-adapter` | `core`, `portable-skills`, `agents-instructions` | Experimental Cursor IDE/CLI guidance, descriptor, and conformance |
 | `example-project` | `core` | Optional removable example content |
 
 Shared dependencies have one owner. Selecting both Claude and Codex therefore

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,12 +2,13 @@
 
 Context OS can begin with a blank interview or selected context from another
 assistant. The result is a small, reviewable repository that Claude Code,
-Codex, Hermes, and experimental OpenClaw support can use as shared state.
+Codex, Hermes, and the experimental OpenClaw and Cursor adapters can use as
+shared state.
 
 ## Before you clone
 
 You need Git, Bash, Python 3.10 or newer, and at least one supported local
-agent: Claude Code, Codex, Hermes, or OpenClaw. claude.ai can help produce files but
+agent: Claude Code, Codex, Hermes, OpenClaw, or Cursor. claude.ai can help produce files but
 cannot maintain a local checkout directly.
 
 Python may be installed as either `python3` or `python`; the repository resolves
@@ -47,6 +48,8 @@ bash scripts/setup.sh --agents claude,codex
 bash scripts/setup.sh --agents hermes
 # or
 bash scripts/setup.sh --agents openclaw
+# or
+bash scripts/setup.sh --agents cursor
 # or, for the provider-neutral core only
 bash scripts/setup.sh --agents none
 ```
@@ -89,13 +92,19 @@ codex
 hermes
 # or, after following adapters/openclaw/README.md
 openclaw
+# or, open the repository in Cursor or start its Agent CLI here
+agent
 ```
 
-Run `/setup` in Claude Code or Hermes, `$setup` in Codex, or `/skill setup` in
-OpenClaw. OpenClaw first requires the separate private-workspace and copied-skill
+Run `/setup` in Claude Code or Hermes, `/context-setup` in Cursor, `$setup` in
+Codex, or `/skill setup` in OpenClaw. OpenClaw first requires the separate private-workspace and copied-skill
 steps in its [experimental adapter guide](../adapters/openclaw/README.md). The guided
 interview asks one question at a time, builds a deterministic proposal, and
 waits before applying the exact reviewed diff.
+
+Cursor has separate IDE and Agent CLI permission surfaces. Follow its
+[experimental adapter guide](../adapters/cursor/README.md); setup registers the
+runtime but launches neither surface and changes no Cursor authorization setting.
 
 ### Bring existing context
 
@@ -136,11 +145,11 @@ Commit and push only after the diff matches what you intend to preserve.
 
 ## Run the daily loop
 
-| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) |
-|---|---|---|---|---|
-| Start work | `/start` | `$start` | `/start` | `/skill start` |
-| Save progress without closing | `/update` | `$update` | `/update` | `/skill update` |
-| End with a reviewed handoff | `/end` | `$end` | `/end` | `/skill end` |
+| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) |
+|---|---|---|---|---|---|---|
+| Start work | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `/context-start` |
+| Save progress without closing | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `/context-update` |
+| End with a reviewed handoff | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `/context-end` |
 
 The lifecycle kernel writes shared continuity to `state/` and `sessions/` only
 after exact-proposal approval, then emits a local receipt. Each host retains

--- a/docs/memory-across-agents.md
+++ b/docs/memory-across-agents.md
@@ -46,6 +46,17 @@ It does not synchronize native memory into Context OS. Promote a durable fact
 across runtimes only through the same reviewed repository proposal used by the
 other hosts.
 
+## Cursor
+
+Cursor rules and skills are prompt context, not shared memory. Cursor account
+settings, IDE and CLI session history, Cloud Agents, Automations, and any
+host-native memories stay outside the repository contract. Context OS does not
+claim a foreground native-memory format or synchronize Cursor state.
+
+Use `state/` and `sessions/` for continuity that must travel between runtimes.
+Promote any durable Cursor-derived fact only through a reviewed repository
+proposal. See `adapters/cursor/README.md` for the separate IDE and CLI boundary.
+
 ## Proposal/apply boundary
 
 All registered runtimes use the same repository transaction:

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -242,10 +242,10 @@ intent with these rules:
 - only `agent disable` may shrink the configured set;
 - local launch choice is ephemeral and never creates a stored primary agent;
 - no adapter or component is deleted merely because it was not selected; and
-- Cursor remains a launch/read compatibility name until a registered runtime
-  descriptor exists, so it cannot be stored in `agents` yet. OpenClaw is a
-  registered experimental runtime and can be selected, but its private
-  workspace and copied-skill onboarding remain separate host-local steps.
+- Cursor and OpenClaw are registered experimental runtimes and may be stored in
+  `agents`. Cursor registration does not conflate or launch its IDE and Agent
+  CLI surfaces; OpenClaw registration does not configure its private workspace
+  or copied skills. Both retain separate host-local onboarding steps.
 
 ## Root discovery
 

--- a/runtimes/cursor.json
+++ b/runtimes/cursor.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 2,
+  "runtime": "cursor",
+  "display_name": "Cursor",
+  "support_tier": "experimental",
+  "support_summary": "Separate IDE and CLI onboarding through root AGENTS.md and project Agent Skills, without hook, memory, or rule-conflict claims",
+  "components": ["core", "portable-skills", "agents-instructions", "cursor-adapter"],
+  "install": {
+    "mode": "native-project-discovery",
+    "next_steps": [
+      "Open this repository as the Cursor workspace for IDE use, or start the Cursor Agent CLI from this repository root.",
+      "Invoke /context-setup, /context-start, /context-update, and /context-end explicitly; Cursor discovers the checked-in .agents/skills directory.",
+      "Keep Cursor rules and permissions non-overlapping with the shared AGENTS.md contract, and review every Context OS proposal before apply."
+    ]
+  },
+  "onboarding_doc": "adapters/cursor/README.md",
+  "surfaces": {
+    "ide": {
+      "kind": "ide",
+      "support_tier": "experimental",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+      ],
+      "skill_sources": [
+        {"scope": "repository", "role": "skills", "path": ".agents/skills", "precedence": 100}
+      ],
+      "invocation": {"setup": "/context-setup", "start": "/context-start", "update": "/context-update", "end": "/context-end"},
+      "capabilities": {
+        "agent_skills": "native",
+        "explicit_invocation": "native",
+        "project_hooks": "unsupported",
+        "blocking_pre_tool_hook": "unsupported",
+        "mcp": "native",
+        "native_memory": "unsupported",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "unsupported",
+        "execution_authorization": "native"
+      },
+      "hook_output": null,
+      "binary_probes": [
+        {"purpose": "availability", "candidates": ["cursor"]},
+        {"purpose": "version", "candidates": ["cursor"]}
+      ],
+      "conformance_tests": [
+        "tests/test_cursor_conformance.py",
+        "tests/test_contextos_kernel.py"
+      ],
+      "evidence": [
+        "cursor-rules", "cursor-skills", "cursor-mcp", "cursor-run-modes",
+        "cursor-kernel", "cursor-conformance"
+      ]
+    },
+    "cli": {
+      "kind": "cli",
+      "support_tier": "experimental",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+      ],
+      "skill_sources": [
+        {"scope": "repository", "role": "skills", "path": ".agents/skills", "precedence": 100}
+      ],
+      "invocation": {"setup": "/context-setup", "start": "/context-start", "update": "/context-update", "end": "/context-end"},
+      "capabilities": {
+        "agent_skills": "native",
+        "explicit_invocation": "native",
+        "project_hooks": "unsupported",
+        "blocking_pre_tool_hook": "unsupported",
+        "mcp": "native",
+        "native_memory": "unsupported",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "unsupported",
+        "execution_authorization": "native"
+      },
+      "hook_output": null,
+      "binary_probes": [],
+      "conformance_tests": [
+        "tests/test_cursor_conformance.py",
+        "tests/test_contextos_kernel.py"
+      ],
+      "evidence": [
+        "cursor-cli-using", "cursor-skills", "cursor-cli-slash-commands", "cursor-cli-headless",
+        "cursor-cli-permissions", "cursor-mcp", "cursor-kernel", "cursor-conformance"
+      ]
+    }
+  },
+  "evidence": {
+    "checked_on": "2026-08-27",
+    "tested_versions": [],
+    "sources": [
+      {
+        "id": "cursor-rules",
+        "type": "official",
+        "location": "https://cursor.com/docs/rules",
+        "claims": ["instruction_sources"]
+      },
+      {
+        "id": "cursor-skills",
+        "type": "official",
+        "location": "https://cursor.com/docs/skills",
+        "claims": ["agent_skills", "explicit_invocation", "skill_sources", "invocation"]
+      },
+      {
+        "id": "cursor-cli-using",
+        "type": "official",
+        "location": "https://cursor.com/docs/cli/using",
+        "claims": ["instruction_sources"]
+      },
+      {
+        "id": "cursor-cli-headless",
+        "type": "official",
+        "location": "https://cursor.com/docs/cli/headless",
+        "claims": ["execution_authorization"]
+      },
+      {
+        "id": "cursor-cli-slash-commands",
+        "type": "official",
+        "location": "https://cursor.com/docs/cli/reference/slash-commands",
+        "claims": ["invocation"]
+      },
+      {
+        "id": "cursor-cli-permissions",
+        "type": "official",
+        "location": "https://cursor.com/docs/cli/reference/permissions",
+        "claims": ["execution_authorization"]
+      },
+      {
+        "id": "cursor-run-modes",
+        "type": "official",
+        "location": "https://cursor.com/docs/agent/security/run-modes",
+        "claims": ["execution_authorization"]
+      },
+      {
+        "id": "cursor-mcp",
+        "type": "official",
+        "location": "https://cursor.com/docs/mcp",
+        "claims": ["mcp"]
+      },
+      {
+        "id": "cursor-kernel",
+        "type": "conformance",
+        "location": "tests/test_contextos_kernel.py",
+        "claims": ["proposal_apply"]
+      },
+      {
+        "id": "cursor-conformance",
+        "type": "conformance",
+        "location": "tests/test_cursor_conformance.py",
+        "claims": ["support"]
+      }
+    ]
+  }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
-SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex,openclaw|auto|none] [--agent auto|RUNTIME|none]"
+SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex,cursor,openclaw|auto|none] [--agent auto|RUNTIME|none]"
 AGENT_SELECTION_KIND=""
 AGENT_SELECTION_RAW=""
 while [ "$#" -gt 0 ]; do
@@ -60,7 +60,7 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       echo "$SETUP_USAGE"
       echo "  --agents records an additive tracked runtime set; it never removes agents."
-      echo "  --agent is the deprecated singleton alias and retains auto/Cursor launch compatibility."
+      echo "  --agent is the deprecated singleton alias."
       exit 0
       ;;
     *)
@@ -88,11 +88,6 @@ validate_agent_selection() {
     case "$raw" in
       auto)
         LAUNCH_SELECTION="auto"
-        return
-        ;;
-      cursor)
-        LAUNCH_SELECTION="$raw"
-        echo "  Note: $raw remains launch-only until it has a registered runtime descriptor."
         return
         ;;
       none)
@@ -339,13 +334,14 @@ else
   echo "    Optional: hermes — see AGENTS.md (Hermes Agent section)"
 fi
 
-CURSOR_FOUND=false
-if command -v cursor-agent &>/dev/null || command -v cursor &>/dev/null; then
-  echo "    Found: cursor"
-  CURSOR_FOUND=true
+CURSOR_IDE_FOUND=false
+if command -v cursor &>/dev/null; then
+  echo "    Found: cursor (IDE launcher)"
+  CURSOR_IDE_FOUND=true
 else
-  echo "    Optional: cursor (Cursor CLI)"
+  echo "    Optional: cursor (IDE launcher)"
 fi
+echo "    Cursor Agent CLI uses the generic 'agent' name; verify it manually with agent --version."
 
 OPENCLAW_FOUND=false
 if command -v openclaw &>/dev/null; then
@@ -496,6 +492,8 @@ if [[ "$SELECTED_AGENT" == *,* ]]; then
     SELECTED_AGENT="codex"
   elif [[ ",$SELECTED_AGENT," == *,hermes,* ]] && [ "$HERMES_FOUND" = true ]; then
     SELECTED_AGENT="hermes"
+  elif [[ ",$SELECTED_AGENT," == *,cursor,* ]] && [ "$CURSOR_IDE_FOUND" = true ]; then
+    SELECTED_AGENT="cursor"
   elif [[ ",$SELECTED_AGENT," == *,openclaw,* ]] && [ "$OPENCLAW_FOUND" = true ]; then
     SELECTED_AGENT="openclaw"
   else
@@ -509,6 +507,8 @@ if [ "$SELECTED_AGENT" = "auto" ]; then
     SELECTED_AGENT="codex"
   elif [ "$HERMES_FOUND" = true ]; then
     SELECTED_AGENT="hermes"
+  elif [ "$CURSOR_IDE_FOUND" = true ]; then
+    SELECTED_AGENT="cursor"
   elif [ "$OPENCLAW_FOUND" = true ]; then
     SELECTED_AGENT="openclaw"
   else
@@ -565,15 +565,16 @@ case "$SELECTED_AGENT" in
     fi
     ;;
   cursor)
-    printf '  1. cd %q\n' "$REPO_ROOT"
-    echo "  2. Open the repository in Cursor; Cursor reads AGENTS.md from the"
-    echo "     repository root. The portable lifecycle skills in .agents/skills/"
-    echo "     can be pasted or referenced in Cursor rules as needed."
-    echo ""
-    if [ -t 0 ] && [ "$CURSOR_FOUND" = true ] && prompt_yn "  Launch Cursor CLI now?" "y"; then
-      cd "$REPO_ROOT"
-      if command -v cursor-agent &>/dev/null; then exec cursor-agent; else exec cursor; fi
+    if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
+      "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime cursor >/dev/null
     fi
+    printf '  IDE: open %q as the Cursor workspace, then run /context-setup.\n' "$REPO_ROOT"
+    printf '  CLI: cd %q && agent, then run /context-setup.\n' "$REPO_ROOT"
+    echo "  Cursor discovers AGENTS.md and .agents/skills/ natively."
+    echo "  See adapters/cursor/README.md for separate IDE/CLI permission boundaries."
+    echo "  Setup does not launch Cursor because it cannot safely distinguish or"
+    echo "  verify both experimental surfaces and their authorization settings."
+    echo ""
     ;;
   openclaw)
     if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
@@ -594,7 +595,7 @@ case "$SELECTED_AGENT" in
     printf '  Claude Code: cd %q && claude, then run /setup\n' "$REPO_ROOT"
     printf '  Codex:       cd %q && codex, then run $setup\n' "$REPO_ROOT"
     printf '  Hermes:      cd %q && hermes (reads AGENTS.md; see AGENTS.md Hermes section)\n' "$REPO_ROOT"
-    printf '  Cursor:      cd %q and open in Cursor (reads AGENTS.md)\n' "$REPO_ROOT"
+    printf '  Cursor:      see adapters/cursor/README.md (separate IDE and Agent CLI paths)\n'
     echo "  OpenClaw:    see adapters/openclaw/README.md (private workspace + copied skills)"
     echo "  claude.ai:   open SETUP-PROMPTS.md and paste the prompts there"
     echo "  Guide:       docs/getting-started.md"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -269,7 +269,7 @@ if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$duplica
 fi
 
 help_output=$(bash scripts/setup.sh --help)
-grep -Fq -- '--agents claude,codex,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
+grep -Fq -- '--agents claude,codex,cursor,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
 grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"
 grep -Fq 'Setup does not launch OpenClaw' scripts/setup.sh \
   || fail "OpenClaw setup omits the private-workspace launch boundary"
@@ -278,6 +278,14 @@ test -n "$openclaw_setup_case" \
   || fail "OpenClaw setup case could not be inspected for launch behavior"
 if grep -Eq '(^|[[:space:]])exec[[:space:]]+openclaw([[:space:]]|$)' <<<"$openclaw_setup_case"; then
   fail "setup can launch OpenClaw before private-workspace configuration is verified"
+fi
+grep -Fq 'Setup does not launch Cursor' scripts/setup.sh \
+  || fail "Cursor setup omits the separate-surface launch boundary"
+cursor_setup_case=$(sed -n '/^  cursor)/,/^    ;;/p' scripts/setup.sh)
+test -n "$cursor_setup_case" \
+  || fail "Cursor setup case could not be inspected for launch behavior"
+if grep -Eq '(^|[[:space:]])exec[[:space:]]+(cursor|agent)([[:space:]]|$)' <<<"$cursor_setup_case"; then
+  fail "setup launches an unverified Cursor surface"
 fi
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"

--- a/tests/test_component_manifests.py
+++ b/tests/test_component_manifests.py
@@ -588,6 +588,7 @@ class ComponentManifestTest(unittest.TestCase):
             *owners,
             ".agents/skills/standup/SKILL.md",
             ".claude/commands/standup.md",
+            ".cursor/cli.json",
             "contextos.workspace.json",
             "sessions/2026-08-25.md",
         ]
@@ -595,6 +596,7 @@ class ComponentManifestTest(unittest.TestCase):
             [
                 ".agents/skills/standup/SKILL.md",
                 ".claude/commands/standup.md",
+                ".cursor/cli.json",
                 "sessions/2026-08-25.md",
             ],
             unclassified_tracked_paths(

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -333,7 +333,7 @@ class KernelTest(unittest.TestCase):
             (self.root / "state" / name).write_text(
                 f"# {name}\n\n**Last Updated:** 2026-08-20\n", encoding="utf-8"
             )
-        for runtime in ("claude", "codex", "hermes", "openclaw"):
+        for runtime in ("claude", "codex", "cursor", "hermes", "openclaw"):
             source = ROOT / "runtimes" / f"{runtime}.json"
             (self.root / "runtimes" / f"{runtime}.json").write_bytes(source.read_bytes())
         for directory in (
@@ -1551,7 +1551,10 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         hosts_path.write_text(json.dumps(hosts), encoding="utf-8")
 
         report = doctor(self.root, all_runtimes=True)
-        self.assertEqual({"claude", "codex", "hermes", "openclaw"}, set(report["runtimes"]))
+        self.assertEqual(
+            {"claude", "codex", "cursor", "hermes", "openclaw"},
+            set(report["runtimes"]),
+        )
 
     def test_bare_doctor_validates_all_manifests_during_setup(self) -> None:
         manifest = json.loads((self.root / "runtimes/claude.json").read_text(encoding="utf-8"))

--- a/tests/test_cursor_conformance.py
+++ b/tests/test_cursor_conformance.py
@@ -97,6 +97,8 @@ class CursorDescriptorTest(unittest.TestCase):
             "ships no Cursor rule file",
             "same-name collision winner",
             "built-in `/update`",
+            "Cursor discovers both sets",
+            "does not document whether its built-in `/update`",
             "agent -p --force",
             "too generic for safe automatic detection",
             "explicit deny wins an allow",
@@ -106,6 +108,8 @@ class CursorDescriptorTest(unittest.TestCase):
             "No Cursor-native memory is synchronized",
             "Never run a `--force` conformance check against a real context repository",
             "exact-version conformance for both surfaces",
+            "aggregate availability status reflects only",
+            "exact-version and required-flag smoke test",
         ):
             with self.subTest(required=required):
                 self.assertIn(required, normalized)
@@ -116,7 +120,7 @@ class CursorDescriptorTest(unittest.TestCase):
     and os.environ.get("CONTEXTOS_CURSOR_CLI_VERSION"),
     "set CONTEXTOS_CURSOR_CLI_BIN and CONTEXTOS_CURSOR_CLI_VERSION for the exact CLI",
 )
-class InstalledCursorCliTest(unittest.TestCase):
+class CursorCliSmokeTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.binary = Path(os.environ["CONTEXTOS_CURSOR_CLI_BIN"]).resolve(strict=True)

--- a/tests/test_cursor_conformance.py
+++ b/tests/test_cursor_conformance.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DESCRIPTOR = json.loads((ROOT / "runtimes/cursor.json").read_text(encoding="utf-8"))
+LIFECYCLE = {
+    name: f"/context-{name}" for name in ("setup", "start", "update", "end")
+}
+
+
+class CursorDescriptorTest(unittest.TestCase):
+    def test_ide_and_cli_remain_distinct_experimental_surfaces(self) -> None:
+        self.assertEqual("experimental", DESCRIPTOR["support_tier"])
+        self.assertEqual({"ide", "cli"}, set(DESCRIPTOR["surfaces"]))
+        ide = DESCRIPTOR["surfaces"]["ide"]
+        cli = DESCRIPTOR["surfaces"]["cli"]
+        self.assertEqual("ide", ide["kind"])
+        self.assertEqual("cli", cli["kind"])
+        self.assertEqual(
+            [
+                {"purpose": "availability", "candidates": ["cursor"]},
+                {"purpose": "version", "candidates": ["cursor"]},
+            ],
+            ide["binary_probes"],
+        )
+        self.assertEqual([], cli["binary_probes"])
+        self.assertNotEqual(
+            ide["binary_probes"], cli["binary_probes"],
+            "IDE availability must not stand in for CLI availability",
+        )
+
+    def test_both_surfaces_use_shared_instructions_and_explicit_skills(self) -> None:
+        for surface_name, surface in DESCRIPTOR["surfaces"].items():
+            with self.subTest(surface=surface_name):
+                self.assertEqual(LIFECYCLE, surface["invocation"])
+                self.assertEqual(
+                    ["AGENTS.md"],
+                    [source["path"] for source in surface["instruction_sources"]],
+                )
+                self.assertEqual(
+                    [".agents/skills"],
+                    [source["path"] for source in surface["skill_sources"]],
+                )
+                self.assertEqual("native", surface["capabilities"]["agent_skills"])
+                self.assertEqual("native", surface["capabilities"]["explicit_invocation"])
+
+    def test_unverified_hooks_memory_and_collisions_are_not_claimed(self) -> None:
+        self.assertEqual([], DESCRIPTOR["evidence"]["tested_versions"])
+        for surface_name, surface in DESCRIPTOR["surfaces"].items():
+            with self.subTest(surface=surface_name):
+                self.assertEqual("unsupported", surface["capabilities"]["project_hooks"])
+                self.assertEqual(
+                    "unsupported", surface["capabilities"]["blocking_pre_tool_hook"]
+                )
+                self.assertEqual("unsupported", surface["capabilities"]["native_memory"])
+                self.assertEqual("unsupported", surface["capabilities"]["skill_allowlists"])
+                self.assertIsNone(surface["hook_output"])
+
+    def test_evidence_and_install_steps_do_not_flatten_the_surfaces(self) -> None:
+        ide_evidence = set(DESCRIPTOR["surfaces"]["ide"]["evidence"])
+        cli_evidence = set(DESCRIPTOR["surfaces"]["cli"]["evidence"])
+        self.assertFalse(any(item.startswith("cursor-cli-") for item in ide_evidence))
+        self.assertTrue(
+            {"cursor-cli-using", "cursor-cli-headless", "cursor-cli-permissions"}
+            <= cli_evidence
+        )
+        self.assertNotIn("cursor-run-modes", cli_evidence)
+        install_text = "\n".join(DESCRIPTOR["install"]["next_steps"])
+        self.assertNotIn("--trust", install_text)
+        self.assertNotIn("--force", install_text)
+
+    def test_adapter_does_not_ship_unverified_cursor_configuration(self) -> None:
+        for path in (
+            ".cursor/rules",
+            ".cursor/hooks.json",
+            ".cursor/cli.json",
+            ".cursor/permissions.json",
+            ".cursor/mcp.json",
+            ".cursor/skills",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse((ROOT / path).exists())
+
+    def test_guide_names_the_unsupported_and_authorization_boundaries(self) -> None:
+        guide = (ROOT / "adapters/cursor/README.md").read_text(encoding="utf-8")
+        normalized = " ".join(guide.split())
+        for required in (
+            "A green CLI check is not IDE evidence",
+            "does not document which source wins",
+            "ships no Cursor rule file",
+            "same-name collision winner",
+            "built-in `/update`",
+            "agent -p --force",
+            "too generic for safe automatic detection",
+            "explicit deny wins an allow",
+            "not approval of a Context OS proposal",
+            "ships no Cursor hook adapter",
+            "failClosed",
+            "No Cursor-native memory is synchronized",
+            "Never run a `--force` conformance check against a real context repository",
+            "exact-version conformance for both surfaces",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, normalized)
+
+
+@unittest.skipUnless(
+    os.environ.get("CONTEXTOS_CURSOR_CLI_BIN")
+    and os.environ.get("CONTEXTOS_CURSOR_CLI_VERSION"),
+    "set CONTEXTOS_CURSOR_CLI_BIN and CONTEXTOS_CURSOR_CLI_VERSION for the exact CLI",
+)
+class InstalledCursorCliTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.binary = Path(os.environ["CONTEXTOS_CURSOR_CLI_BIN"]).resolve(strict=True)
+        if not cls.binary.is_file():
+            raise unittest.SkipTest("CONTEXTOS_CURSOR_CLI_BIN is not an exact file")
+        cls.expected_version = os.environ["CONTEXTOS_CURSOR_CLI_VERSION"]
+        cls.temporary = tempfile.TemporaryDirectory()
+        cls.cwd = Path(cls.temporary.name).resolve()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.binary), *args],
+            cwd=self.cwd,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+            timeout=60,
+        )
+
+    def test_exact_version_and_required_headless_controls(self) -> None:
+        version = self._run("--version")
+        self.assertEqual(0, version.returncode, version.stderr)
+        self.assertEqual(self.expected_version, version.stdout.strip())
+        help_result = self._run("--help")
+        self.assertEqual(0, help_result.returncode, help_result.stderr)
+        help_text = help_result.stdout + help_result.stderr
+        for required in ("--print", "--force", "--workspace", "--trust"):
+            with self.subTest(required=required):
+                self.assertIn(required, help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cursor_conformance.py
+++ b/tests/test_cursor_conformance.py
@@ -77,6 +77,8 @@ class CursorDescriptorTest(unittest.TestCase):
         self.assertNotIn("--force", install_text)
 
     def test_adapter_does_not_ship_unverified_cursor_configuration(self) -> None:
+        if os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace":
+            self.skipTest("workspace-owned .cursor configuration is permitted")
         for path in (
             ".cursor/rules",
             ".cursor/hooks.json",
@@ -110,6 +112,10 @@ class CursorDescriptorTest(unittest.TestCase):
             "exact-version conformance for both surfaces",
             "aggregate availability status reflects only",
             "exact-version and required-flag smoke test",
+            "Cursor CLI also reads a root `CLAUDE.md`",
+            "removable seed",
+            "Project-owned `.cursor/` configuration is permitted",
+            "portable skill frontmatter does not currently enforce",
         ):
             with self.subTest(required=required):
                 self.assertIn(required, normalized)

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -287,6 +287,8 @@ class DocumentationPositioningTests(unittest.TestCase):
             "The portable cores", 1
         )[0]
         claude_specific = index.split("## Claude-specific command index", 1)[1]
+        # Only Claude's lifecycle column and Claude-specific table describe
+        # .claude/commands; other host columns may name portable skills.
         indexed_commands = set(
             re.findall(
                 r"^\|[^|]+\| `/([a-z0-9]+(?:-[a-z0-9]+)*)` \|",

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -283,7 +283,23 @@ class DocumentationPositioningTests(unittest.TestCase):
         index = self.text("docs/commands-and-skills.md")
         workspace = os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace"
         shipped_commands = {path.stem for path in (ROOT / ".claude/commands").glob("*.md")}
-        indexed_commands = set(re.findall(r"`/([a-z0-9]+(?:-[a-z0-9]+)*)`", index))
+        shared_lifecycle = index.split("## Shared lifecycle", 1)[1].split(
+            "The portable cores", 1
+        )[0]
+        claude_specific = index.split("## Claude-specific command index", 1)[1]
+        indexed_commands = set(
+            re.findall(
+                r"^\|[^|]+\| `/([a-z0-9]+(?:-[a-z0-9]+)*)` \|",
+                shared_lifecycle,
+                re.MULTILINE,
+            )
+        ) | set(
+            re.findall(
+                r"^\| `/([a-z0-9]+(?:-[a-z0-9]+)*)` \|",
+                claude_specific,
+                re.MULTILINE,
+            )
+        )
         if workspace:
             self.assertLessEqual(indexed_commands, shipped_commands)
         else:

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -29,9 +29,9 @@ def load(runtime: str) -> dict:
 
 class RuntimeManifestTest(unittest.TestCase):
     def test_registry_discovers_and_validates_every_descriptor(self) -> None:
-        self.assertEqual(["claude", "codex", "hermes", "openclaw"], runtime_ids(ROOT))
+        self.assertEqual(["claude", "codex", "cursor", "hermes", "openclaw"], runtime_ids(ROOT))
         registry = runtime_registry(ROOT)
-        self.assertEqual({"claude", "codex", "hermes", "openclaw"}, set(registry))
+        self.assertEqual({"claude", "codex", "cursor", "hermes", "openclaw"}, set(registry))
         self.assertNotIn("generic", registry)
         for runtime, manifest in registry.items():
             with self.subTest(runtime=runtime):
@@ -50,6 +50,12 @@ class RuntimeManifestTest(unittest.TestCase):
             {name: f"/skill {name}" for name in ("setup", "start", "update", "end")},
             openclaw,
         )
+        cursor = load("cursor")
+        expected = {
+            name: f"/context-{name}" for name in ("setup", "start", "update", "end")
+        }
+        self.assertEqual(expected, cursor["surfaces"]["ide"]["invocation"])
+        self.assertEqual(expected, cursor["surfaces"]["cli"]["invocation"])
 
     def test_checked_in_schema_matches_authoritative_contract(self) -> None:
         actual = json.loads((ROOT / "runtimes/schema.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What's in this PR

Adds a truthful experimental Cursor adapter with separate IDE and Agent CLI
surfaces. Cursor uses root `AGENTS.md` and project Agent Skills, while
unsupported hook, memory, and rule-conflict behavior remains explicit.
Namespaced `context-*` lifecycle commands avoid relying on Cursor CLI's built-in
`/update` resolution. Setup registers Cursor but launches neither surface or
changes host authorization.

The adapter also documents Cursor CLI's optional root `CLAUDE.md` source, keeps
the generic `agent` executable out of resolution-only probes, and makes
workspace-owned `.cursor/` configuration extensible without weakening strict
maintainer ownership.

Related to #73. This intentionally leaves #73 open until exact installed IDE
and CLI conformance is available.

## Verification

- Full validator: 407 tests passed, 32 expected skips.
- Portability and hook checks passed.
- Integration catalog, component manifest (10 components, 182 paths), runtime
  registry (5 descriptors), workspace configuration, JSON, links, and doc
  reachability passed.
- Workspace-profile controls permit user-owned `.cursor/` configuration while
  strict maintainer controls reject unowned shipped paths.
- No Cursor binary was installed; `tested_versions` remains empty and the
  opt-in CLI check is described as a version/flag smoke, not live conformance.
- Hosted `validate`, minimum-Python, and Windows jobs passed at exact SHA
  `0dae08c15a9ce871f5ca99060ad6dca001e597b8`.

## Review

- Claude Opus (`claude-opus-5`) final exact-SHA review: no merge blocker.
- Hermes (`thinkingmachines/inkling:free`, verified zero-price endpoint) final
  exact-SHA review: no merge blocker.
- Two repair cycles used. Findings about short-alias discovery, IDE-only doctor
  availability, smoke-test wording, optional `CLAUDE.md`, and workspace-owned
  `.cursor/` configuration were repaired and reverified.

## Checklist

### Skills & commands

- [x] No new portable skill bodies or Claude commands.
- [x] Portable workflow behavior remains in existing shared skills.
- [x] Explicit namespaced invocation is documented for both Cursor surfaces.

### Repo hygiene

- [x] No sensitive data committed.
- [x] `CHANGELOG.md` updated.
- [x] CI passes.
