### PR TITLE
feat: materialize verified component bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Digest-bound bundle composition and upgrade proposals that materialize binary
+  and text component files through the existing journal, receipt, recovery, and
+  rollback engine. Clean composition writes workspace configuration in the same
+  transaction; upgrades add, replace, or remove only ownership-authorized paths,
+  preserve seed content, and record ignored installed-bundle state.
 - Detached immutable bundle locks with Git-index-stable raw-byte identity,
   explicit offline digest verification, exact component compatibility, and a
   deterministic read-only structural planner that rejects stale, dirty,

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ state/                     Current focus, priorities, blockers, and decisions
 sessions/                  Reviewed session handoffs
 .agents/skills/            Provider-neutral workflow cores
 contextos/                 Deterministic lifecycle kernel
+                           and offline bundle materializer
 .claude/commands/          Claude Code slash-command adapters
 .claude/skills/            Claude Code-only skills
 .claude/hooks/             Claude Code-only safety and session hooks

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -100,6 +100,10 @@
                     "policy": "managed"
                 },
                 {
+                    "path": "contextos/materializer.py",
+                    "policy": "managed"
+                },
+                {
                     "path": "contextos/primitives.py",
                     "policy": "managed"
                 },
@@ -393,6 +397,10 @@
                 },
                 {
                     "path": "tests/test_bundle_lock.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_materializer.py",
                     "policy": "development"
                 },
                 {

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -37,6 +37,7 @@ from .primitives import (
 from .workspace_schema import (
     WORKSPACE_SCHEMA_VERSION,
     WorkspaceConfigError,
+    render_workspace_config,
     strict_json_loads,
     validate_workspace_config,
     validate_workspace_path,
@@ -850,6 +851,105 @@ def create_structural_plan(
             "template": {"source": candidate.name, "version": candidate.version},
         },
         "current_components": current_ids,
+        "desired_components": desired_ids,
+        "actions": actions,
+    }
+    return {
+        **unsigned,
+        "plan_digest": sha256_bytes(canonical_json(unsigned).encode("utf-8")),
+    }
+
+
+def create_initial_structural_plan(
+    *,
+    target_root: Path,
+    workspace_config: dict[str, Any],
+    candidate: VerifiedBundle,
+    desired_components: Sequence[str],
+) -> dict[str, Any]:
+    """Plan a first materialization without requiring tracked target state first."""
+    target_root = _source_root(target_root, "target_root")
+    try:
+        if os.path.samefile(target_root, candidate.root):
+            _fail("target_root", "must be separate from the candidate source root")
+    except OSError as exc:
+        raise BundleError(f"cannot compare source and target roots: {exc}") from exc
+    try:
+        config = validate_workspace_config(
+            workspace_config, known_runtime_ids=_runtime_ids(candidate)
+        )
+    except WorkspaceConfigError as exc:
+        raise BundleError(str(exc)) from exc
+    if config["template"] != {
+        "source": candidate.name,
+        "version": candidate.version,
+    }:
+        _fail("workspace.template", "does not match the candidate bundle identity")
+    desired_ids = _component_closure(candidate.manifest, desired_components)
+    required_desired_ids = _configured_components(candidate, config["agents"])
+    if not set(required_desired_ids).issubset(desired_ids):
+        missing = sorted(
+            set(required_desired_ids) - set(desired_ids), key=portable_path_identity
+        )
+        _fail(
+            "desired_components",
+            "omits components required by configured agents: " + ", ".join(missing),
+        )
+    desired = _owned_records(candidate, desired_ids)
+    actions: list[dict[str, Any]] = []
+    for relative in sorted(desired, key=portable_path_identity):
+        after = desired[relative]
+        target = _safe_path(
+            target_root, relative, f"target.{relative}", missing_ok=True
+        )
+        observed = _snapshot(
+            target,
+            f"target.{relative}",
+            executable_hint=after["executable"],
+        )
+        if observed is not None and after["policy"] != "seed":
+            _fail(f"target.{relative}", "unowned target collides with a planned add")
+        action = "preserve-seed" if observed is not None else "add"
+        reason = (
+            "pre-existing seed path remains user-owned"
+            if observed is not None
+            else "selected component path is absent"
+        )
+        actions.append({
+            "path": relative,
+            "owner": after["owner"],
+            "policy": after["policy"],
+            "action": action,
+            "base": None,
+            "current": _snapshot_value(observed),
+            "desired": _snapshot_value(after),
+            "reason": reason,
+        })
+    _assert_bundle_current(candidate, "candidate_bundle")
+    for item in actions:
+        target = _safe_path(
+            target_root, item["path"], f"target.{item['path']}", missing_ok=True
+        )
+        observed = _snapshot(
+            target,
+            f"target.{item['path']}",
+            executable_hint=desired[item["path"]]["executable"],
+        )
+        if _snapshot_value(observed) != item["current"]:
+            _fail(f"target.{item['path']}", "changed while the plan was being created")
+    config_digest = sha256_bytes(render_workspace_config(config).encode("utf-8"))
+    unsigned = {
+        "schema_version": PLANNER_PROTOCOL_VERSION,
+        "candidate_bundle_sha256": candidate.digest,
+        "current_bundle_sha256": None,
+        "workspace_config_sha256_raw": config_digest,
+        "executable_modes_verified": {
+            "candidate_source": candidate.mode_verified,
+            "current_source": None,
+            "target": os.name != "nt",
+        },
+        "intended_workspace": config,
+        "current_components": [],
         "desired_components": desired_ids,
         "actions": actions,
     }

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -704,8 +704,10 @@ def create_structural_plan(
         _fail("candidate_bundle", "cannot mix components from different bundle names")
     expected_config_sha256 = _sha256(expected_config_sha256, "expected_config_sha256")
     try:
-        config_relative = workspace_config_path.absolute().relative_to(target_root).as_posix()
-    except ValueError as exc:
+        config_relative = (
+            workspace_config_path.absolute().resolve().relative_to(target_root).as_posix()
+        )
+    except (OSError, ValueError) as exc:
         raise BundleError("workspace_config_path: must remain inside target_root") from exc
     config_path = _safe_path(
         target_root, config_relative, "workspace_config_path", missing_ok=False

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -160,7 +160,10 @@ def _source_root(root: Path, field: str) -> Path:
         _fail(field, f"cannot inspect local directory: {exc}")
     if not stat.S_ISDIR(metadata.st_mode):
         _fail(field, "must be an existing local directory")
-    return absolute
+    try:
+        return absolute.resolve()
+    except OSError as exc:
+        _fail(field, f"cannot resolve local directory identity: {exc}")
 
 
 def _safe_path(root: Path, relative: str, field: str, *, missing_ok: bool) -> Path:

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -35,6 +35,10 @@ from .kernel import (
     start_report,
     workspace_resolution_report,
 )
+from .materializer import (
+    create_composition_proposal,
+    create_materialization_proposal,
+)
 from .workspace_schema import WorkspaceConfigError, parse_agent_selection
 
 
@@ -177,24 +181,41 @@ def parser() -> argparse.ArgumentParser:
     plan_bundle = bundle_commands.add_parser(
         "plan", help="Print a deterministic read-only structural plan"
     )
-    plan_bundle.add_argument("--lock", type=Path, required=True)
-    plan_bundle.add_argument("--source", type=Path, required=True)
-    plan_bundle.add_argument("--expect-sha256", required=True)
-    plan_bundle.add_argument(
-        "--source-mode", choices=("git-index", "directory"), default="directory"
+    propose_bundle = bundle_commands.add_parser(
+        "propose", help="Create a digest-bound materialization proposal"
     )
-    plan_bundle.add_argument("--target", type=Path, required=True)
-    plan_bundle.add_argument("--workspace-config", type=Path, required=True)
-    plan_bundle.add_argument("--expect-config-sha256", required=True)
-    plan_bundle.add_argument("--components", required=True)
-    plan_bundle.add_argument("--current-lock", type=Path)
-    plan_bundle.add_argument("--current-source", type=Path)
-    plan_bundle.add_argument("--expect-current-sha256")
-    plan_bundle.add_argument(
-        "--current-source-mode", choices=("git-index", "directory"),
-        default="directory",
+    compose_bundle = bundle_commands.add_parser(
+        "compose", help="Create a first-install proposal for a clean target"
     )
-    plan_bundle.add_argument("--current-components")
+    apply_bundle = bundle_commands.add_parser(
+        "apply", help="Apply a materialization proposal to its explicit target"
+    )
+    apply_bundle.add_argument("--target", type=Path, required=True)
+    apply_bundle.add_argument("--proposal", type=Path, required=True)
+    apply_bundle.add_argument("--confirm", required=True)
+    apply_bundle.add_argument("--runtime", default="generic")
+    for command in (plan_bundle, propose_bundle, compose_bundle):
+        command.add_argument("--lock", type=Path, required=True)
+        command.add_argument("--source", type=Path, required=True)
+        command.add_argument("--expect-sha256", required=True)
+        command.add_argument(
+            "--source-mode", choices=("git-index", "directory"), default="directory"
+        )
+        command.add_argument("--target", type=Path, required=True)
+        command.add_argument("--workspace-config", type=Path, required=True)
+        command.add_argument("--expect-config-sha256", required=True)
+        command.add_argument("--components", required=True)
+        command.add_argument("--current-lock", type=Path)
+        command.add_argument("--current-source", type=Path)
+        command.add_argument("--expect-current-sha256")
+        command.add_argument(
+            "--current-source-mode", choices=("git-index", "directory"),
+            default="directory",
+        )
+        command.add_argument("--current-components")
+    propose_bundle.add_argument("--now", help="ISO-8601 timestamp for deterministic proposal IDs")
+    compose_bundle.add_argument("--workspace-config-input", type=Path, required=True)
+    compose_bundle.add_argument("--now", help="ISO-8601 timestamp for deterministic proposal IDs")
     return result
 
 
@@ -210,6 +231,14 @@ def component_selection(raw: str, field: str) -> list[str]:
 
 
 def _bundle_main(args: argparse.Namespace) -> int:
+    if args.bundle_command == "apply":
+        root = args.target.absolute().resolve()
+        proposal = args.proposal if args.proposal.is_absolute() else root / args.proposal
+        receipt_path, receipt = apply_proposal(
+            root, proposal, args.confirm, args.runtime
+        )
+        emit({"receipt": receipt_path.relative_to(root).as_posix(), **receipt})
+        return 0
     if args.bundle_command == "generate":
         lock = create_bundle_lock(
             args.source,
@@ -262,12 +291,78 @@ def _bundle_main(args: argparse.Namespace) -> int:
         current_components = component_selection(
             args.current_components, "current_components"
         )
+    desired_components = component_selection(args.components, "components")
+    if args.bundle_command == "compose":
+        if current is not None or current_components:
+            raise BundleError("compose: current bundle inputs are not allowed")
+        proposal_path, proposal = create_composition_proposal(
+            target_root=args.target,
+            workspace_config_path=args.workspace_config,
+            workspace_config_input_path=args.workspace_config_input,
+            expected_config_input_sha256=args.expect_config_sha256,
+            candidate=candidate,
+            desired_components=desired_components,
+            now=parse_now(args.now),
+        )
+        emit({
+            "proposal": proposal_path.relative_to(args.target.absolute()).as_posix(),
+            "proposal_id": proposal["proposal_id"],
+            "proposal_digest": proposal["proposal_digest"],
+            "plan_digest": proposal["authorization"]["plan"]["plan_digest"],
+            "changes": [
+                {
+                    "action": change["action"],
+                    "path": change["path"],
+                    "owner": change["authorization"]["owner"],
+                    "policy": change["authorization"]["policy"],
+                    "before_sha256_raw": change["before_raw_sha256"],
+                    "after_sha256_raw": change["after_raw_sha256"],
+                    "summary": change["diff"].strip(),
+                }
+                for change in proposal["changes"]
+            ],
+            "writes": True,
+            "applied": False,
+        })
+        return 0
+    if args.bundle_command == "propose":
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=args.target,
+            workspace_config_path=args.workspace_config,
+            expected_config_sha256=args.expect_config_sha256,
+            candidate=candidate,
+            desired_components=desired_components,
+            current=current,
+            current_components=current_components,
+            now=parse_now(args.now),
+        )
+        emit({
+            "proposal": proposal_path.relative_to(args.target.absolute()).as_posix(),
+            "proposal_id": proposal["proposal_id"],
+            "proposal_digest": proposal["proposal_digest"],
+            "plan_digest": proposal["authorization"]["plan"]["plan_digest"],
+            "changes": [
+                {
+                    "action": change["action"],
+                    "path": change["path"],
+                    "owner": change["authorization"]["owner"],
+                    "policy": change["authorization"]["policy"],
+                    "before_sha256_raw": change["before_raw_sha256"],
+                    "after_sha256_raw": change["after_raw_sha256"],
+                    "summary": change["diff"].strip(),
+                }
+                for change in proposal["changes"]
+            ],
+            "writes": True,
+            "applied": False,
+        })
+        return 0
     plan = create_structural_plan(
         target_root=args.target,
         workspace_config_path=args.workspace_config,
         expected_config_sha256=args.expect_config_sha256,
         candidate=candidate,
-        desired_components=component_selection(args.components, "components"),
+        desired_components=desired_components,
         current=current,
         current_components=current_components,
     )

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -36,6 +36,7 @@ from .kernel import (
     workspace_resolution_report,
 )
 from .materializer import (
+    MATERIALIZE_OPERATION,
     create_composition_proposal,
     create_materialization_proposal,
 )
@@ -234,6 +235,8 @@ def _bundle_main(args: argparse.Namespace) -> int:
     if args.bundle_command == "apply":
         root = args.target.absolute().resolve()
         proposal = args.proposal if args.proposal.is_absolute() else root / args.proposal
+        if read_json(proposal).get("operation") != MATERIALIZE_OPERATION:
+            raise BundleError("bundle apply accepts only materialization proposals")
         receipt_path, receipt = apply_proposal(
             root, proposal, args.confirm, args.runtime
         )

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -66,11 +66,13 @@ WORKSPACE_MIGRATION_OPERATION = "workspace-migrate"
 WORKSPACE_SETUP_OPERATION = "workspace-setup"
 AGENT_ENABLE_OPERATION = "agent-enable"
 AGENT_DISABLE_OPERATION = "agent-disable"
+MATERIALIZE_OPERATION = "component-materialize"
 AGENT_SET_OPERATIONS = {
     WORKSPACE_MIGRATION_OPERATION,
     WORKSPACE_SETUP_OPERATION,
     AGENT_ENABLE_OPERATION,
     AGENT_DISABLE_OPERATION,
+    MATERIALIZE_OPERATION,
 }
 LOCAL_ARTIFACT_MODE = 0o600
 NEW_CONTENT_MODE = 0o666 if os.name == "nt" else 0o644
@@ -470,6 +472,14 @@ def safe_repo_path(root: Path, raw: str) -> Path:
     except ValueError as exc:
         raise ContextOSError(f"path escapes repository root: {raw}") from exc
     return resolved
+
+
+def _transaction_target(root: Path, raw: str, operation: str | None) -> Path:
+    if operation == MATERIALIZE_OPERATION and raw == ".context-os/installed-bundle.json":
+        candidate = root / ".context-os" / "installed-bundle.json"
+        _guard_local_artifact_path(root, candidate)
+        return candidate
+    return safe_repo_path(root, raw)
 
 
 def workspace_resolution_report(root: Path) -> dict[str, Any]:
@@ -1516,6 +1526,10 @@ def _validate_agent_proposal_shape(
     if set(document) != required:
         raise ContextOSError("agent-config proposal has an invalid top-level shape")
     operation = document.get("operation")
+    if operation == MATERIALIZE_OPERATION:
+        from .materializer import validate_materialization_proposal_shape
+
+        return validate_materialization_proposal_shape(root, document)
     if operation not in AGENT_SET_OPERATIONS:
         raise ContextOSError(f"unsupported agent lifecycle operation: {operation}")
     created_at = parse_now(ensure_text(document.get("created_at"), "created_at"))
@@ -1771,7 +1785,7 @@ def _validate_proposal_shape(root: Path, proposal: Path, document: dict[str, Any
         if relative in seen:
             raise ContextOSError(f"proposal contains duplicate path: {relative}")
         seen.add(relative)
-        safe_repo_path(root, relative)
+        _transaction_target(root, relative, operation)
         if workflow != AGENT_LIFECYCLE_WORKFLOW:
             _validate_change_path(workspace, workflow, created_at, relative)
         if workflow == "setup" and change.get("replacement_approved") not in {True, False}:
@@ -1780,6 +1794,11 @@ def _validate_proposal_shape(root: Path, proposal: Path, document: dict[str, Any
 
 
 def _validate_agent_preflight(root: Path, document: dict[str, Any]) -> None:
+    if document.get("operation") == MATERIALIZE_OPERATION:
+        from .materializer import validate_materialization_preflight
+
+        validate_materialization_preflight(root, document)
+        return
     if document.get("source_git_head") != git_head(root):
         raise ContextOSError("refusing stale agent-config proposal; git HEAD changed")
     # Targets are also authorization inputs (the current workspace configuration
@@ -2112,7 +2131,7 @@ def _create_agent_journal(
     workflow = document["workflow"]
     entries: list[dict[str, Any]] = []
     for index, change in enumerate(document["changes"]):
-        path = safe_repo_path(root, change["path"])
+        path = _transaction_target(root, change["path"], document.get("operation"))
         before = backups[path]
         slot = _transaction_slot(index, change["path"])
         backup_relative = None
@@ -2249,8 +2268,21 @@ def _recover_agent_journal(
             or set(evidence) != {"authorization", "source_hashes"}
             or not isinstance(evidence.get("authorization"), dict)
             or not isinstance(evidence.get("source_hashes"), dict)
-            or manifest.get("invariants") != AGENT_MIGRATION_INVARIANTS
         ):
+            raise ContextOSError(f"invalid agent transaction evidence: {journal}")
+        if manifest.get("operation") == MATERIALIZE_OPERATION:
+            from .materializer import MATERIALIZE_INVARIANTS
+
+            authorization = evidence["authorization"]
+            if (
+                manifest.get("invariants") != MATERIALIZE_INVARIANTS
+                or authorization.get("policy") != "component-materialization-v1"
+                or not isinstance(authorization.get("recovery_policy"), dict)
+            ):
+                raise ContextOSError(
+                    f"invalid materialization transaction evidence: {journal}"
+                )
+        elif manifest.get("invariants") != AGENT_MIGRATION_INVARIANTS:
             raise ContextOSError(f"invalid agent transaction evidence: {journal}")
     else:
         if (
@@ -2298,7 +2330,7 @@ def _recover_agent_journal(
             raise ContextOSError(f"journal slot identity mismatch for {relative}")
         seen_paths.add(relative)
         seen_slots.add(slot)
-        target = safe_repo_path(root, relative)
+        target = _transaction_target(root, relative, manifest.get("operation"))
         if type(entry.get("existed")) is not bool:
             raise ContextOSError(f"invalid journal entry {index}: {journal}")
         mode = entry.get("mode")
@@ -2322,18 +2354,36 @@ def _recover_agent_journal(
             raise ContextOSError(f"invalid journal entry {index}: {journal}")
         receipt_entry = entry.get("receipt_entry")
         if workflow == AGENT_LIFECYCLE_WORKFLOW:
-            recovery_policy = {
-                "contextos.workspace.json": ("write", "workspace-config", "managed"),
-            }
-            if manifest.get("operation") in {
-                WORKSPACE_MIGRATION_OPERATION,
-                WORKSPACE_SETUP_OPERATION,
-            }:
-                recovery_policy["workspace.yaml"] = (
-                    "delete",
-                    "legacy-workspace-config",
-                    "migration-only",
-                )
+            if manifest.get("operation") == MATERIALIZE_OPERATION:
+                raw_policy = manifest["agent_evidence"]["authorization"][
+                    "recovery_policy"
+                ]
+                recovery_policy = {
+                    path: (
+                        item.get("action"), item.get("owner"), item.get("policy")
+                    )
+                    for path, item in raw_policy.items()
+                    if isinstance(path, str) and isinstance(item, dict)
+                }
+                if len(recovery_policy) != len(raw_policy):
+                    raise ContextOSError(
+                        f"invalid materialization recovery policy: {journal}"
+                    )
+            else:
+                recovery_policy = {
+                    "contextos.workspace.json": (
+                        "write", "workspace-config", "managed"
+                    ),
+                }
+                if manifest.get("operation") in {
+                    WORKSPACE_MIGRATION_OPERATION,
+                    WORKSPACE_SETUP_OPERATION,
+                }:
+                    recovery_policy["workspace.yaml"] = (
+                        "delete",
+                        "legacy-workspace-config",
+                        "migration-only",
+                    )
             if relative not in recovery_policy:
                 raise ContextOSError(f"journal path is not recoverable: {relative}")
             allowed_action, allowed_owner, allowed_policy = recovery_policy[relative]
@@ -3172,6 +3222,7 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
         publication_anchors: dict[Path, Path] = {}
         journal_path: Path | None = None
         receipt_published = False
+        materialization_payloads: dict[str, bytes] = {}
         staging_root = root / ".context-os" / "staging" / document["proposal_id"]
         receipt_path = root / ".context-os" / "receipts" / f"{document['proposal_id']}.json"
         _guard_local_artifact_path(root, staging_root)
@@ -3189,8 +3240,14 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                     staging_root,
                 )
             staging_root.mkdir(parents=True)
+            if document.get("operation") == MATERIALIZE_OPERATION:
+                from .materializer import materialization_payloads as load_payloads
+
+                materialization_payloads = load_payloads(root, document)
             for change_index, change in enumerate(document["changes"]):
-                path = safe_repo_path(root, change["path"])
+                path = _transaction_target(
+                    root, change["path"], document.get("operation")
+                )
                 backups[path] = path.read_bytes() if path.exists() else None
                 backup_modes[path] = (
                     path.stat().st_mode & 0o7777 if path.exists() else None
@@ -3208,7 +3265,9 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                     )
                     _write_exclusive_bytes(
                         stage,
-                        change["after_text"].encode("utf-8"),
+                        materialization_payloads[change["path"]]
+                        if document.get("operation") == MATERIALIZE_OPERATION
+                        else change["after_text"].encode("utf-8"),
                         root=root,
                         mode=target_mode,
                     )
@@ -3222,7 +3281,9 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
             for change in document["changes"]:
                 if change.get("action", "write") != "write":
                     continue
-                path = safe_repo_path(root, change["path"])
+                path = _transaction_target(
+                    root, change["path"], document.get("operation")
+                )
                 expected_after_raw = (
                     change["after_raw_sha256"]
                     if workflow == AGENT_LIFECYCLE_WORKFLOW
@@ -3249,7 +3310,9 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                 # source and target immediately before the first mutation.
                 _validate_agent_preflight(root, document)
             for change in document["changes"]:
-                path = safe_repo_path(root, change["path"])
+                path = _transaction_target(
+                    root, change["path"], document.get("operation")
+                )
                 if workflow == AGENT_LIFECYCLE_WORKFLOW:
                     if raw_file_digest(path) != change["before_raw_sha256"]:
                         raise ContextOSError(
@@ -3352,7 +3415,7 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                 "git_head_before": head_before,
                 "git_head_after": git_head(root),
                 "invariants_checked": (
-                    list(AGENT_MIGRATION_INVARIANTS)
+                    list(document["invariants"])
                     if workflow == AGENT_LIFECYCLE_WORKFLOW
                     else _content_invariants(workflow, document["changes"])
                 ),

--- a/contextos/materializer.py
+++ b/contextos/materializer.py
@@ -127,6 +127,18 @@ def _target_path(root: Path, relative: str) -> Path:
     return kernel.safe_repo_path(root, relative)
 
 
+def _workspace_config_relative(root: Path, path: Path) -> str:
+    try:
+        relative = path.absolute().relative_to(root).as_posix()
+    except ValueError as exc:
+        raise BundleError("workspace_config_path: must remain inside target_root") from exc
+    if relative != "contextos.workspace.json":
+        raise BundleError(
+            "workspace_config_path: must equal target_root/contextos.workspace.json"
+        )
+    return relative
+
+
 def _inline_ref(text: str) -> dict[str, Any]:
     return {"kind": "inline", "role": None, "path": None, "text": text}
 
@@ -326,10 +338,7 @@ def create_materialization_proposal(
         current_components=current_components,
     )
     _validate_installed_state(root, current, plan)
-    try:
-        config_relative = workspace_config_path.absolute().relative_to(root).as_posix()
-    except ValueError as exc:
-        raise BundleError("workspace_config_path: must remain inside target_root") from exc
+    config_relative = _workspace_config_relative(root, workspace_config_path)
     changes = _expected_changes(
         root,
         candidate=candidate,
@@ -358,7 +367,7 @@ def create_materialization_proposal(
     }
     source_hashes = {
         str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes()),
-        str(workspace_config_path.absolute()): expected_config_sha256,
+        str(kernel.safe_repo_path(root, config_relative)): expected_config_sha256,
     }
     if current is not None:
         source_hashes[str(current.lock_path.absolute())] = sha256_bytes(
@@ -424,12 +433,10 @@ def create_composition_proposal(
         candidate=candidate,
         desired_components=desired_components,
     )
-    try:
-        config_relative = workspace_config_path.absolute().relative_to(root).as_posix()
-    except ValueError as exc:
-        raise BundleError("workspace_config_path: must remain inside target_root") from exc
+    config_relative = _workspace_config_relative(root, workspace_config_path)
     if kernel.raw_file_digest(kernel.safe_repo_path(root, config_relative)) is not None:
         raise BundleError("workspace_config_path: clean composition target already exists")
+    _validate_installed_state(root, None, plan)
     changes = _expected_changes(
         root,
         candidate=candidate,
@@ -512,6 +519,8 @@ def _materialization_context(
     config = authorization.get("workspace_config")
     if not isinstance(config, dict) or not isinstance(config.get("path"), str):
         raise BundleError("authorization.workspace_config is invalid")
+    if config["path"] != "contextos.workspace.json":
+        raise BundleError("materialization workspace config path is not canonical")
     if mode == "upgrade":
         if (
             set(config) != {"path", "expected_sha256"}

--- a/contextos/materializer.py
+++ b/contextos/materializer.py
@@ -1,0 +1,660 @@
+"""Digest-bound materialization proposals backed by verified offline bundles."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+from .bundle_schema import (
+    BundleError,
+    VerifiedBundle,
+    create_initial_structural_plan,
+    create_structural_plan,
+    verify_bundle,
+)
+from .component_schema import portable_path_identity
+from .primitives import canonical_json, read_regular_file_snapshot, sha256_bytes
+from .workspace_schema import (
+    WorkspaceConfigError,
+    render_workspace_config,
+    strict_json_loads,
+    validate_workspace_config,
+)
+
+
+MATERIALIZE_OPERATION = "component-materialize"
+MATERIALIZE_INVARIANTS = [
+    "exact-structural-plan-digest",
+    "offline-bundle-source-revalidation",
+    "component-ownership-closed",
+    "seed-and-extensible-content-preserved",
+    "exact-raw-file-hashes-and-modes",
+    "second-pre-mutation-revalidation",
+    "shared-journal-receipt-and-rollback",
+]
+INSTALLED_STATE_PATH = ".context-os/installed-bundle.json"
+BUNDLE_SPEC_KEYS = {"lock", "source", "expected_sha256", "source_mode"}
+MATERIALIZE_AUTHORIZATION_KEYS = {
+    "policy",
+    "mode",
+    "plan",
+    "candidate",
+    "current",
+    "workspace_config",
+    "recovery_policy",
+}
+MATERIALIZE_CHANGE_KEYS = {
+    "path",
+    "action",
+    "authorization",
+    "before_raw_sha256",
+    "before_mode",
+    "after_raw_sha256",
+    "after_mode",
+    "after_text",
+    "content_ref",
+    "diff",
+}
+CHANGE_AUTHORIZATION_KEYS = {"kind", "owner", "policy"}
+CONTENT_REF_KEYS = {"kind", "role", "path", "text"}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _kernel():
+    # Imported lazily so kernel.py can call validation helpers without a module cycle.
+    from . import kernel
+
+    return kernel
+
+
+def _bundle_spec(bundle: VerifiedBundle) -> dict[str, str]:
+    return {
+        "lock": str(bundle.lock_path.absolute()),
+        "source": str(bundle.root.absolute()),
+        "expected_sha256": bundle.digest,
+        "source_mode": bundle.source_mode,
+    }
+
+
+def _load_bundle_spec(value: Any, field: str, *, role: str) -> VerifiedBundle:
+    if not isinstance(value, dict) or set(value) != BUNDLE_SPEC_KEYS:
+        raise BundleError(f"{field}: invalid bundle input shape")
+    for key in ("lock", "source", "expected_sha256", "source_mode"):
+        if not isinstance(value.get(key), str) or not value[key]:
+            raise BundleError(f"{field}.{key}: must be a non-empty string")
+    if not SHA256_RE.fullmatch(value["expected_sha256"]):
+        raise BundleError(f"{field}.expected_sha256: must be a lowercase SHA-256 digest")
+    if value["source_mode"] not in {"directory", "git-index"}:
+        raise BundleError(f"{field}.source_mode: unsupported value")
+    lock = Path(value["lock"])
+    source = Path(value["source"])
+    if not lock.is_absolute() or not source.is_absolute():
+        raise BundleError(f"{field}: lock and source must be absolute local paths")
+    return verify_bundle(
+        lock,
+        source,
+        expected_sha256=value["expected_sha256"],
+        source_mode=value["source_mode"],
+        role=role,
+    )
+
+
+def _mode_for_write(path: Path, *, executable: bool) -> int:
+    kernel = _kernel()
+    if os.name == "nt":
+        return stat.S_IMODE(path.stat().st_mode) if path.exists() else kernel.NEW_CONTENT_MODE
+    return 0o755 if executable else 0o644
+
+
+def _before(path: Path) -> tuple[str | None, int | None]:
+    kernel = _kernel()
+    digest = kernel.raw_file_digest(path)
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else None
+    return digest, mode
+
+
+def _target_path(root: Path, relative: str) -> Path:
+    kernel = _kernel()
+    if relative == INSTALLED_STATE_PATH:
+        candidate = root / ".context-os" / "installed-bundle.json"
+        kernel._guard_local_artifact_path(root, candidate)
+        return candidate
+    return kernel.safe_repo_path(root, relative)
+
+
+def _inline_ref(text: str) -> dict[str, Any]:
+    return {"kind": "inline", "role": None, "path": None, "text": text}
+
+
+def _bundle_ref(path: str) -> dict[str, Any]:
+    return {"kind": "bundle", "role": "candidate", "path": path, "text": None}
+
+
+def _change(
+    root: Path,
+    *,
+    relative: str,
+    action: str,
+    owner: str,
+    policy: str,
+    kind: str,
+    after_hash: str | None,
+    after_mode: int | None,
+    content_ref: dict[str, Any] | None,
+    reason: str,
+) -> dict[str, Any]:
+    kernel = _kernel()
+    path = _target_path(root, relative)
+    before_hash, before_mode = _before(path)
+    return {
+        "path": relative,
+        "action": action,
+        "authorization": {"kind": kind, "owner": owner, "policy": policy},
+        "before_raw_sha256": before_hash,
+        "before_mode": before_mode,
+        "after_raw_sha256": after_hash,
+        "after_mode": after_mode,
+        "after_text": content_ref["text"] if content_ref is not None else None,
+        "content_ref": content_ref,
+        "diff": f"{action} {relative}: {reason}\n",
+    }
+
+
+def _installed_state(candidate: VerifiedBundle, plan: dict[str, Any]) -> str:
+    value = {
+        "schema_version": 1,
+        "bundle": {
+            "name": candidate.name,
+            "version": candidate.version,
+            "sha256": candidate.digest,
+            "source_git_commit": candidate.lock["bundle"]["source_git_commit"],
+        },
+        "components": list(plan["desired_components"]),
+        "plan_digest": plan["plan_digest"],
+    }
+    return json.dumps(value, indent=2, ensure_ascii=False) + "\n"
+
+
+def _validate_installed_state(
+    root: Path, current: VerifiedBundle | None, plan: dict[str, Any]
+) -> None:
+    path = _target_path(root, INSTALLED_STATE_PATH)
+    if not path.exists():
+        return
+    if current is None:
+        raise BundleError("installed bundle state requires an explicit current bundle")
+    try:
+        raw, _metadata = read_regular_file_snapshot(
+            path, subject="installed bundle state"
+        )
+        value = strict_json_loads(raw.decode("utf-8"), source=INSTALLED_STATE_PATH)
+    except (OSError, UnicodeError, WorkspaceConfigError) as exc:
+        raise BundleError(str(exc)) from exc
+    expected_keys = {"schema_version", "bundle", "components", "plan_digest"}
+    if not isinstance(value, dict) or set(value) != expected_keys:
+        raise BundleError("installed bundle state has an invalid shape")
+    bundle = value.get("bundle")
+    expected_bundle = {
+        "name": current.name,
+        "version": current.version,
+        "sha256": current.digest,
+        "source_git_commit": current.lock["bundle"]["source_git_commit"],
+    }
+    if bundle != expected_bundle:
+        raise BundleError("installed bundle state contradicts the current bundle")
+    if value.get("components") != plan["current_components"]:
+        raise BundleError("installed bundle state contradicts current_components")
+    if (
+        value.get("schema_version") != 1
+        or not isinstance(value.get("plan_digest"), str)
+        or not SHA256_RE.fullmatch(value["plan_digest"])
+    ):
+        raise BundleError("installed bundle state is invalid")
+
+
+def _expected_changes(
+    root: Path,
+    *,
+    candidate: VerifiedBundle,
+    plan: dict[str, Any],
+    workspace_config_relative: str,
+) -> list[dict[str, Any]]:
+    kernel = _kernel()
+    changes: list[dict[str, Any]] = []
+    for item in plan["actions"]:
+        action = item["action"]
+        if action not in {"add", "replace", "remove"}:
+            continue
+        relative = item["path"]
+        record = candidate.records.get(relative)
+        if action in {"add", "replace"}:
+            if record is None:
+                raise BundleError(f"plan.{relative}: candidate record is missing")
+            target = kernel.safe_repo_path(root, relative)
+            changes.append(
+                _change(
+                    root,
+                    relative=relative,
+                    action="write",
+                    owner=item["owner"],
+                    policy=item["policy"],
+                    kind="component",
+                    after_hash=record["sha256_raw"],
+                    after_mode=_mode_for_write(target, executable=record["executable"]),
+                    content_ref=_bundle_ref(relative),
+                    reason=item["reason"],
+                )
+            )
+        else:
+            changes.append(
+                _change(
+                    root,
+                    relative=relative,
+                    action="delete",
+                    owner=item["owner"],
+                    policy=item["policy"],
+                    kind="component",
+                    after_hash=None,
+                    after_mode=None,
+                    content_ref=None,
+                    reason=item["reason"],
+                )
+            )
+
+    config_text = render_workspace_config(plan["intended_workspace"])
+    config_path = kernel.safe_repo_path(root, workspace_config_relative)
+    if kernel.raw_file_digest(config_path) != sha256_bytes(config_text.encode("utf-8")):
+        changes.append(
+            _change(
+                root,
+                relative=workspace_config_relative,
+                action="write",
+                owner="workspace-config",
+                policy="managed",
+                kind="workspace-config",
+                after_hash=sha256_bytes(config_text.encode("utf-8")),
+                after_mode=_mode_for_write(config_path, executable=False),
+                content_ref=_inline_ref(config_text),
+                reason="bind workspace identity to the candidate bundle",
+            )
+        )
+
+    installed_text = _installed_state(candidate, plan)
+    installed_path = _target_path(root, INSTALLED_STATE_PATH)
+    changes.append(
+        _change(
+            root,
+            relative=INSTALLED_STATE_PATH,
+            action="write",
+            owner="context-os",
+            policy="local-managed",
+            kind="installed-state",
+            after_hash=sha256_bytes(installed_text.encode("utf-8")),
+            after_mode=_mode_for_write(installed_path, executable=False),
+            content_ref=_inline_ref(installed_text),
+            reason="record the exact installed bundle and component closure",
+        )
+    )
+    return sorted(changes, key=lambda item: portable_path_identity(item["path"]))
+
+
+def create_materialization_proposal(
+    *,
+    target_root: Path,
+    workspace_config_path: Path,
+    expected_config_sha256: str,
+    candidate: VerifiedBundle,
+    desired_components: Sequence[str],
+    now: datetime,
+    current: VerifiedBundle | None = None,
+    current_components: Sequence[str] = (),
+) -> tuple[Path, dict[str, Any]]:
+    kernel = _kernel()
+    root = target_root.absolute()
+    plan = create_structural_plan(
+        target_root=root,
+        workspace_config_path=workspace_config_path,
+        expected_config_sha256=expected_config_sha256,
+        candidate=candidate,
+        desired_components=desired_components,
+        current=current,
+        current_components=current_components,
+    )
+    _validate_installed_state(root, current, plan)
+    try:
+        config_relative = workspace_config_path.absolute().relative_to(root).as_posix()
+    except ValueError as exc:
+        raise BundleError("workspace_config_path: must remain inside target_root") from exc
+    changes = _expected_changes(
+        root,
+        candidate=candidate,
+        plan=plan,
+        workspace_config_relative=config_relative,
+    )
+    recovery_policy = {
+        change["path"]: {
+            "action": change["action"],
+            "owner": change["authorization"]["owner"],
+            "policy": change["authorization"]["policy"],
+        }
+        for change in changes
+    }
+    authorization = {
+        "policy": "component-materialization-v1",
+        "mode": "upgrade",
+        "plan": plan,
+        "candidate": _bundle_spec(candidate),
+        "current": _bundle_spec(current) if current is not None else None,
+        "workspace_config": {
+            "path": config_relative,
+            "expected_sha256": expected_config_sha256,
+        },
+        "recovery_policy": recovery_policy,
+    }
+    source_hashes = {
+        str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes()),
+        str(workspace_config_path.absolute()): expected_config_sha256,
+    }
+    if current is not None:
+        source_hashes[str(current.lock_path.absolute())] = sha256_bytes(
+            current.lock_path.read_bytes()
+        )
+    source_hashes = dict(sorted(source_hashes.items()))
+    document: dict[str, Any] = {
+        "schema_version": kernel.SCHEMA_VERSION,
+        "workflow": kernel.AGENT_LIFECYCLE_WORKFLOW,
+        "operation": MATERIALIZE_OPERATION,
+        "created_at": now.isoformat(),
+        "proposal_id": kernel.proposal_id(
+            kernel.AGENT_LIFECYCLE_WORKFLOW, now, changes
+        ),
+        "changes": changes,
+        "authorization": authorization,
+        "source_hashes": source_hashes,
+        "source_git_head": kernel.git_head(root),
+        "invariants": list(MATERIALIZE_INVARIANTS),
+    }
+    document["proposal_digest"] = sha256_bytes(
+        canonical_json(document).encode("utf-8")
+    )
+    path = root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
+    kernel._write_exclusive_text(
+        path, json.dumps(document, indent=2, ensure_ascii=False) + "\n", root=root
+    )
+    return path, document
+
+
+def create_composition_proposal(
+    *,
+    target_root: Path,
+    workspace_config_path: Path,
+    workspace_config_input_path: Path,
+    expected_config_input_sha256: str,
+    candidate: VerifiedBundle,
+    desired_components: Sequence[str],
+    now: datetime,
+) -> tuple[Path, dict[str, Any]]:
+    """Create a transaction proposal for a first install into a clean target."""
+    kernel = _kernel()
+    root = target_root.absolute()
+    input_path = workspace_config_input_path.absolute()
+    try:
+        input_bytes, _metadata = read_regular_file_snapshot(
+            input_path, subject="workspace configuration input"
+        )
+        input_digest = sha256_bytes(input_bytes)
+        if input_digest != expected_config_input_sha256:
+            raise BundleError("expected_config_input_sha256: workspace input is stale")
+        input_value = strict_json_loads(
+            input_bytes.decode("utf-8"), source=str(input_path)
+        )
+        intended = validate_workspace_config(
+            input_value, known_runtime_ids=sorted(candidate.runtimes)
+        )
+    except (OSError, UnicodeError, WorkspaceConfigError) as exc:
+        raise BundleError(str(exc)) from exc
+    plan = create_initial_structural_plan(
+        target_root=root,
+        workspace_config=intended,
+        candidate=candidate,
+        desired_components=desired_components,
+    )
+    try:
+        config_relative = workspace_config_path.absolute().relative_to(root).as_posix()
+    except ValueError as exc:
+        raise BundleError("workspace_config_path: must remain inside target_root") from exc
+    if kernel.raw_file_digest(kernel.safe_repo_path(root, config_relative)) is not None:
+        raise BundleError("workspace_config_path: clean composition target already exists")
+    changes = _expected_changes(
+        root,
+        candidate=candidate,
+        plan=plan,
+        workspace_config_relative=config_relative,
+    )
+    recovery_policy = {
+        change["path"]: {
+            "action": change["action"],
+            "owner": change["authorization"]["owner"],
+            "policy": change["authorization"]["policy"],
+        }
+        for change in changes
+    }
+    authorization = {
+        "policy": "component-materialization-v1",
+        "mode": "compose",
+        "plan": plan,
+        "candidate": _bundle_spec(candidate),
+        "current": None,
+        "workspace_config": {
+            "path": config_relative,
+            "expected_sha256": expected_config_input_sha256,
+            "input_path": str(input_path),
+            "intended": intended,
+        },
+        "recovery_policy": recovery_policy,
+    }
+    source_hashes = dict(sorted({
+        str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes()),
+        str(input_path): input_digest,
+    }.items()))
+    document: dict[str, Any] = {
+        "schema_version": kernel.SCHEMA_VERSION,
+        "workflow": kernel.AGENT_LIFECYCLE_WORKFLOW,
+        "operation": MATERIALIZE_OPERATION,
+        "created_at": now.isoformat(),
+        "proposal_id": kernel.proposal_id(
+            kernel.AGENT_LIFECYCLE_WORKFLOW, now, changes
+        ),
+        "changes": changes,
+        "authorization": authorization,
+        "source_hashes": source_hashes,
+        "source_git_head": kernel.git_head(root),
+        "invariants": list(MATERIALIZE_INVARIANTS),
+    }
+    document["proposal_digest"] = sha256_bytes(
+        canonical_json(document).encode("utf-8")
+    )
+    path = root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
+    kernel._write_exclusive_text(
+        path, json.dumps(document, indent=2, ensure_ascii=False) + "\n", root=root
+    )
+    return path, document
+
+
+def _materialization_context(
+    root: Path, document: dict[str, Any]
+) -> tuple[VerifiedBundle, VerifiedBundle | None, dict[str, Any], list[dict[str, Any]]]:
+    authorization = document.get("authorization")
+    if not isinstance(authorization, dict) or set(authorization) != MATERIALIZE_AUTHORIZATION_KEYS:
+        raise BundleError("materialization authorization has an invalid shape")
+    if authorization.get("policy") != "component-materialization-v1":
+        raise BundleError("materialization authorization policy is invalid")
+    mode = authorization.get("mode")
+    if mode not in {"compose", "upgrade"}:
+        raise BundleError("materialization authorization mode is invalid")
+    candidate = _load_bundle_spec(
+        authorization.get("candidate"), "authorization.candidate", role="candidate"
+    )
+    current_spec = authorization.get("current")
+    current = (
+        _load_bundle_spec(current_spec, "authorization.current", role="current")
+        if current_spec is not None
+        else None
+    )
+    plan = authorization.get("plan")
+    if not isinstance(plan, dict) or not SHA256_RE.fullmatch(str(plan.get("plan_digest"))):
+        raise BundleError("authorization.plan is invalid")
+    config = authorization.get("workspace_config")
+    if not isinstance(config, dict) or not isinstance(config.get("path"), str):
+        raise BundleError("authorization.workspace_config is invalid")
+    if mode == "upgrade":
+        if (
+            set(config) != {"path", "expected_sha256"}
+            or not SHA256_RE.fullmatch(str(config.get("expected_sha256")))
+        ):
+            raise BundleError("authorization.workspace_config is invalid")
+        recomputed = create_structural_plan(
+            target_root=root,
+            workspace_config_path=_kernel().safe_repo_path(root, config["path"]),
+            expected_config_sha256=config["expected_sha256"],
+            candidate=candidate,
+            desired_components=plan.get("desired_components", []),
+            current=current,
+            current_components=plan.get("current_components", []),
+        )
+    else:
+        if (
+            set(config) != {"path", "expected_sha256", "input_path", "intended"}
+            or not SHA256_RE.fullmatch(str(config.get("expected_sha256")))
+            or not isinstance(config.get("input_path"), str)
+            or not Path(config["input_path"]).is_absolute()
+        ):
+            raise BundleError("authorization.workspace_config is invalid")
+        input_path = Path(config["input_path"])
+        try:
+            input_bytes, _metadata = read_regular_file_snapshot(
+                input_path, subject="workspace configuration input"
+            )
+            if sha256_bytes(input_bytes) != config["expected_sha256"]:
+                raise BundleError("workspace configuration input became stale")
+            parsed = validate_workspace_config(
+                strict_json_loads(input_bytes.decode("utf-8"), source=str(input_path)),
+                known_runtime_ids=sorted(candidate.runtimes),
+            )
+        except (OSError, UnicodeError, WorkspaceConfigError) as exc:
+            raise BundleError(str(exc)) from exc
+        if parsed != config["intended"]:
+            raise BundleError("workspace configuration input no longer matches intent")
+        recomputed = create_initial_structural_plan(
+            target_root=root,
+            workspace_config=parsed,
+            candidate=candidate,
+            desired_components=plan.get("desired_components", []),
+        )
+    if recomputed != plan:
+        raise BundleError("materialization structural plan is stale or invalid")
+    _validate_installed_state(root, current, recomputed)
+    changes = _expected_changes(
+        root,
+        candidate=candidate,
+        plan=recomputed,
+        workspace_config_relative=config["path"],
+    )
+    return candidate, current, recomputed, changes
+
+
+def validate_materialization_proposal_shape(
+    root: Path, document: dict[str, Any]
+) -> tuple[str, datetime]:
+    kernel = _kernel()
+    required = {
+        "schema_version", "workflow", "operation", "created_at", "proposal_id",
+        "changes", "authorization", "source_hashes", "source_git_head",
+        "invariants", "proposal_digest",
+    }
+    if set(document) != required or document.get("operation") != MATERIALIZE_OPERATION:
+        raise BundleError("materialization proposal has an invalid top-level shape")
+    if document.get("invariants") != MATERIALIZE_INVARIANTS:
+        raise BundleError("materialization proposal invariants are invalid")
+    created_at = kernel.parse_now(kernel.ensure_text(document.get("created_at"), "created_at"))
+    candidate, _current, plan, expected_changes = _materialization_context(root, document)
+    changes = document.get("changes")
+    if changes != expected_changes:
+        raise BundleError("materialization changes are stale or invalid")
+    for index, change in enumerate(changes):
+        if not isinstance(change, dict) or set(change) != MATERIALIZE_CHANGE_KEYS:
+            raise BundleError(f"materialization changes[{index}] has an invalid shape")
+        if set(change["authorization"]) != CHANGE_AUTHORIZATION_KEYS:
+            raise BundleError(f"materialization authorization is invalid: {change['path']}")
+        content_ref = change.get("content_ref")
+        if content_ref is not None and (
+            not isinstance(content_ref, dict) or set(content_ref) != CONTENT_REF_KEYS
+        ):
+            raise BundleError(f"materialization content reference is invalid: {change['path']}")
+    expected_recovery = {
+        change["path"]: {
+            "action": change["action"],
+            "owner": change["authorization"]["owner"],
+            "policy": change["authorization"]["policy"],
+        }
+        for change in changes
+    }
+    if document["authorization"].get("recovery_policy") != expected_recovery:
+        raise BundleError("materialization recovery policy is invalid")
+    config = document["authorization"]["workspace_config"]
+    config_source = (
+        config["input_path"]
+        if document["authorization"]["mode"] == "compose"
+        else str(_kernel().safe_repo_path(root, config["path"]))
+    )
+    expected_sources = {
+        str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes()),
+        config_source: config["expected_sha256"],
+    }
+    current_spec = document["authorization"].get("current")
+    if current_spec is not None:
+        expected_sources[current_spec["lock"]] = sha256_bytes(Path(current_spec["lock"]).read_bytes())
+    if document.get("source_hashes") != dict(sorted(expected_sources.items())):
+        raise BundleError("materialization source hashes are stale or invalid")
+    return MATERIALIZE_OPERATION, created_at
+
+
+def validate_materialization_preflight(root: Path, document: dict[str, Any]) -> None:
+    kernel = _kernel()
+    if document.get("source_git_head") != kernel.git_head(root):
+        raise BundleError("refusing stale materialization proposal; git HEAD changed")
+    validate_materialization_proposal_shape(root, document)
+
+
+def materialization_payloads(root: Path, document: dict[str, Any]) -> dict[str, bytes]:
+    candidate, _current, _plan, changes = _materialization_context(root, document)
+    payloads: dict[str, bytes] = {}
+    for change in changes:
+        if change["action"] != "write":
+            continue
+        reference = change["content_ref"]
+        if reference["kind"] == "inline":
+            payload = reference["text"].encode("utf-8")
+        else:
+            relative = reference["path"]
+            record = candidate.records.get(relative)
+            if record is None:
+                raise BundleError(f"candidate source record is missing: {relative}")
+            source = candidate.root.joinpath(*Path(relative).parts)
+            payload, _metadata = read_regular_file_snapshot(
+                source, subject=f"candidate source {relative}"
+            )
+            if (
+                len(payload) != record["size"]
+                or sha256_bytes(payload) != record["sha256_raw"]
+            ):
+                raise BundleError(f"candidate source changed during materialization: {relative}")
+        if sha256_bytes(payload) != change["after_raw_sha256"]:
+            raise BundleError(f"materialization payload hash is invalid: {change['path']}")
+        payloads[change["path"]] = payload
+    return payloads

--- a/contextos/materializer.py
+++ b/contextos/materializer.py
@@ -129,8 +129,8 @@ def _target_path(root: Path, relative: str) -> Path:
 
 def _workspace_config_relative(root: Path, path: Path) -> str:
     try:
-        relative = path.absolute().relative_to(root).as_posix()
-    except ValueError as exc:
+        relative = path.absolute().resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError) as exc:
         raise BundleError("workspace_config_path: must remain inside target_root") from exc
     if relative != "contextos.workspace.json":
         raise BundleError(

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -90,13 +90,67 @@ user file already present at a seed path first introduced by the candidate. The
 candidate, current source, and destination must be explicit local paths, and
 source roots must be separate from the destination.
 
-Planning never writes. Export, materializing add/remove/upgrade, installed-lock
-state, second pre-mutation checks, transaction journals, receipts, and rollback
-belong to the materializer layer tracked separately in issue #72. Until that
-layer exists, a structural plan is review evidence, not authorization to copy or
-delete files. The materializer must bind this exact `plan_digest` inside the
-existing kernel proposal/transaction contract; the plan is not a second apply
-protocol.
+Planning never writes. Materialization turns that exact `plan_digest` into a
+reviewable proposal and uses the existing kernel transaction engine; it is not a
+second apply protocol. Proposal creation writes only ignored local evidence.
+Apply re-verifies candidate and current bundle bytes, the workspace input, the
+plan, every destination snapshot, and every payload before the first target
+mutation. Binary files remain byte-exact. The journal, receipt, rollback, and
+process-recovery behavior is shared with workspace and agent transactions.
+
+## Materializing a clean workspace
+
+Prepare a canonical workspace JSON file whose template name and version match
+the pinned candidate. The target directory must already exist, but its tracked
+configuration does not. Existing seed paths remain user-owned; an existing
+managed path is a collision and fails closed.
+
+```bash
+bash scripts/contextos.sh bundle compose \
+  --lock /path/to/contextos.bundle.lock.json \
+  --source /path/to/extracted-bundle \
+  --expect-sha256 <candidate-bundle-digest> \
+  --target /path/to/empty-target \
+  --workspace-config /path/to/empty-target/contextos.workspace.json \
+  --workspace-config-input /path/to/reviewed-workspace.json \
+  --expect-config-sha256 <workspace-input-raw-digest> \
+  --components core,codex-adapter
+
+bash scripts/contextos.sh bundle apply \
+  --target /path/to/empty-target \
+  --proposal .context-os/proposals/<proposal-id>.json \
+  --confirm <proposal-digest>
+```
+
+The explicit `bundle apply --target` route exists because a clean destination
+has no tracked marker for ordinary root discovery until the approved transaction
+publishes it.
+
+## Materializing an upgrade
+
+`bundle propose` consumes the exact current configuration and, when applicable,
+a verified current bundle plus the component closure actually installed. It can
+then add, replace, and remove pristine managed paths while preserving seeds.
+
+```bash
+bash scripts/contextos.sh bundle propose \
+  --lock /path/to/new/contextos.bundle.lock.json \
+  --source /path/to/new/extracted-bundle \
+  --expect-sha256 <candidate-bundle-digest> \
+  --target /path/to/workspace \
+  --workspace-config /path/to/workspace/contextos.workspace.json \
+  --expect-config-sha256 <current-config-raw-digest> \
+  --components core,codex-adapter \
+  --current-lock /path/to/old/contextos.bundle.lock.json \
+  --current-source /path/to/old/extracted-bundle \
+  --expect-current-sha256 <current-bundle-digest> \
+  --current-components core,codex-adapter
+```
+
+After confirmation, use either ordinary `apply` from a discoverable workspace
+or `bundle apply --target`. Successful materialization writes
+`.context-os/installed-bundle.json`, binding bundle identity, component closure,
+and plan digest without making local installation state tracked content.
 
 Protocol version 1 also fixes three boundaries for that materializer:
 
@@ -106,6 +160,6 @@ Protocol version 1 also fixes three boundaries for that materializer:
 - component ownership and managed/seed policy are immutable between ordinary
   upgrades; changing either requires a future signed migration contract and
   protocol version; and
-- `contextos.workspace.json` is an existing, digest-bound planner input. Fresh
-  workspace creation must establish it through the existing workspace-setup
-  transaction before bundle planning, rather than adding an unplanned write.
+- `contextos.workspace.json` is a digest-bound planner input during upgrades.
+  Fresh composition instead binds a separately reviewed input and publishes the
+  canonical tracked configuration inside the same materialization transaction.

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -212,7 +212,10 @@ class MaterializerTest(unittest.TestCase):
         def fail_after_binary_replace(source: Path, destination: Path):
             nonlocal publications, injected
             result = original_publish(source, destination)
-            if destination.is_relative_to(self.target) and ".context-os" not in destination.parts:
+            if (
+                destination.is_relative_to(self.target.resolve())
+                and ".context-os" not in destination.parts
+            ):
                 publications += 1
                 if destination.name == "managed.bin" and not injected:
                     injected = True

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+from contextos.bundle_schema import BundleError
+from contextos.kernel import (
+    ContextOSError,
+    _recover_pending_agent_journals,
+    apply_proposal,
+)
+from contextos.materializer import (
+    INSTALLED_STATE_PATH,
+    create_composition_proposal,
+    create_materialization_proposal,
+)
+try:
+    from tests.test_bundle_lock import BundleFixture, workspace
+except ModuleNotFoundError:
+    from test_bundle_lock import BundleFixture, workspace
+
+
+NOW = datetime(2026, 8, 28, 18, 0, tzinfo=timezone.utc)
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class MaterializerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        current_root = self.root / "current-source"
+        candidate_root = self.root / "candidate-source"
+        current_root.mkdir()
+        candidate_root.mkdir()
+        self.current_fixture = BundleFixture(
+            current_root,
+            version="1.0.0",
+            managed=b"binary\x00v1\n",
+            addon=False,
+        )
+        self.candidate_fixture = BundleFixture(
+            candidate_root,
+            version="2.0.0",
+            managed=b"binary\x00v2\n",
+            addon=True,
+        )
+        self.current = self.current_fixture.verify(role="current")
+        self.candidate = self.candidate_fixture.verify()
+        self.target = self.root / "target"
+        shutil.copytree(current_root, self.target)
+        (self.target / "seed.txt").write_text("personal seed\n", encoding="utf-8")
+        self.config = self.target / "contextos.workspace.json"
+        self.config.write_text(
+            json.dumps(workspace("fixture-template", "1.0.0"), indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def propose(self):
+        return create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=self.candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+
+    def composition_input(self) -> tuple[Path, Path]:
+        target = self.root / "clean-target"
+        target.mkdir()
+        config_input = self.root / "compose-workspace.json"
+        config_input.write_text(
+            json.dumps(workspace("fixture-template", "2.0.0"), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return target, config_input
+
+    def compose(self, target: Path, config_input: Path):
+        return create_composition_proposal(
+            target_root=target,
+            workspace_config_path=target / "contextos.workspace.json",
+            workspace_config_input_path=config_input,
+            expected_config_input_sha256=digest(config_input),
+            candidate=self.candidate,
+            desired_components=["addon"],
+            now=NOW,
+        )
+
+    def test_clean_composition_installs_config_binary_components_and_state(self) -> None:
+        target, config_input = self.composition_input()
+        (target / "seed.txt").write_text("personal seed\n", encoding="utf-8")
+        proposal_path, proposal = self.compose(target, config_input)
+
+        _receipt_path, receipt = apply_proposal(
+            target, proposal_path, proposal["proposal_digest"], "generic"
+        )
+
+        self.assertEqual(b"binary\x00v2\n", (target / "managed.bin").read_bytes())
+        self.assertEqual("addon 2.0.0\n", (target / "addon.txt").read_text())
+        self.assertEqual("personal seed\n", (target / "seed.txt").read_text())
+        self.assertEqual(
+            workspace("fixture-template", "2.0.0"),
+            json.loads((target / "contextos.workspace.json").read_text()),
+        )
+        self.assertEqual("compose", proposal["authorization"]["mode"])
+        self.assertEqual("component-materialize", receipt["operation"])
+
+    def test_clean_composition_rejects_managed_collision(self) -> None:
+        target, config_input = self.composition_input()
+        (target / "managed.bin").write_bytes(b"local\n")
+        with self.assertRaisesRegex(BundleError, "collides with a planned add"):
+            self.compose(target, config_input)
+
+    def test_clean_composition_input_drift_fails_without_target_writes(self) -> None:
+        target, config_input = self.composition_input()
+        proposal_path, proposal = self.compose(target, config_input)
+        config_input.write_text("{}\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(BundleError, "became stale"):
+            apply_proposal(
+                target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+
+        self.assertFalse((target / "managed.bin").exists())
+        self.assertFalse((target / "contextos.workspace.json").exists())
+
+    def test_binary_upgrade_add_and_installed_state_use_shared_apply(self) -> None:
+        proposal_path, proposal = self.propose()
+        receipt_path, receipt = apply_proposal(
+            self.target, proposal_path, proposal["proposal_digest"], "generic"
+        )
+
+        self.assertEqual(b"binary\x00v2\n", (self.target / "managed.bin").read_bytes())
+        self.assertEqual("addon 2.0.0\n", (self.target / "addon.txt").read_text())
+        self.assertEqual("personal seed\n", (self.target / "seed.txt").read_text())
+        config = json.loads(self.config.read_text(encoding="utf-8"))
+        self.assertEqual("2.0.0", config["template"]["version"])
+        installed = json.loads(
+            (self.target / INSTALLED_STATE_PATH).read_text(encoding="utf-8")
+        )
+        self.assertEqual(self.candidate.digest, installed["bundle"]["sha256"])
+        self.assertEqual(["core", "addon"], installed["components"])
+        self.assertEqual(
+            proposal["authorization"]["plan"]["plan_digest"],
+            installed["plan_digest"],
+        )
+        self.assertTrue(receipt_path.is_file())
+        self.assertEqual("component-materialize", receipt["operation"])
+        self.assertEqual(proposal["invariants"], receipt["invariants_checked"])
+
+    def test_candidate_drift_after_proposal_fails_without_target_writes(self) -> None:
+        proposal_path, proposal = self.propose()
+        before = {
+            path.relative_to(self.target).as_posix(): path.read_bytes()
+            for path in self.target.rglob("*")
+            if path.is_file() and ".context-os" not in path.parts
+        }
+        (self.candidate.root / "managed.bin").write_bytes(b"tampered\n")
+        with self.assertRaisesRegex((BundleError, ContextOSError), "raw bytes"):
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+        after = {
+            path.relative_to(self.target).as_posix(): path.read_bytes()
+            for path in self.target.rglob("*")
+            if path.is_file() and ".context-os" not in path.parts
+        }
+        self.assertEqual(before, after)
+
+    def test_failure_after_first_publication_rolls_back_binary_and_add(self) -> None:
+        proposal_path, proposal = self.propose()
+        original_publish = __import__(
+            "contextos.kernel", fromlist=["_publish_exclusive"]
+        )._publish_exclusive
+        publications = 0
+
+        def fail_after_first(source: Path, destination: Path):
+            nonlocal publications
+            result = original_publish(source, destination)
+            if destination.is_relative_to(self.target) and ".context-os" not in destination.parts:
+                publications += 1
+                if publications == 1:
+                    raise OSError("injected materialization failure")
+            return result
+
+        with mock.patch(
+            "contextos.kernel._publish_exclusive", side_effect=fail_after_first
+        ), self.assertRaisesRegex(ContextOSError, "rolled back"):
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+        self.assertEqual(b"binary\x00v1\n", (self.target / "managed.bin").read_bytes())
+        self.assertFalse((self.target / "addon.txt").exists())
+        self.assertEqual("1.0.0", json.loads(self.config.read_text())["template"]["version"])
+        self.assertFalse((self.target / INSTALLED_STATE_PATH).exists())
+
+    def test_materialized_component_removal_preserves_seed_and_local_state(self) -> None:
+        proposal_path, proposal = self.propose()
+        apply_proposal(
+            self.target, proposal_path, proposal["proposal_digest"], "generic"
+        )
+        next_root = self.root / "next-source"
+        next_root.mkdir()
+        next_fixture = BundleFixture(
+            next_root,
+            version="3.0.0",
+            managed=b"binary\x00v3\n",
+            addon=False,
+        )
+        next_candidate = next_fixture.verify()
+        current = self.candidate_fixture.verify(role="current")
+        next_path, next_proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=next_candidate,
+            desired_components=["core"],
+            current=current,
+            current_components=["addon"],
+            now=NOW.replace(minute=1),
+        )
+        apply_proposal(
+            self.target,
+            next_path,
+            next_proposal["proposal_digest"],
+            "generic",
+        )
+        self.assertFalse((self.target / "addon.txt").exists())
+        self.assertEqual(b"binary\x00v3\n", (self.target / "managed.bin").read_bytes())
+        self.assertEqual("personal seed\n", (self.target / "seed.txt").read_text())
+        installed = json.loads(
+            (self.target / INSTALLED_STATE_PATH).read_text(encoding="utf-8")
+        )
+        self.assertEqual(["core"], installed["components"])
+        self.assertEqual("3.0.0", installed["bundle"]["version"])
+
+    def test_upgrade_rejects_installed_state_that_contradicts_current_components(self) -> None:
+        proposal_path, proposal = self.propose()
+        apply_proposal(
+            self.target, proposal_path, proposal["proposal_digest"], "generic"
+        )
+        state_path = self.target / INSTALLED_STATE_PATH
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["components"] = ["core"]
+        state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(BundleError, "contradicts current_components"):
+            create_materialization_proposal(
+                target_root=self.target,
+                workspace_config_path=self.config,
+                expected_config_sha256=digest(self.config),
+                candidate=self.candidate_fixture.verify(),
+                desired_components=["addon"],
+                current=self.candidate_fixture.verify(role="current"),
+                current_components=["addon"],
+                now=NOW.replace(minute=2),
+            )
+
+    def test_committed_materialization_journal_recovers_without_source_policy_widening(self) -> None:
+        proposal_path, proposal = self.propose()
+        with mock.patch(
+            "contextos.kernel._discard_agent_journal",
+            side_effect=OSError("retain committed journal"),
+        ):
+            receipt_path, _receipt = apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+        journal = self.target / ".context-os/journals" / proposal["proposal_id"]
+        self.assertTrue(receipt_path.is_file())
+        self.assertTrue(journal.is_dir())
+
+        _recover_pending_agent_journals(self.target)
+
+        self.assertFalse(journal.exists())
+        self.assertEqual(b"binary\x00v2\n", (self.target / "managed.bin").read_bytes())

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import tempfile
 import unittest
@@ -123,6 +124,27 @@ class MaterializerTest(unittest.TestCase):
         with self.assertRaisesRegex(BundleError, "collides with a planned add"):
             self.compose(target, config_input)
 
+    def test_clean_composition_requires_the_canonical_workspace_marker(self) -> None:
+        target, config_input = self.composition_input()
+        with self.assertRaisesRegex(BundleError, "must equal target_root"):
+            create_composition_proposal(
+                target_root=target,
+                workspace_config_path=target / "notes/workspace.json",
+                workspace_config_input_path=config_input,
+                expected_config_input_sha256=digest(config_input),
+                candidate=self.candidate,
+                desired_components=["addon"],
+                now=NOW,
+            )
+
+    def test_clean_composition_rejects_stale_installed_state_during_proposal(self) -> None:
+        target, config_input = self.composition_input()
+        state_path = target / INSTALLED_STATE_PATH
+        state_path.parent.mkdir()
+        state_path.write_text("{}\n", encoding="utf-8")
+        with self.assertRaisesRegex(BundleError, "explicit current bundle"):
+            self.compose(target, config_input)
+
     def test_clean_composition_input_drift_fails_without_target_writes(self) -> None:
         target, config_input = self.composition_input()
         proposal_path, proposal = self.compose(target, config_input)
@@ -179,24 +201,26 @@ class MaterializerTest(unittest.TestCase):
         }
         self.assertEqual(before, after)
 
-    def test_failure_after_first_publication_rolls_back_binary_and_add(self) -> None:
+    def test_failure_after_binary_publication_rolls_back_replace_and_add(self) -> None:
         proposal_path, proposal = self.propose()
         original_publish = __import__(
             "contextos.kernel", fromlist=["_publish_exclusive"]
         )._publish_exclusive
         publications = 0
+        injected = False
 
-        def fail_after_first(source: Path, destination: Path):
-            nonlocal publications
+        def fail_after_binary_replace(source: Path, destination: Path):
+            nonlocal publications, injected
             result = original_publish(source, destination)
             if destination.is_relative_to(self.target) and ".context-os" not in destination.parts:
                 publications += 1
-                if publications == 1:
+                if destination.name == "managed.bin" and not injected:
+                    injected = True
                     raise OSError("injected materialization failure")
             return result
 
         with mock.patch(
-            "contextos.kernel._publish_exclusive", side_effect=fail_after_first
+            "contextos.kernel._publish_exclusive", side_effect=fail_after_binary_replace
         ), self.assertRaisesRegex(ContextOSError, "rolled back"):
             apply_proposal(
                 self.target, proposal_path, proposal["proposal_digest"], "generic"
@@ -205,6 +229,7 @@ class MaterializerTest(unittest.TestCase):
         self.assertFalse((self.target / "addon.txt").exists())
         self.assertEqual("1.0.0", json.loads(self.config.read_text())["template"]["version"])
         self.assertFalse((self.target / INSTALLED_STATE_PATH).exists())
+        self.assertGreater(publications, 1)
 
     def test_materialized_component_removal_preserves_seed_and_local_state(self) -> None:
         proposal_path, proposal = self.propose()
@@ -267,6 +292,24 @@ class MaterializerTest(unittest.TestCase):
                 current_components=["addon"],
                 now=NOW.replace(minute=2),
             )
+
+    @unittest.skipUnless(os.name == "nt", "Windows case alias control")
+    def test_upgrade_normalizes_case_aliased_config_source_key(self) -> None:
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=Path(str(self.target).lower()),
+            workspace_config_path=Path(str(self.config).lower()),
+            expected_config_sha256=digest(self.config),
+            candidate=self.candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+
+        apply_proposal(
+            self.target, proposal_path, proposal["proposal_digest"], "generic"
+        )
+        self.assertEqual(b"binary\x00v2\n", (self.target / "managed.bin").read_bytes())
 
     def test_committed_materialization_journal_recovers_without_source_policy_widening(self) -> None:
         proposal_path, proposal = self.propose()


### PR DESCRIPTION
Closes #72.

## Summary

- add digest-bound clean composition and add/remove/upgrade materialization for verified offline component bundles
- publish binary and text payloads through the existing proposal, journal, receipt, rollback, and recovery engine
- preserve seed content, reject dirty/unowned collisions, bind installed-bundle state, and publish canonical workspace configuration in the clean-install transaction
- add explicit `bundle compose`, `bundle propose`, and materialization-only `bundle apply --target` CLI paths
- document the workflow and register the new implementation/tests in the component manifest

## Validation

- `scripts/validate-all.sh`: passed
- 458 Python tests passed, 36 platform skips
- portability, hooks, integration catalog, component manifest, bundle schema, runtime registry, workspace configuration, links, docs reachability, and JSON checks passed

## Cross-model review

- Claude `claude-opus-5`, exact SHA `47bf1a50dfd0d6c61d1821411efc261b115b086f`: core safety invariants hold; optional `git-index` payload mismatch deferred as #104 after the three-cycle repair budget
- Hermes `nvidia/nemotron-3-ultra-550b-a55b:free`, exact SHA `47bf1a50dfd0d6c61d1821411efc261b115b086f`: CLEAN
- OpenRouter live endpoint pricing for the Hermes model was confirmed at zero prompt and completion cost before review

Repair cycle 1 fixed path normalization across case/symlink aliases, enforced the canonical root marker, made stale installed state fail during proposal creation, constrained the explicit-target apply route, and strengthened binary rollback coverage.
Repair cycles 2–3 fixed Windows 8.3/long-name and ancestor-alias identity symmetry in both proposal creation and apply. The default/documented `directory` materialization mode is fully covered; #104 tracks sourcing index blobs for the optional `git-index` materialization mode, which currently fails closed before writes when working-tree bytes differ.
