### PR TITLE
Add experimental Devin managed-account adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ this is guidance, not a host-enforced gate. The `$context-setup`, `$context-star
 - Invoke `/setup`, `/start`, `/update`, and `/end` explicitly.
 - Keep Hermes `MEMORY.md` and `USER.md` separate from repository state. See
   `docs/memory-across-agents.md`.
-- Hermes hooks are optional defense in depth; kernel enforcement does not depend on them.
+- `.claude/hooks/` does not run in Hermes; its hooks are optional defense in depth.
 
 ## OpenClaw
 
@@ -90,11 +90,11 @@ this is guidance, not a host-enforced gate. The `$context-setup`, `$context-star
 
 - Cloud sessions use `@skills:context-setup`, `@skills:context-start`,
   `@skills:context-update`, and `@skills:context-end`; automatic skill discovery
-  remains possible, while exact-digest approval still gates repository writes.
+  remains possible. Digests prevent proposal substitution, not automated approval.
 - Review sends code externally and is not a lifecycle host. Account state is not
   locally configured or verified; see `adapters/devin/README.md`.
 
 ## Validation
 
 Run `bash scripts/validate-all.sh --workspace` for workspace changes. Product
-contributors and CI run the strict form after product changes.
+contributors and CI run it without `--workspace` after product changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ remain supported.
 - `adapters/hermes/` documents optional Hermes hooks and skill installation.
 - `adapters/openclaw/` documents experimental skills-first OpenClaw support.
 - `adapters/cursor/` documents separate experimental Cursor IDE and CLI support.
+- `adapters/devin/` documents experimental Devin cloud-session and Review support.
 - Runtime manifests under `runtimes/` declare support instead of implying parity.
 - Kernel proposal/apply is the enforcement boundary on every host; hooks are
   defense in depth and host-local memory is never shared automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,7 @@
 # Context OS
 
-This repository is the durable source of truth for personal, project, and
-session context. Keep provider-neutral state here and host-specific behavior in
-its adapter directory.
+This repository is the durable source of truth for personal, project, and session
+context. Keep provider-neutral state here and host-specific behavior in its adapter.
 
 ## Session lifecycle
 
@@ -11,9 +10,9 @@ its adapter directory.
 - Save a mid-session checkpoint: use `$update`.
 - Close a session: use `$end`.
 
-These workflows require explicit invocation. The `$context-setup`,
-`$context-start`, `$context-update`, and `$context-end` compatibility names
-remain supported.
+Invoke these workflows explicitly with the form documented by the host adapter;
+this is guidance, not a host-enforced gate. The `$context-setup`, `$context-start`,
+`$context-update`, and `$context-end` compatibility names remain supported.
 
 ## Lifecycle kernel
 
@@ -38,7 +37,7 @@ remain supported.
   destructive action, credential change, or permission expansion.
 - Show proposed context changes before broad or destructive rewrites.
 - Never commit or push without explicit approval.
-- Optional integrations stay disabled until chosen and configured. Review
+- Optional integrations stay disabled until chosen and configured; see
   `references/integrations.md` for data and side-effect boundaries.
 
 ## Portability boundary
@@ -63,8 +62,7 @@ remain supported.
 - Invoke `/setup`, `/start`, `/update`, and `/end` explicitly.
 - Keep Hermes `MEMORY.md` and `USER.md` separate from repository state. See
   `docs/memory-across-agents.md`.
-- `.claude/hooks/` does not run under Hermes. The optional Hermes adapter maps
-  supported events to portable checks; kernel enforcement does not depend on it.
+- Hermes hooks are optional defense in depth; kernel enforcement does not depend on them.
 
 ## OpenClaw
 
@@ -73,9 +71,8 @@ remain supported.
   private workspace's `.agents/skills/`; refresh copied skills after changes.
 - Run OpenClaw from the repository directory so root `AGENTS.md` is included,
   then invoke `/skill setup`, `/skill start`, `/skill update`, or `/skill end`.
-- This experimental adapter installs no OpenClaw hook or plugin. Skill
-  allowlists do not replace separate shell-execution authorization.
-- See `adapters/openclaw/README.md` for the tested version and diagnostics.
+- This adapter installs no hook or plugin; skill allowlists do not replace
+  execution authorization. See `adapters/openclaw/README.md`.
 
 ## Cursor
 
@@ -87,12 +84,17 @@ remain supported.
   document their conflict order. IDE and CLI permissions remain separate.
 - Cursor CLI also reads the removable root `CLAUDE.md` when present. Treat its
   short lifecycle commands as Claude adapters, not Cursor invocations.
-- This experimental adapter ships no Cursor hook or native-memory bridge. See
-  `adapters/cursor/README.md` for authorization and conformance boundaries.
+- This adapter ships no hook or memory bridge; see `adapters/cursor/README.md`.
+
+## Devin
+
+- Cloud sessions use `@skills:context-setup`, `@skills:context-start`,
+  `@skills:context-update`, and `@skills:context-end`; automatic skill discovery
+  remains possible, while exact-digest approval still gates repository writes.
+- Review sends code externally and is not a lifecycle host. Account state is not
+  locally configured or verified; see `adapters/devin/README.md`.
 
 ## Validation
 
-Run `bash scripts/validate-all.sh --workspace` after changing personal context
-or adding workspace-owned skills and commands. Product contributors and CI run
-the strict form without `--workspace` after changing instructions, hooks,
-scripts, manifests, or generated references.
+Run `bash scripts/validate-all.sh --workspace` for workspace changes. Product
+contributors and CI run the strict form after product changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,4 +97,4 @@ this is guidance, not a host-enforced gate. The `$context-setup`, `$context-star
 ## Validation
 
 Run `bash scripts/validate-all.sh --workspace` for workspace changes. Product
-contributors and CI run it without `--workspace` after product changes.
+contributors and CI omit `--workspace` after instructions, hooks, scripts, manifests, or generated references change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Experimental Devin onboarding with distinct cloud-session and Review
+  surfaces, repository-native AGENTS.md and Agent Skills, a managed-account
+  setup/doctor boundary, and hostile controls that reject repository claims for
+  Blueprints, snapshots, Knowledge, secrets, permissions, or UI state.
 - Experimental Cursor onboarding with separate IDE and Agent CLI surfaces,
   native root-instruction and project-skill discovery, explicit lifecycle
   invocation, separate authorization guidance, no hook or memory claim, and

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ Compatibility paths that are not registered runtime adapters:
 
 ## One source, explicit host adapters
 
-| Capability | Shared | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) |
+| Capability | Shared | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE/CLI (experimental) | Devin session (experimental) |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Identity, project, state, and session files | Yes | Reads | Reads | Reads | Reads | Reads | Reads |
 | Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls | Copied skill calls | Native skill calls | Native skill calls |
-| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. | `/skill setup` etc. | `/context-setup` etc. | `/context-setup` etc. |
+| Lifecycle vocabulary | Semantics | `/setup` etc. | `$setup` etc. | `/setup` etc. | `/skill setup` etc. | `/context-setup` etc. | `@skills:context-setup` etc. |
 | Project hooks | Event contract only | `.claude/` | `.codex/` | Optional adapter | Not claimed | Not claimed | Not claimed |
-| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` | Private workspace | Outside contract | Outside contract |
+| Native memory | No | Claude auto-memory | Outside contract | `MEMORY.md` / `USER.md` | Private workspace | Outside contract | Account-managed; not synchronized |
 
 The shared layer is intentionally plain files. Provider-specific tool names, hooks, permissions, and memory features stay in their adapter directories.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Context OS
 
-A portable Git-backed context and workflow layer for agents like Claude Code, Codex, Hermes, OpenClaw, and Cursor. Evolves alongside you and your agents.
+A portable Git-backed context and workflow layer for agents like Claude Code, Codex, Hermes, OpenClaw, Cursor, and Devin. Evolves alongside you and your agents.
 
 [![GitHub stars](https://img.shields.io/github/stars/conorbronsdon/agent-context-os?style=social)](https://github.com/conorbronsdon/agent-context-os/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -15,7 +15,7 @@ A portable Git-backed context and workflow layer for agents like Claude Code, Co
 
 Chat history, project instructions, and copied prompts drift apart. Context OS puts the durable parts in plain Markdown: who you are, what you are working on, decisions already made, and the workflows you want an agent to follow.
 
-Claude Code, Codex, Hermes, and the experimental OpenClaw and Cursor adapters
+Claude Code, Codex, Hermes, and the experimental OpenClaw, Cursor, and Devin adapters
 read the same repository state. A deterministic
 lifecycle kernel turns reviewed setup, checkpoint, and close requests into
 hash-checked proposals and receipts, without treating native memory as the
@@ -47,6 +47,7 @@ bash scripts/setup.sh --agents claude,codex
 # bash scripts/setup.sh --agents hermes
 # bash scripts/setup.sh --agents openclaw
 # bash scripts/setup.sh --agents cursor
+# bash scripts/setup.sh --agents devin
 # bash scripts/setup.sh --agents none  # core-only
 ```
 
@@ -71,6 +72,7 @@ Then start your agent from the repository root:
 | New workspace in Hermes | Run `/setup` after exposing the repository skills |
 | New workspace in OpenClaw | Follow the [experimental adapter](adapters/openclaw/README.md), then run `/skill setup` |
 | New workspace in Cursor | Follow the separate [experimental IDE and CLI paths](adapters/cursor/README.md), then run `/context-setup` |
+| New cloud session in Devin | Complete the [managed-account checks](adapters/devin/README.md), then run `@skills:context-setup` |
 | Existing context in another assistant | Follow the [migration guide](docs/migration-guide.md), then use the selected material during setup |
 | claude.ai only | Use [SETUP-PROMPTS.md](SETUP-PROMPTS.md) and copy the approved output into the repository |
 
@@ -81,7 +83,7 @@ The setup interview fills the identity, first project, workflows, and weekly sta
 ![A start session in Claude Code: state files load and a session briefing comes back, using sample data from the included example musician project](docs/assets/start-demo.gif)
 
 `/start` in Claude Code or Hermes, `/context-start` in Cursor, `$start` in Codex,
-and `/skill start` in OpenClaw read your state,
+`/skill start` in OpenClaw, and `@skills:context-start` in a Devin session read your state,
 priorities, decisions, blockers, and recent handoff. The result is grounded in
 files rather than reconstructed from chat.
 
@@ -93,12 +95,12 @@ At the end, `/end` or `$end` proposes a handoff for review before it updates `se
 
 Start small. Use the core loop for a week, add one active project, then turn a repeated task into a skill when the repetition is clear.
 
-| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) | Shared result |
+| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE/CLI (experimental) | Devin session (experimental) | Shared result |
 |---|---|---|---|---|---|---|---|
-| First run or major refresh | `/setup` | `$setup` | `/setup` | `/skill setup` | `/context-setup` | `/context-setup` | Reviewed context proposal |
-| Start work | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `/context-start` | Read-only continuity inventory and briefing |
-| Save a checkpoint | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `/context-update` | Hash-checked update and receipt |
-| Finish work | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `/context-end` | Hash-checked handoff, decisions, and receipt |
+| First run or major refresh | `/setup` | `$setup` | `/setup` | `/skill setup` | `/context-setup` | `@skills:context-setup` | Reviewed context proposal |
+| Start work | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `@skills:context-start` | Read-only continuity inventory and briefing |
+| Save a checkpoint | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `@skills:context-update` | Hash-checked update and receipt |
+| Finish work | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `@skills:context-end` | Hash-checked handoff, decisions, and receipt |
 
 The namespaced `$context-setup`, `$context-start`, `$context-update`, and
 `$context-end` invocations remain available for compatibility.
@@ -125,6 +127,7 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 | Claude Code | first-class | Shared lifecycle, slash-command adapters, hooks, optional live reads, and Claude-only auto-memory curation |
 | Codex | first-class | Shared lifecycle, native skills, project instructions, hooks, and reviewed proposal/apply writes |
 | Cursor | experimental | Separate IDE and CLI onboarding through root AGENTS.md and project Agent Skills, without hook, memory, or rule-conflict claims |
+| Devin | experimental | Experimental cloud-session lifecycle through repository AGENTS.md and Agent Skills, with Devin Review and all account-managed state kept separate |
 | Hermes Agent | first-class | Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory |
 | OpenClaw | experimental | Skills-first lifecycle support with copied portable skills, separate private memory, and no project-hook claim |
 <!-- runtime-support:end -->
@@ -177,6 +180,7 @@ contextos/                 Deterministic lifecycle kernel
 adapters/hermes/           Hermes installation and optional hook adapter
 adapters/openclaw/         Experimental OpenClaw skills-first adapter
 adapters/cursor/           Experimental Cursor IDE and CLI adapter
+adapters/devin/            Experimental Devin session and Review adapter
 runtimes/                  Machine-readable capability manifests
 components/                Component ownership and dependency manifest
 workspace/                 Schema and inactive canonical config example

--- a/adapters/devin/README.md
+++ b/adapters/devin/README.md
@@ -14,14 +14,17 @@ Devin cloud sessions document repository-root `AGENTS.md` and Agent Skills under
 `.agents/skills/`. Start a session for this repository and invoke
 `@skills:context-setup`, `@skills:context-start`, `@skills:context-update`, or
 `@skills:context-end`. The namespaced forms avoid implying that Devin owns the
-short command vocabulary. The lifecycle kernel still requires an exact-digest
-proposal and approval before apply.
+short command vocabulary. The lifecycle kernel binds apply to the exact proposal
+digest, preventing proposal substitution. It does not authenticate who supplied
+the confirmation or prove that a human reviewed the diff.
 
 Devin skills default to automatic model invocation unless their frontmatter
 sets `triggers: ["user"]`. The portable Context OS skills do not currently ship
 that Devin-specific field, so explicit invocation is guidance rather than a
 native enforcement claim. An instruction to ask first is not the same as a
-host permission boundary.
+host permission boundary. This adapter also has no execution-authorization or
+blocking-hook control that can prove human approval: do not run lifecycle skills
+in unattended sessions, and verify every diff outside the agent before apply.
 
 ## Account-managed boundary
 

--- a/adapters/devin/README.md
+++ b/adapters/devin/README.md
@@ -1,0 +1,93 @@
+# Devin experimental adapter
+
+Context OS supports Devin through two deliberately separate surfaces: cloud
+Agent sessions are an experimental lifecycle host, while Devin Review is a
+compatibility surface for repository instructions only. Evidence from one
+surface does not establish behavior in the other.
+
+No exact Devin model or product build was available to pin for this release.
+The adapter is therefore an evidence-backed pilot, not first-class support.
+
+## Repository boundary
+
+Devin cloud sessions document repository-root `AGENTS.md` and Agent Skills under
+`.agents/skills/`. Start a session for this repository and invoke
+`@skills:context-setup`, `@skills:context-start`, `@skills:context-update`, or
+`@skills:context-end`. The namespaced forms avoid implying that Devin owns the
+short command vocabulary. The lifecycle kernel still requires an exact-digest
+proposal and approval before apply.
+
+Devin skills default to automatic model invocation unless their frontmatter
+sets `triggers: ["user"]`. The portable Context OS skills do not currently ship
+that Devin-specific field, so explicit invocation is guidance rather than a
+native enforcement claim. An instruction to ask first is not the same as a
+host permission boundary.
+
+## Account-managed boundary
+
+Blueprints, builds, snapshots, standalone Knowledge, secrets, repository
+permissions, organization roles, security profiles, MCP configuration, and UI
+state are Devin-managed account state. They are not Context OS components,
+repository instruction sources, locally installable artifacts, or proof of
+readiness. Git-based blueprints are not currently supported; configure them in
+**Settings > Environment > Blueprints**. Context OS ships no `.devin/` file or
+blueprint YAML.
+
+Setup can register `devin` in `contextos.workspace.json` and local host
+metadata. That means only "selected for this workspace." It does not connect a
+repository, grant a role, create Knowledge, configure a Blueprint, build or pin
+a snapshot, inject a secret, authenticate a session, or verify any of those
+account-side states. A missing local binary is not a failure because this
+surface is cloud-managed; `doctor` can validate the descriptor and materialized
+repository files but does not certify the Devin account.
+
+Before use, verify in Devin that:
+
+1. the intended organization can access the exact repository;
+2. the repository is included or configured in the environment;
+3. the current Blueprint build succeeded and the intended snapshot is active;
+4. the session security profile and user role match the task; and
+5. required secrets exist at the intended scope.
+
+Secrets are injected by Devin rather than committed here. Devin documents that
+secret values are scrubbed from snapshots, but a Blueprint command that writes
+a value into a configuration file can persist it in the snapshot. Never put a
+real secret in a conformance fixture or repository file.
+
+## Devin Review is not a session
+
+Devin Review documents instruction-file support, including `AGENTS.md`, but it
+does not document cloud-session lifecycle skills, Knowledge, snapshots, MCP,
+secrets, or hooks as Review inputs. The Review CLI is also distinct from a cloud
+Agent session: `npx devin-review <pull-request-url>` computes a local diff in an
+isolated worktree and sends the diff and file contents to Devin servers. Run it
+only with explicit external-data-transfer approval and never use a private or
+user workspace as an incidental fixture.
+
+GitHub comments, approvals, merges, and code changes from Review require
+account-side GitHub App permissions. A PAT connection is read-only, and local
+git access for the Review CLI does not prove Devin account access to the repo.
+
+## Unsupported and promotion gates
+
+Context OS ships no Devin repository hook, blocking pre-tool hook, memory
+bridge, skill allowlist, execution-authorization adapter, Blueprint, Knowledge
+record, secret, playbook, MCP config, or Review config. `MEMORY.md` has no
+documented special Devin session semantics and is not synchronized.
+
+Promotion requires dated live-account fixtures that demonstrate instruction
+and skill discovery, explicit lifecycle behavior, proposal/apply authorization,
+repository access, and exact account/build identity. Account-dependent checks
+must skip as **unverified** when credentials or opt-in are absent; documentation
+or local registration alone must never turn them green. Review needs its own
+fixtures and may not inherit a session result.
+
+Current first-party references:
+
+- [AGENTS.md](https://docs.devin.ai/onboard-devin/agents-md)
+- [Agent Skills](https://docs.devin.ai/product-guides/skills)
+- [Declarative environment configuration](https://docs.devin.ai/onboard-devin/environment/blueprints)
+- [Blueprint reference](https://docs.devin.ai/onboard-devin/environment/blueprint-reference)
+- [Knowledge](https://docs.devin.ai/product-guides/knowledge)
+- [Secrets](https://docs.devin.ai/product-guides/secrets)
+- [Devin Review](https://docs.devin.ai/work-with-devin/devin-review)

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -817,6 +817,29 @@
             ]
         },
         {
+            "id": "devin-adapter",
+            "description": "Experimental Devin cloud-session and Review onboarding with managed-account boundary controls.",
+            "depends_on": [
+                "core",
+                "portable-skills",
+                "agents-instructions"
+            ],
+            "paths": [
+                {
+                    "path": "adapters/devin/README.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "runtimes/devin.json",
+                    "policy": "managed"
+                },
+                {
+                    "path": "tests/test_devin_conformance.py",
+                    "policy": "development"
+                }
+            ]
+        },
+        {
             "id": "example-project",
             "description": "Optional removable example project and workflow seeds.",
             "depends_on": [

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -4414,9 +4414,17 @@ def doctor(
         )
 
         host_entry = local_hosts["hosts"].get(runtime_id) if local_hosts_valid else None
+        managed_account = (
+            manifest is not None
+            and manifest["install"]["mode"] == "managed-account"
+        )
         onboarding_status = (
             "unknown"
             if not local_hosts_valid
+            else "account-acknowledged"
+            if managed_account and host_entry is not None
+            else "account-unverified"
+            if managed_account
             else "configured"
             if host_entry is not None
             else "not-configured"

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -4421,6 +4421,8 @@ def doctor(
         onboarding_status = (
             "unknown"
             if not local_hosts_valid
+            else "unknown"
+            if manifest is None
             else "account-acknowledged"
             if managed_account and host_entry is not None
             else "account-unverified"

--- a/contextos/runtime_schema.py
+++ b/contextos/runtime_schema.py
@@ -26,6 +26,13 @@ CAPABILITY_KEYS = {
     "execution_authorization",
 }
 SUPPORT_TIERS = {"first-class", "experimental", "compatibility", "deprecated"}
+INSTALL_MODES = {
+    "managed-account",
+    "native-project-discovery",
+    "repository-native",
+    "skill-copy-or-external-directory",
+    "skill-copy-to-private-workspace",
+}
 SURFACE_KINDS = {"cli", "ide", "cloud", "review", "gateway", "messaging", "environment"}
 HOOK_OUTPUT_MODES = {"system-message", "allow-message"}
 PROBE_PURPOSES = {"availability", "version", "native-doctor"}
@@ -166,7 +173,7 @@ def validate_runtime_manifest(
             _fail(f"components[{index}]", f"invalid component id {component!r}")
 
     install = _exact_keys(document.get("install"), {"mode", "next_steps"}, "install")
-    _string(install.get("mode"), "install.mode")
+    _enum(install.get("mode"), INSTALL_MODES, "install.mode")
     _unique_strings(install.get("next_steps"), "install.next_steps", minimum=1)
     _repo_path(
         root, document.get("onboarding_doc"), "onboarding_doc", must_exist=check_paths
@@ -409,7 +416,7 @@ def runtime_schema_document() -> dict[str, Any]:
                 "items": {"type": "string", "pattern": COMPONENT_ID_RE.pattern}},
             "install": {"type": "object", "additionalProperties": False,
                 "required": ["mode", "next_steps"],
-                "properties": {"mode": text, "next_steps": {"type": "array", "minItems": 1,
+                "properties": {"mode": {"enum": sorted(INSTALL_MODES)}, "next_steps": {"type": "array", "minItems": 1,
                     "uniqueItems": True, "items": text}}},
             "onboarding_doc": text,
             "surfaces": {"type": "object", "minProperties": 1,

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -35,7 +35,7 @@ The mutation protocol is always:
 | Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | Execution-directory `AGENTS.md` | Root `AGENTS.md` | Root `AGENTS.md` |
 | Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills | Copied into private workspace `.agents/skills/` | `.agents/skills/` | `.agents/skills/` |
 | Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter | Not claimed | Not claimed | Not claimed |
-| Authorization | Host settings | Host settings | Outside contract | Separate execution approvals | Host permissions | Account-managed; outside adapter |
+| Authorization | Host settings | Host settings | Outside contract | Separate execution approvals | IDE/CLI permissions; CLI `--force` | Account-managed; outside adapter |
 | Lifecycle enforcement | Kernel | Kernel | Kernel | Kernel | Kernel | Kernel |
 | Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` | Private OpenClaw workspace | Outside contract | Knowledge is not synchronized |
 

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -6,16 +6,18 @@ dates, append behavior, optimistic hashes, locking, and receipts.
 
 ## Shared lifecycle
 
-| Job | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) | Deterministic operation |
+| Job | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE/CLI (experimental) | Devin session (experimental) | Deterministic operation |
 |---|---|---|---|---|---|---|---|
-| Initialize context | `/setup` | `$setup` | `/setup` | `/skill setup` | `/context-setup` | `/context-setup` | `contextos propose setup` then `apply` |
-| Start a session | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `/context-start` | read-only `contextos start` |
-| Checkpoint | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `/context-update` | `contextos propose update` then `apply` |
-| Close a session | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `/context-end` | `contextos propose end` then `apply` |
+| Initialize context | `/setup` | `$setup` | `/setup` | `/skill setup` | `/context-setup` | `@skills:context-setup` | `contextos propose setup` then `apply` |
+| Start a session | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `@skills:context-start` | read-only `contextos start` |
+| Checkpoint | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `@skills:context-update` | `contextos propose update` then `apply` |
+| Close a session | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `@skills:context-end` | `contextos propose end` then `apply` |
 
 The portable cores are `.agents/skills/context-setup`, `context-start`,
 `context-update`, and `context-end`. Short skill directories are thin aliases;
 Claude files are host adapters. All lifecycle names require explicit invocation.
+Devin's portable skill frontmatter does not enforce user-only invocation, so
+that host remains experimental and the explicit-invocation claim is advisory.
 
 The mutation protocol is always:
 

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -30,14 +30,14 @@ The mutation protocol is always:
 
 ## Runtime boundary
 
-| Capability | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) |
+| Capability | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE/CLI (experimental) | Devin session (experimental) |
 |---|---|---|---|---|---|---|
 | Project instructions | `CLAUDE.md` | `AGENTS.md` | `AGENTS.md` | Execution-directory `AGENTS.md` | Root `AGENTS.md` | Root `AGENTS.md` |
 | Portable skill source | Thin slash adapters | `.agents/skills/` | External directory or copied skills | Copied into private workspace `.agents/skills/` | `.agents/skills/` | `.agents/skills/` |
 | Project hooks | `.claude/settings.json` | `.codex/hooks.json` after trust | Optional shell/plugin adapter | Not claimed | Not claimed | Not claimed |
-| Authorization | Host settings | Host settings | Outside contract | Separate execution approvals | IDE Run Modes and permissions | CLI permissions and `--force` |
+| Authorization | Host settings | Host settings | Outside contract | Separate execution approvals | Host permissions | Account-managed; outside adapter |
 | Lifecycle enforcement | Kernel | Kernel | Kernel | Kernel | Kernel | Kernel |
-| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` | Private OpenClaw workspace | Outside contract | Outside contract |
+| Native memory | Claude auto-memory | Not part of the shared contract | `MEMORY.md` and `USER.md` | Private OpenClaw workspace | Outside contract | Knowledge is not synchronized |
 
 Runtime manifests in `runtimes/` are machine-readable claims. Hooks are defense
 in depth: the kernel repeats mutation invariants during every proposal and apply.

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -57,6 +57,7 @@ other repository-root paths extensible or writable.
 | `hermes-adapter` | `core`, `portable-skills`, `agents-instructions` | Hermes guidance, optional hooks, and descriptor |
 | `openclaw-adapter` | `core`, `portable-skills`, `agents-instructions` | Experimental OpenClaw guidance, descriptor, and conformance |
 | `cursor-adapter` | `core`, `portable-skills`, `agents-instructions` | Experimental Cursor IDE/CLI guidance, descriptor, and conformance |
+| `devin-adapter` | `core`, `portable-skills`, `agents-instructions` | Experimental Devin cloud-session/Review guidance and managed-account conformance |
 | `example-project` | `core` | Optional removable example content |
 
 Shared dependencies have one owner. Selecting both Claude and Codex therefore

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,9 +7,9 @@ shared state.
 
 ## Before you clone
 
-You need Git, Bash, Python 3.10 or newer, and at least one supported local
-agent: Claude Code, Codex, Hermes, OpenClaw, or Cursor. claude.ai can help produce files but
-cannot maintain a local checkout directly.
+You need Git, Bash, and Python 3.10 or newer. Local hosts include Claude Code,
+Codex, Hermes, OpenClaw, and Cursor; Devin uses the separately verified managed
+cloud path. claude.ai can help produce files but cannot maintain a local checkout.
 
 Python may be installed as either `python3` or `python`; the repository resolves
 whichever works. To pin a specific interpreter — a virtualenv, or one of several
@@ -154,11 +154,11 @@ Commit and push only after the diff matches what you intend to preserve.
 
 ## Run the daily loop
 
-| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE (experimental) | Cursor CLI (experimental) |
+| Moment | Claude Code | Codex | Hermes | OpenClaw (experimental) | Cursor IDE/CLI (experimental) | Devin session (experimental) |
 |---|---|---|---|---|---|---|
-| Start work | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `/context-start` |
-| Save progress without closing | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `/context-update` |
-| End with a reviewed handoff | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `/context-end` |
+| Start work | `/start` | `$start` | `/start` | `/skill start` | `/context-start` | `@skills:context-start` |
+| Save progress without closing | `/update` | `$update` | `/update` | `/skill update` | `/context-update` | `@skills:context-update` |
+| End with a reviewed handoff | `/end` | `$end` | `/end` | `/skill end` | `/context-end` | `@skills:context-end` |
 
 The lifecycle kernel writes shared continuity to `state/` and `sessions/` only
 after exact-proposal approval, then emits a local receipt. Each host retains

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,8 @@ bash scripts/setup.sh --agents hermes
 bash scripts/setup.sh --agents openclaw
 # or
 bash scripts/setup.sh --agents cursor
+# or
+bash scripts/setup.sh --agents devin
 # or, for the provider-neutral core only
 bash scripts/setup.sh --agents none
 ```
@@ -57,7 +59,9 @@ bash scripts/setup.sh --agents none
 Setup shows the exact tracked workspace diff and proposal digest, then defaults
 the apply decision to no. An approved selection is additive: rerunning with a
 subset or `none` preserves the existing set, while a new runtime expands it.
-Selected runtimes are also registered in the gitignored local host map. Omit
+Selected local runtimes are also registered in the gitignored local host map.
+Managed-account runtimes such as Devin record tracked intent without claiming
+the remote account is configured. Omit
 the option, or use `--agents auto`, to auto-detect local launch instructions
 without changing tracked intent. `--agent` remains a deprecated singleton
 alias. See [workspace configuration](workspace-configuration.md) for the full
@@ -105,6 +109,11 @@ waits before applying the exact reviewed diff.
 Cursor has separate IDE and Agent CLI permission surfaces. Follow its
 [experimental adapter guide](../adapters/cursor/README.md); setup registers the
 runtime but launches neither surface and changes no Cursor authorization setting.
+
+For Devin, follow the [experimental managed-account guide](../adapters/devin/README.md),
+verify repository access and the active environment in Devin, then start a fresh
+cloud session and invoke `@skills:context-setup`. Local setup does not authenticate,
+launch, or verify Devin, and Devin Review is not a lifecycle surface.
 
 ### Bring existing context
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,8 @@ shared state.
 ## Before you clone
 
 You need Git, Bash, and Python 3.10 or newer. Local hosts include Claude Code,
-Codex, Hermes, OpenClaw, and Cursor; Devin uses the separately verified managed
-cloud path. claude.ai can help produce files but cannot maintain a local checkout.
+Codex, Hermes, OpenClaw, and Cursor; verify Devin's managed cloud path separately
+in its account UI. claude.ai cannot maintain a local checkout directly.
 
 Python may be installed as either `python3` or `python`; the repository resolves
 whichever works. To pin a specific interpreter — a virtualenv, or one of several

--- a/docs/memory-across-agents.md
+++ b/docs/memory-across-agents.md
@@ -57,6 +57,14 @@ Use `state/` and `sessions/` for continuity that must travel between runtimes.
 Promote any durable Cursor-derived fact only through a reviewed repository
 proposal. See `adapters/cursor/README.md` for the separate IDE and CLI boundary.
 
+## Devin
+
+Devin Knowledge, Blueprint knowledge, snapshots, and session history are
+account-managed state, not repository memory. Context OS neither materializes
+nor synchronizes them. Durable cross-runtime facts still belong in `state/`,
+`sessions/`, or another canonical repository file through a reviewed proposal.
+See `adapters/devin/README.md` for the separate session and Review boundary.
+
 ## Proposal/apply boundary
 
 All registered runtimes use the same repository transaction:

--- a/runtimes/devin.json
+++ b/runtimes/devin.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": 2,
+  "runtime": "devin",
+  "display_name": "Devin",
+  "support_tier": "experimental",
+  "support_summary": "Experimental cloud-session lifecycle through repository AGENTS.md and Agent Skills, with Devin Review and all account-managed state kept separate",
+  "components": ["core", "portable-skills", "agents-instructions", "devin-adapter"],
+  "install": {
+    "mode": "managed-account",
+    "next_steps": [
+      "Connect and authorize the repository in Devin; local Context OS registration does not prove account access.",
+      "Verify the active Blueprint build and snapshot in Devin Settings, then start a fresh cloud session for this repository.",
+      "Invoke @skills:context-setup, @skills:context-start, @skills:context-update, or @skills:context-end explicitly and review every proposal before apply."
+    ]
+  },
+  "onboarding_doc": "adapters/devin/README.md",
+  "surfaces": {
+    "session": {
+      "kind": "cloud",
+      "support_tier": "experimental",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+      ],
+      "skill_sources": [
+        {"scope": "repository", "role": "skills", "path": ".agents/skills", "precedence": 100}
+      ],
+      "invocation": {
+        "setup": "@skills:context-setup",
+        "start": "@skills:context-start",
+        "update": "@skills:context-update",
+        "end": "@skills:context-end"
+      },
+      "capabilities": {
+        "agent_skills": "native",
+        "explicit_invocation": "advisory",
+        "project_hooks": "unsupported",
+        "blocking_pre_tool_hook": "unsupported",
+        "mcp": "unsupported",
+        "native_memory": "unsupported",
+        "proposal_apply": "adapter",
+        "skill_allowlists": "unsupported",
+        "execution_authorization": "unsupported"
+      },
+      "hook_output": null,
+      "binary_probes": [],
+      "conformance_tests": [
+        "tests/test_devin_conformance.py",
+        "tests/test_contextos_kernel.py"
+      ],
+      "evidence": [
+        "devin-agents",
+        "devin-skills",
+        "devin-kernel",
+        "devin-conformance"
+      ]
+    },
+    "review": {
+      "kind": "review",
+      "support_tier": "compatibility",
+      "instruction_sources": [
+        {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
+      ],
+      "skill_sources": [],
+      "invocation": {"setup": null, "start": null, "update": null, "end": null},
+      "capabilities": {
+        "agent_skills": "unsupported",
+        "explicit_invocation": "unsupported",
+        "project_hooks": "unsupported",
+        "blocking_pre_tool_hook": "unsupported",
+        "mcp": "unsupported",
+        "native_memory": "unsupported",
+        "proposal_apply": "unsupported",
+        "skill_allowlists": "unsupported",
+        "execution_authorization": "unsupported"
+      },
+      "hook_output": null,
+      "binary_probes": [],
+      "conformance_tests": ["tests/test_devin_conformance.py"],
+      "evidence": ["devin-review", "devin-conformance"]
+    }
+  },
+  "evidence": {
+    "checked_on": "2026-08-27",
+    "tested_versions": [],
+    "sources": [
+      {
+        "id": "devin-agents",
+        "type": "official",
+        "location": "https://docs.devin.ai/onboard-devin/agents-md",
+        "claims": ["instruction_sources"]
+      },
+      {
+        "id": "devin-skills",
+        "type": "official",
+        "location": "https://docs.devin.ai/product-guides/skills",
+        "claims": ["agent_skills", "skill_sources", "invocation"]
+      },
+      {
+        "id": "devin-review",
+        "type": "official",
+        "location": "https://docs.devin.ai/work-with-devin/devin-review",
+        "claims": ["instruction_sources", "support"]
+      },
+      {
+        "id": "devin-kernel",
+        "type": "conformance",
+        "location": "tests/test_contextos_kernel.py",
+        "claims": ["proposal_apply"]
+      },
+      {
+        "id": "devin-conformance",
+        "type": "conformance",
+        "location": "tests/test_devin_conformance.py",
+        "claims": ["explicit_invocation", "support"]
+      }
+    ]
+  }
+}

--- a/runtimes/schema.json
+++ b/runtimes/schema.json
@@ -60,9 +60,13 @@
       ],
       "properties": {
         "mode": {
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^(?!\\s)(?:[^\\x00-\\x1f]*\\S)$"
+          "enum": [
+            "managed-account",
+            "native-project-discovery",
+            "repository-native",
+            "skill-copy-or-external-directory",
+            "skill-copy-to-private-workspace"
+          ]
         },
         "next_steps": {
           "type": "array",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -458,6 +458,7 @@ PY
   if [ "${#SETUP_MANAGED_RUNTIMES[@]}" -gt 0 ]; then
     setup_managed_csv=$(IFS=,; echo "${SETUP_MANAGED_RUNTIMES[*]}")
     echo "  Tracked managed-account intent; remote onboarding remains unverified: $setup_managed_csv"
+    echo "  Complete each managed host's account checks in its adapter guide."
   fi
 elif [ -n "$REQUESTED_REGISTERED_AGENTS" ]; then
   LAUNCH_SELECTION="none"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
-SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex,cursor,openclaw|auto|none] [--agent auto|RUNTIME|none]"
+SETUP_USAGE="Usage: bash scripts/setup.sh [--agents claude,codex,cursor,devin,openclaw|auto|none] [--agent auto|RUNTIME|none]"
 AGENT_SELECTION_KIND=""
 AGENT_SELECTION_RAW=""
 while [ "$#" -gt 0 ]; do
@@ -432,10 +432,31 @@ fi
 
 if [ "$SETUP_SELECTION_ACTIVATED" = true ] && [ -n "$REQUESTED_REGISTERED_AGENTS" ]; then
   IFS=',' read -r -a SETUP_RUNTIME_IDS <<<"$REQUESTED_REGISTERED_AGENTS"
+  SETUP_REGISTERED_RUNTIMES=()
+  SETUP_MANAGED_RUNTIMES=()
   for setup_runtime in "${SETUP_RUNTIME_IDS[@]}"; do
-    "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime "$setup_runtime" >/dev/null
+    setup_install_mode=$("$CONTEXTOS_PYTHON_CMD" - "$setup_runtime" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads((Path("runtimes") / f"{sys.argv[1]}.json").read_text(encoding="utf-8"))
+print(manifest["install"]["mode"])
+PY
+)
+    if [ "$setup_install_mode" = "managed-account" ]; then
+      SETUP_MANAGED_RUNTIMES+=("$setup_runtime")
+    else
+      "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime "$setup_runtime" >/dev/null
+      SETUP_REGISTERED_RUNTIMES+=("$setup_runtime")
+    fi
   done
-  echo "  Registered selected runtimes on this host: $REQUESTED_REGISTERED_AGENTS"
+  if [ "${#SETUP_REGISTERED_RUNTIMES[@]}" -gt 0 ]; then
+    echo "  Registered selected runtimes on this host: ${SETUP_REGISTERED_RUNTIMES[*]}"
+  fi
+  if [ "${#SETUP_MANAGED_RUNTIMES[@]}" -gt 0 ]; then
+    echo "  Tracked managed-account intent; remote onboarding remains unverified: ${SETUP_MANAGED_RUNTIMES[*]}"
+  fi
 elif [ -n "$REQUESTED_REGISTERED_AGENTS" ]; then
   LAUNCH_SELECTION="none"
 fi
@@ -576,6 +597,15 @@ case "$SELECTED_AGENT" in
     echo "  verify both experimental surfaces and their authorization settings."
     echo ""
     ;;
+  devin)
+    echo "  1. Connect and authorize this repository in the intended Devin organization."
+    echo "  2. Verify its Blueprint build and active snapshot in Devin Settings."
+    echo "  3. Start a fresh cloud session, then invoke @skills:context-setup."
+    echo "     See adapters/devin/README.md for the repository/account boundary."
+    echo "     Setup records tracked intent only; it does not authenticate, launch,"
+    echo "     configure, or verify any Devin account state."
+    echo ""
+    ;;
   openclaw)
     if [ -z "$REQUESTED_REGISTERED_AGENTS" ]; then
       "$CONTEXTOS_PYTHON_CMD" -m contextos install --runtime openclaw >/dev/null
@@ -596,6 +626,7 @@ case "$SELECTED_AGENT" in
     printf '  Codex:       cd %q && codex, then run $setup\n' "$REPO_ROOT"
     printf '  Hermes:      cd %q && hermes (reads AGENTS.md; see AGENTS.md Hermes section)\n' "$REPO_ROOT"
     printf '  Cursor:      see adapters/cursor/README.md (separate IDE and Agent CLI paths)\n'
+    echo "  Devin:       see adapters/devin/README.md (managed cloud account + Review)"
     echo "  OpenClaw:    see adapters/openclaw/README.md (private workspace + copied skills)"
     echo "  claude.ai:   open SETUP-PROMPTS.md and paste the prompts there"
     echo "  Guide:       docs/getting-started.md"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -452,10 +452,12 @@ PY
     fi
   done
   if [ "${#SETUP_REGISTERED_RUNTIMES[@]}" -gt 0 ]; then
-    echo "  Registered selected runtimes on this host: ${SETUP_REGISTERED_RUNTIMES[*]}"
+    setup_registered_csv=$(IFS=,; echo "${SETUP_REGISTERED_RUNTIMES[*]}")
+    echo "  Registered selected runtimes on this host: $setup_registered_csv"
   fi
   if [ "${#SETUP_MANAGED_RUNTIMES[@]}" -gt 0 ]; then
-    echo "  Tracked managed-account intent; remote onboarding remains unverified: ${SETUP_MANAGED_RUNTIMES[*]}"
+    setup_managed_csv=$(IFS=,; echo "${SETUP_MANAGED_RUNTIMES[*]}")
+    echo "  Tracked managed-account intent; remote onboarding remains unverified: $setup_managed_csv"
   fi
 elif [ -n "$REQUESTED_REGISTERED_AGENTS" ]; then
   LAUNCH_SELECTION="none"

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -287,11 +287,14 @@ test -n "$cursor_setup_case" \
 if grep -Eq '(^|[[:space:]])exec[[:space:]]+(cursor|agent)([[:space:]]|$)' <<<"$cursor_setup_case"; then
   fail "setup launches an unverified Cursor surface"
 fi
-grep -Fq 'Setup records tracked intent only' scripts/setup.sh \
-  || fail "Devin setup omits the managed-account boundary"
 devin_setup_case=$(sed -n '/^  devin)/,/^    ;;/p' scripts/setup.sh)
 test -n "$devin_setup_case" \
   || fail "Devin setup case could not be inspected for managed-account behavior"
+grep -Fq 'Setup records tracked intent only' <<<"$devin_setup_case" \
+  || fail "Devin setup omits the managed-account boundary"
+if grep -Fq 'contextos install' <<<"$devin_setup_case"; then
+  fail "Devin setup case locally installs a managed-account runtime"
+fi
 if grep -Eq '(^|[[:space:]])exec[[:space:]]+devin([[:space:]]|$)' <<<"$devin_setup_case"; then
   fail "setup launches an unverified Devin account surface"
 fi

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -269,7 +269,7 @@ if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$duplica
 fi
 
 help_output=$(bash scripts/setup.sh --help)
-grep -Fq -- '--agents claude,codex,cursor,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
+grep -Fq -- '--agents claude,codex,cursor,devin,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
 grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"
 grep -Fq 'Setup does not launch OpenClaw' scripts/setup.sh \
   || fail "OpenClaw setup omits the private-workspace launch boundary"
@@ -286,6 +286,14 @@ test -n "$cursor_setup_case" \
   || fail "Cursor setup case could not be inspected for launch behavior"
 if grep -Eq '(^|[[:space:]])exec[[:space:]]+(cursor|agent)([[:space:]]|$)' <<<"$cursor_setup_case"; then
   fail "setup launches an unverified Cursor surface"
+fi
+grep -Fq 'Setup records tracked intent only' scripts/setup.sh \
+  || fail "Devin setup omits the managed-account boundary"
+devin_setup_case=$(sed -n '/^  devin)/,/^    ;;/p' scripts/setup.sh)
+test -n "$devin_setup_case" \
+  || fail "Devin setup case could not be inspected for managed-account behavior"
+if grep -Eq '(^|[[:space:]])exec[[:space:]]+devin([[:space:]]|$)' <<<"$devin_setup_case"; then
+  fail "setup launches an unverified Devin account surface"
 fi
 if bash scripts/setup.sh --agent invalid >/dev/null 2>&1; then
   fail "setup accepted an invalid agent"
@@ -376,6 +384,26 @@ unexpected_setup_paths=$(git -C "$multi_agent_fixture" status --short | \
   grep -Ev '^( D workspace\.yaml|\?\? contextos\.workspace\.json)$' || true)
 test -z "$unexpected_setup_paths" \
   || fail "multi-agent setup changed unselected adapter or unrelated paths: $unexpected_setup_paths"
+
+devin_fixture="$portability_tmp/devin-managed-account-selection"
+make_setup_fixture "$devin_fixture"
+devin_output=$(printf 'y\n\nn\nn\nn\ny\nn\n' | (
+  cd "$devin_fixture" &&
+  PATH="$setup_test_path" bash scripts/setup.sh --agents devin
+) 2>&1)
+"$CONTEXTOS_PYTHON_CMD" - "$devin_fixture/contextos.workspace.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert config["agents"] == ["devin"], config["agents"]
+hosts_path = Path(sys.argv[1]).parent / ".context-os" / "hosts.json"
+if hosts_path.exists():
+    assert "devin" not in json.loads(hosts_path.read_text(encoding="utf-8"))["hosts"]
+PY
+grep -Fq 'remote onboarding remains unverified: devin' <<<"$devin_output" \
+  || fail "managed-account setup implied that Devin was locally configured"
 
 # Subset and none reruns are no-ops; a disjoint selection expands the set.
 subset_output=$(printf 'y\n\nn\nn\nn\n' | (

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -70,7 +70,10 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             "runtimes/schema.json",
             "runtimes/claude.json",
             "runtimes/codex.json",
+            "runtimes/cursor.json",
+            "runtimes/devin.json",
             "runtimes/hermes.json",
+            "runtimes/openclaw.json",
             "workspace/schema.json",
         ):
             target = self.root / relative

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1218,6 +1218,14 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
             ordinary["runtimes"]["devin"]["local_onboarding"]["status"],
         )
 
+        manifest["unknown"] = True
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        invalid = doctor(self.root)
+        self.assertEqual(
+            "unknown",
+            invalid["runtimes"]["devin"]["local_onboarding"]["status"],
+        )
+
     def test_legacy_runtime_migrates_only_to_atomic_local_host_state(self) -> None:
         local = self.root / ".context-os"
         local.mkdir()
@@ -1434,7 +1442,7 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         self.assertNotIn("manifest:codex", names)
         self.assertTrue(report["runtimes"]["codex"]["configuration"]["inert"])
         self.assertEqual(
-            "configured", report["runtimes"]["codex"]["local_onboarding"]["status"]
+            "unknown", report["runtimes"]["codex"]["local_onboarding"]["status"]
         )
 
     def test_profile_materialization_blocks_only_configured_adapters(self) -> None:

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -333,7 +333,7 @@ class KernelTest(unittest.TestCase):
             (self.root / "state" / name).write_text(
                 f"# {name}\n\n**Last Updated:** 2026-08-20\n", encoding="utf-8"
             )
-        for runtime in ("claude", "codex", "cursor", "hermes", "openclaw"):
+        for runtime in ("claude", "codex", "cursor", "devin", "hermes", "openclaw"):
             source = ROOT / "runtimes" / f"{runtime}.json"
             (self.root / "runtimes" / f"{runtime}.json").write_bytes(source.read_bytes())
         for directory in (
@@ -1182,6 +1182,42 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         drift_check = next(item for item in drift["checks"] if item["name"] == "runtime-manifest-drift")
         self.assertEqual("warn", drift_check["status"])
 
+    def test_managed_account_registration_never_claims_remote_readiness(self) -> None:
+        self._materialize_components("devin-adapter")
+        self._configure_profile("devin")
+        unverified = doctor(self.root)
+        self.assertEqual(
+            "account-unverified",
+            unverified["runtimes"]["devin"]["local_onboarding"]["status"],
+        )
+        onboarding = next(
+            item for item in unverified["checks"]
+            if item["name"] == "runtime-onboarding:devin"
+        )
+        self.assertEqual("warn", onboarding["status"])
+
+        install_runtime(self.root, "devin")
+        acknowledged = doctor(self.root)
+        self.assertEqual(
+            "account-acknowledged",
+            acknowledged["runtimes"]["devin"]["local_onboarding"]["status"],
+        )
+        onboarding = next(
+            item for item in acknowledged["checks"]
+            if item["name"] == "runtime-onboarding:devin"
+        )
+        self.assertEqual("warn", onboarding["status"])
+
+        manifest_path = self.root / "runtimes/devin.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["install"]["mode"] = "native-project-discovery"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        ordinary = doctor(self.root)
+        self.assertEqual(
+            "configured",
+            ordinary["runtimes"]["devin"]["local_onboarding"]["status"],
+        )
+
     def test_legacy_runtime_migrates_only_to_atomic_local_host_state(self) -> None:
         local = self.root / ".context-os"
         local.mkdir()
@@ -1552,7 +1588,7 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
 
         report = doctor(self.root, all_runtimes=True)
         self.assertEqual(
-            {"claude", "codex", "cursor", "hermes", "openclaw"},
+            {"claude", "codex", "cursor", "devin", "hermes", "openclaw"},
             set(report["runtimes"]),
         )
 

--- a/tests/test_devin_conformance.py
+++ b/tests/test_devin_conformance.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DESCRIPTOR = json.loads((ROOT / "runtimes/devin.json").read_text(encoding="utf-8"))
+GUIDE_PATH = ROOT / "adapters/devin/README.md"
+
+
+class DevinDescriptorTest(unittest.TestCase):
+    def test_session_and_review_remain_separate_and_unversioned(self) -> None:
+        self.assertEqual("experimental", DESCRIPTOR["support_tier"])
+        self.assertEqual({"session", "review"}, set(DESCRIPTOR["surfaces"]))
+        session = DESCRIPTOR["surfaces"]["session"]
+        review = DESCRIPTOR["surfaces"]["review"]
+        self.assertEqual("cloud", session["kind"])
+        self.assertEqual("review", review["kind"])
+        self.assertEqual("experimental", session["support_tier"])
+        self.assertEqual("compatibility", review["support_tier"])
+        self.assertEqual([], DESCRIPTOR["evidence"]["tested_versions"])
+        self.assertEqual([], session["binary_probes"])
+        self.assertEqual([], review["binary_probes"])
+
+    def test_session_uses_only_repository_native_contract_files(self) -> None:
+        session = DESCRIPTOR["surfaces"]["session"]
+        self.assertEqual(
+            ["AGENTS.md"],
+            [source["path"] for source in session["instruction_sources"]],
+        )
+        self.assertEqual(
+            [".agents/skills"],
+            [source["path"] for source in session["skill_sources"]],
+        )
+        self.assertEqual(
+            {name: f"@skills:context-{name}" for name in ("setup", "start", "update", "end")},
+            session["invocation"],
+        )
+        self.assertEqual("native", session["capabilities"]["agent_skills"])
+        self.assertEqual("advisory", session["capabilities"]["explicit_invocation"])
+
+    def test_review_does_not_inherit_session_lifecycle_or_skills(self) -> None:
+        review = DESCRIPTOR["surfaces"]["review"]
+        self.assertEqual([], review["skill_sources"])
+        self.assertTrue(all(value is None for value in review["invocation"].values()))
+        self.assertEqual(
+            {"AGENTS.md"},
+            {source["path"] for source in review["instruction_sources"]},
+        )
+        self.assertTrue(
+            all(value == "unsupported" for value in review["capabilities"].values())
+        )
+        self.assertNotIn("devin-skills", review["evidence"])
+
+    def test_no_managed_account_state_is_encoded_as_a_repo_artifact(self) -> None:
+        serialized = json.dumps(DESCRIPTOR).lower()
+        for forbidden in (".devin/", "blueprint.yaml", "memory.md"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, serialized)
+        paths = {
+            source["path"]
+            for surface in DESCRIPTOR["surfaces"].values()
+            for field in ("instruction_sources", "skill_sources")
+            for source in surface[field]
+        }
+        self.assertEqual({"AGENTS.md", ".agents/skills"}, paths)
+
+    def test_unsupported_host_features_are_not_claimed(self) -> None:
+        for surface_name, surface in DESCRIPTOR["surfaces"].items():
+            with self.subTest(surface=surface_name):
+                self.assertEqual("unsupported", surface["capabilities"]["project_hooks"])
+                self.assertEqual(
+                    "unsupported", surface["capabilities"]["blocking_pre_tool_hook"]
+                )
+                self.assertEqual("unsupported", surface["capabilities"]["native_memory"])
+                self.assertEqual("unsupported", surface["capabilities"]["skill_allowlists"])
+                self.assertIsNone(surface["hook_output"])
+
+    def test_guide_preserves_repo_account_and_data_transfer_boundaries(self) -> None:
+        guide = " ".join(GUIDE_PATH.read_text(encoding="utf-8").split())
+        for required in (
+            "Git-based blueprints are not currently supported",
+            "Context OS ships no `.devin/` file or blueprint YAML",
+            "That means only \"selected for this workspace.\"",
+            "does not certify the Devin account",
+            "Secrets are injected by Devin rather than committed here",
+            "can persist it in the snapshot",
+            "Devin Review is not a session",
+            "sends the diff and file contents to Devin servers",
+            "local git access for the Review CLI does not prove Devin account access",
+            "documentation or local registration alone must never turn them green",
+            "Review needs its own fixtures",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, guide)
+
+    def test_adapter_does_not_ship_fake_devin_configuration(self) -> None:
+        if os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace":
+            self.skipTest("workspace-owned future host configuration is outside maintainer inventory")
+        for path in (".devin", "devin.yaml", "devin.yml", "blueprint.yaml"):
+            with self.subTest(path=path):
+                self.assertFalse((ROOT / path).exists())
+
+
+@unittest.skipUnless(
+    os.environ.get("CONTEXTOS_DEVIN_LIVE_ACCOUNT") == "1",
+    "set CONTEXTOS_DEVIN_LIVE_ACCOUNT=1 only in a dedicated synthetic account fixture",
+)
+class DevinLiveAccountGate(unittest.TestCase):
+    def test_live_account_fixture_is_not_yet_implemented(self) -> None:
+        self.fail(
+            "live Devin conformance is intentionally unimplemented; do not mark the account verified"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_devin_conformance.py
+++ b/tests/test_devin_conformance.py
@@ -69,15 +69,23 @@ class DevinDescriptorTest(unittest.TestCase):
         self.assertEqual({"AGENTS.md", ".agents/skills"}, paths)
 
     def test_unsupported_host_features_are_not_claimed(self) -> None:
-        for surface_name, surface in DESCRIPTOR["surfaces"].items():
-            with self.subTest(surface=surface_name):
-                self.assertEqual("unsupported", surface["capabilities"]["project_hooks"])
-                self.assertEqual(
-                    "unsupported", surface["capabilities"]["blocking_pre_tool_hook"]
-                )
-                self.assertEqual("unsupported", surface["capabilities"]["native_memory"])
-                self.assertEqual("unsupported", surface["capabilities"]["skill_allowlists"])
-                self.assertIsNone(surface["hook_output"])
+        session = DESCRIPTOR["surfaces"]["session"]
+        self.assertEqual(
+            {
+                "agent_skills": "native",
+                "explicit_invocation": "advisory",
+                "project_hooks": "unsupported",
+                "blocking_pre_tool_hook": "unsupported",
+                "mcp": "unsupported",
+                "native_memory": "unsupported",
+                "proposal_apply": "adapter",
+                "skill_allowlists": "unsupported",
+                "execution_authorization": "unsupported",
+            },
+            session["capabilities"],
+        )
+        for surface in DESCRIPTOR["surfaces"].values():
+            self.assertIsNone(surface["hook_output"])
 
     def test_guide_preserves_repo_account_and_data_transfer_boundaries(self) -> None:
         guide = " ".join(GUIDE_PATH.read_text(encoding="utf-8").split())
@@ -93,13 +101,13 @@ class DevinDescriptorTest(unittest.TestCase):
             "local git access for the Review CLI does not prove Devin account access",
             "documentation or local registration alone must never turn them green",
             "Review needs its own fixtures",
+            "does not authenticate who supplied the confirmation",
+            "do not run lifecycle skills in unattended sessions",
         ):
             with self.subTest(required=required):
                 self.assertIn(required, guide)
 
     def test_adapter_does_not_ship_fake_devin_configuration(self) -> None:
-        if os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace":
-            self.skipTest("workspace-owned future host configuration is outside maintainer inventory")
         for path in (".devin", "devin.yaml", "devin.yml", "blueprint.yaml"):
             with self.subTest(path=path):
                 self.assertFalse((ROOT / path).exists())

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -72,6 +72,12 @@ class RuntimeManifestTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeManifestError, "capabilities.mcp"):
             validate_runtime_manifest(manifest, runtime_id="codex", root=ROOT)
 
+    def test_mutation_sentinel_rejects_unknown_install_mode(self) -> None:
+        manifest = load("devin")
+        manifest["install"]["mode"] = "managed-acount"
+        with self.assertRaisesRegex(RuntimeManifestError, "install.mode"):
+            validate_runtime_manifest(manifest, runtime_id="devin", root=ROOT)
+
     def test_probe_contract_rejects_executable_arguments(self) -> None:
         manifest = load("codex")
         manifest["surfaces"]["cli"]["binary_probes"][0]["args"] = ["-c", "do_work()"]

--- a/tests/test_runtime_manifests.py
+++ b/tests/test_runtime_manifests.py
@@ -29,9 +29,9 @@ def load(runtime: str) -> dict:
 
 class RuntimeManifestTest(unittest.TestCase):
     def test_registry_discovers_and_validates_every_descriptor(self) -> None:
-        self.assertEqual(["claude", "codex", "cursor", "hermes", "openclaw"], runtime_ids(ROOT))
+        self.assertEqual(["claude", "codex", "cursor", "devin", "hermes", "openclaw"], runtime_ids(ROOT))
         registry = runtime_registry(ROOT)
-        self.assertEqual({"claude", "codex", "cursor", "hermes", "openclaw"}, set(registry))
+        self.assertEqual({"claude", "codex", "cursor", "devin", "hermes", "openclaw"}, set(registry))
         self.assertNotIn("generic", registry)
         for runtime, manifest in registry.items():
             with self.subTest(runtime=runtime):
@@ -56,6 +56,11 @@ class RuntimeManifestTest(unittest.TestCase):
         }
         self.assertEqual(expected, cursor["surfaces"]["ide"]["invocation"])
         self.assertEqual(expected, cursor["surfaces"]["cli"]["invocation"])
+        devin = load("devin")
+        self.assertEqual(
+            {name: f"@skills:context-{name}" for name in ("setup", "start", "update", "end")},
+            devin["surfaces"]["session"]["invocation"],
+        )
 
     def test_checked_in_schema_matches_authoritative_contract(self) -> None:
         actual = json.loads((ROOT / "runtimes/schema.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What's in this PR

Adds the first evidence-gated Devin slice for #71:

- separates managed cloud sessions from Devin Review;
- declares repository-native AGENTS.md and Agent Skills without claiming cross-surface parity;
- introduces a managed-account setup/doctor convention so tracked intent never reports the remote account as configured;
- keeps Blueprints, builds, snapshots, Knowledge, secrets, repository grants, roles, MCP, and UI state outside repository ownership;
- adds hostile mutation controls for the repository/account boundary and an opt-in live-account gate that cannot silently pass.

No Devin CLI, Review CLI execution, Blueprint file, account automation, secret handling, hook, or memory bridge is shipped. Current first-party docs explicitly say Git-based blueprints are not supported.

Part of #71

## Verification

- ash scripts/validate-all.sh
- 417 tests passed, 33 skipped
- portability and hook checks passed
- links and doc reachability passed
- component manifest passed: 11 components, 185 exact paths
- runtime registry passed: 6 descriptors
- hosted alidate, 	ests-windows, and 	ests-minimum-python passed at ca69aff098f9a38204816c9d53947d53cc198c84
- exact-SHA Opus and free-Hermes reviews passed after three capped repair cycles

## Checklist

### Skills & commands
- [x] No new skill or command was added
- [x] Portable workflows remain provider-neutral; Devin behavior stays in its adapter
- [x] Lifecycle mutation still routes through proposal/apply

### Repo hygiene
- [x] No sensitive data committed
- [x] CHANGELOG.md updated
- [x] CI passes
