### PR TITLE
Fix Git-index materialization payload consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- Git-index materialization now stages the exact index blobs verified against
+  the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
+  unrelated unstaged source edits cannot replace or invalidate approved bytes.
 - Skill validation now prunes ignored Context OS state and dependency
   `node_modules` trees while retaining strict checks for repository skill
   directories, so installed-runtime conformance cannot poison the contributor

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -76,6 +76,7 @@ class VerifiedBundle:
     manifest: dict[str, Any]
     runtimes: dict[str, dict[str, Any]]
     records: dict[str, dict[str, Any]]
+    verified_bytes: dict[str, bytes]
 
     @property
     def digest(self) -> str:
@@ -592,6 +593,7 @@ def verify_bundle(
         root=root, lock_path=lock_path, source_mode=source_mode, role=role,
         mode_verified=(source_mode == "git-index" or os.name != "nt"), lock=lock,
         manifest=manifest, runtimes=runtimes, records=records,
+        verified_bytes=verified_bytes,
     )
 
 

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -312,6 +312,8 @@ def _bundle_main(args: argparse.Namespace) -> int:
             "proposal_id": proposal["proposal_id"],
             "proposal_digest": proposal["proposal_digest"],
             "plan_digest": proposal["authorization"]["plan"]["plan_digest"],
+            "source_mode": candidate.source_mode,
+            "source_git_commit": candidate.lock["bundle"]["source_git_commit"],
             "changes": [
                 {
                     "action": change["action"],
@@ -344,6 +346,8 @@ def _bundle_main(args: argparse.Namespace) -> int:
             "proposal_id": proposal["proposal_id"],
             "proposal_digest": proposal["proposal_digest"],
             "plan_digest": proposal["authorization"]["plan"]["plan_digest"],
+            "source_mode": candidate.source_mode,
+            "source_git_commit": candidate.lock["bundle"]["source_git_commit"],
             "changes": [
                 {
                     "action": change["action"],

--- a/contextos/materializer.py
+++ b/contextos/materializer.py
@@ -654,15 +654,14 @@ def materialization_payloads(root: Path, document: dict[str, Any]) -> dict[str, 
             record = candidate.records.get(relative)
             if record is None:
                 raise BundleError(f"candidate source record is missing: {relative}")
-            source = candidate.root.joinpath(*Path(relative).parts)
-            payload, _metadata = read_regular_file_snapshot(
-                source, subject=f"candidate source {relative}"
-            )
+            payload = candidate.verified_bytes.get(relative)
+            if payload is None:
+                raise BundleError(f"candidate verified payload is missing: {relative}")
             if (
                 len(payload) != record["size"]
                 or sha256_bytes(payload) != record["sha256_raw"]
             ):
-                raise BundleError(f"candidate source changed during materialization: {relative}")
+                raise BundleError(f"candidate verified payload is invalid: {relative}")
         if sha256_bytes(payload) != change["after_raw_sha256"]:
             raise BundleError(f"materialization payload hash is invalid: {change['path']}")
         payloads[change["path"]] = payload

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -98,6 +98,16 @@ plan, every destination snapshot, and every payload before the first target
 mutation. Binary files remain byte-exact. The journal, receipt, rollback, and
 process-recovery behavior is shared with workspace and agent transactions.
 
+When `--source-mode git-index` is selected, compose, propose, and apply use the
+exact blobs in the trusted local Git index. Checkout newline conversion,
+clean/smudge filters, and unstaged working-tree edits are deliberately ignored;
+the CLI reports the source mode and bound Git commit so this is visible during
+review. A new commit between proposal and apply invalidates the proposal before
+target mutation. The warning against received or untrusted `.git` directories
+applies to materialization as well as `bundle check`. On Windows, Git-index
+source modes are verified, but the materialized target cannot preserve a POSIX
+executable bit; the plan records that destination limitation explicitly.
+
 ## Materializing a clean workspace
 
 Prepare a canonical workspace JSON file whose template name and version match

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -27,6 +27,7 @@ from contextos.kernel import git_head
 from contextos.primitives import (
     SnapshotError,
     canonical_json as primitive_canonical_json,
+    git_environment,
     git_repository_identity,
 )
 
@@ -53,6 +54,16 @@ def workspace(source: str, version: str) -> dict:
 
 
 class BundleFixture:
+    def _git(self, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.run(
+            ["git", *arguments], cwd=self.root, check=True,
+            capture_output=True, env=git_environment(),
+        )
+
+    def commit_all(self, message: str) -> None:
+        self._git("add", "--all")
+        self._git("commit", "--quiet", "-m", message)
+
     def __init__(
         self, root: Path, *, version: str, managed: bytes, addon: bool,
         runtime_addon: bool | None = None, include_seed: bool = True,
@@ -110,37 +121,14 @@ class BundleFixture:
         )
         self.source_mode = source_mode
         if source_mode == "git-index":
-            subprocess.run(
-                ["git", "init", "--quiet"], cwd=root, check=True,
-                capture_output=True,
+            self._git("init", "--quiet")
+            self._git("config", "user.email", "fixture@example.invalid")
+            self._git("config", "user.name", "Bundle Fixture")
+            self._git("config", "core.autocrlf", "false")
+            self._git(
+                "config", "core.excludesFile", str(root / ".git/info/exclude")
             )
-            subprocess.run(
-                ["git", "config", "user.email", "fixture@example.invalid"],
-                cwd=root, check=True, capture_output=True,
-            )
-            subprocess.run(
-                ["git", "config", "user.name", "Bundle Fixture"],
-                cwd=root, check=True, capture_output=True,
-            )
-            subprocess.run(
-                ["git", "config", "core.autocrlf", "false"],
-                cwd=root, check=True, capture_output=True,
-            )
-            subprocess.run(
-                [
-                    "git", "config", "core.excludesFile",
-                    str(root / ".git/info/exclude"),
-                ],
-                cwd=root, check=True, capture_output=True,
-            )
-            subprocess.run(
-                ["git", "add", "--all"],
-                cwd=root, check=True, capture_output=True,
-            )
-            subprocess.run(
-                ["git", "commit", "--quiet", "-m", "fixture"], cwd=root,
-                check=True, capture_output=True,
-            )
+            self.commit_all("fixture")
         self.lock = create_bundle_lock(
             root, name="fixture-template", version=version, source_mode=source_mode
         )

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -56,7 +56,7 @@ class BundleFixture:
     def __init__(
         self, root: Path, *, version: str, managed: bytes, addon: bool,
         runtime_addon: bool | None = None, include_seed: bool = True,
-        addon_policy: str = "managed",
+        addon_policy: str = "managed", source_mode: str = "directory",
     ) -> None:
         self.root = root
         (root / "components").mkdir(parents=True)
@@ -108,8 +108,41 @@ class BundleFixture:
         (root / "components/manifest.json").write_text(
             json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
         )
+        self.source_mode = source_mode
+        if source_mode == "git-index":
+            subprocess.run(
+                ["git", "init", "--quiet"], cwd=root, check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "fixture@example.invalid"],
+                cwd=root, check=True, capture_output=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Bundle Fixture"],
+                cwd=root, check=True, capture_output=True,
+            )
+            subprocess.run(
+                ["git", "config", "core.autocrlf", "false"],
+                cwd=root, check=True, capture_output=True,
+            )
+            subprocess.run(
+                [
+                    "git", "config", "core.excludesFile",
+                    str(root / ".git/info/exclude"),
+                ],
+                cwd=root, check=True, capture_output=True,
+            )
+            subprocess.run(
+                ["git", "add", "--all"],
+                cwd=root, check=True, capture_output=True,
+            )
+            subprocess.run(
+                ["git", "commit", "--quiet", "-m", "fixture"], cwd=root,
+                check=True, capture_output=True,
+            )
         self.lock = create_bundle_lock(
-            root, name="fixture-template", version=version, source_mode="directory"
+            root, name="fixture-template", version=version, source_mode=source_mode
         )
         self.lock_path = root.parent / f"lock-{version}.json"
         self.lock_path.write_text(json.dumps(self.lock, indent=2) + "\n", encoding="utf-8")
@@ -119,7 +152,7 @@ class BundleFixture:
             self.lock_path,
             self.root,
             expected_sha256=self.lock["bundle_sha256"],
-            source_mode="directory",
+            source_mode=self.source_mode,
             role=role,
         )
 

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import io
 import hashlib
 import json
 import os
 import shutil
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
 from contextos.bundle_schema import BundleError
+from contextos.cli import main as cli_main
 from contextos.kernel import (
     ContextOSError,
     _recover_pending_agent_journals,
@@ -88,6 +91,17 @@ class MaterializerTest(unittest.TestCase):
         )
         return target, config_input
 
+    def git_candidate(self, *, version: str, managed: bytes) -> BundleFixture:
+        source = self.root / f"git-candidate-{version}"
+        source.mkdir()
+        return BundleFixture(
+            source,
+            version=version,
+            managed=managed,
+            addon=True,
+            source_mode="git-index",
+        )
+
     def compose(self, target: Path, config_input: Path):
         return create_composition_proposal(
             target_root=target,
@@ -117,6 +131,113 @@ class MaterializerTest(unittest.TestCase):
         )
         self.assertEqual("compose", proposal["authorization"]["mode"])
         self.assertEqual("component-materialize", receipt["operation"])
+
+    def test_git_index_upgrade_uses_verified_blobs_not_smudged_worktree(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index binary\x00v3\n")
+        candidate = fixture.verify()
+        (fixture.root / "managed.bin").write_bytes(b"smudged working tree\r\n")
+        (fixture.root / "addon.txt").write_text(
+            "filtered working tree\n", encoding="utf-8"
+        )
+
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+        apply_proposal(
+            self.target, proposal_path, proposal["proposal_digest"], "generic"
+        )
+
+        self.assertEqual(b"index binary\x00v3\n", (self.target / "managed.bin").read_bytes())
+        self.assertEqual(
+            candidate.verified_bytes["addon.txt"],
+            (self.target / "addon.txt").read_bytes(),
+        )
+
+    def test_git_index_cli_compose_propose_and_apply_use_index_bytes(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index line\n")
+        (fixture.root / "managed.bin").write_bytes(b"index line\r\n")
+        target = self.root / "cli-compose-target"
+        target.mkdir()
+        config_input = self.root / "cli-compose-workspace.json"
+        config_input.write_text(
+            json.dumps(workspace("fixture-template", "3.0.0"), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        compose_output = io.StringIO()
+        with redirect_stdout(compose_output):
+            self.assertEqual(
+                0,
+                cli_main([
+                    "bundle", "compose",
+                    "--lock", str(fixture.lock_path),
+                    "--source", str(fixture.root),
+                    "--expect-sha256", fixture.lock["bundle_sha256"],
+                    "--source-mode", "git-index",
+                    "--target", str(target),
+                    "--workspace-config", str(target / "contextos.workspace.json"),
+                    "--workspace-config-input", str(config_input),
+                    "--expect-config-sha256", digest(config_input),
+                    "--components", "addon",
+                    "--now", NOW.isoformat(),
+                ]),
+            )
+        compose_report = json.loads(compose_output.getvalue())
+        apply_output = io.StringIO()
+        with redirect_stdout(apply_output):
+            self.assertEqual(
+                0,
+                cli_main([
+                    "bundle", "apply",
+                    "--target", str(target),
+                    "--proposal", compose_report["proposal"],
+                    "--confirm", compose_report["proposal_digest"],
+                ]),
+            )
+        self.assertEqual("component-materialize", json.loads(apply_output.getvalue())["operation"])
+        self.assertEqual(b"index line\n", (target / "managed.bin").read_bytes())
+
+        propose_output = io.StringIO()
+        with redirect_stdout(propose_output):
+            self.assertEqual(
+                0,
+                cli_main([
+                    "bundle", "propose",
+                    "--lock", str(fixture.lock_path),
+                    "--source", str(fixture.root),
+                    "--expect-sha256", fixture.lock["bundle_sha256"],
+                    "--source-mode", "git-index",
+                    "--target", str(self.target),
+                    "--workspace-config", str(self.config),
+                    "--expect-config-sha256", digest(self.config),
+                    "--components", "addon",
+                    "--current-lock", str(self.current_fixture.lock_path),
+                    "--current-source", str(self.current_fixture.root),
+                    "--expect-current-sha256", self.current_fixture.lock["bundle_sha256"],
+                    "--current-source-mode", "directory",
+                    "--current-components", "core",
+                    "--now", NOW.isoformat(),
+                ]),
+            )
+        self.assertTrue(json.loads(propose_output.getvalue())["proposal"].endswith(".json"))
+
+    def test_bundle_apply_rejects_non_materialization_proposal(self) -> None:
+        proposal = self.target / "not-materialization.json"
+        proposal.write_text('{"operation":"agent-config"}\n', encoding="utf-8")
+        errors = io.StringIO()
+        with redirect_stderr(errors):
+            status = cli_main([
+                "bundle", "apply", "--target", str(self.target),
+                "--proposal", str(proposal), "--confirm", "unused",
+            ])
+        self.assertEqual(2, status)
+        self.assertIn("only materialization proposals", errors.getvalue())
 
     def test_clean_composition_rejects_managed_collision(self) -> None:
         target, config_input = self.composition_input()

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -189,6 +189,11 @@ class MaterializerTest(unittest.TestCase):
                 ]),
             )
         compose_report = json.loads(compose_output.getvalue())
+        self.assertEqual("git-index", compose_report["source_mode"])
+        self.assertEqual(
+            fixture.lock["bundle"]["source_git_commit"],
+            compose_report["source_git_commit"],
+        )
         apply_output = io.StringIO()
         with redirect_stdout(apply_output):
             self.assertEqual(
@@ -225,7 +230,38 @@ class MaterializerTest(unittest.TestCase):
                     "--now", NOW.isoformat(),
                 ]),
             )
-        self.assertTrue(json.loads(propose_output.getvalue())["proposal"].endswith(".json"))
+        propose_report = json.loads(propose_output.getvalue())
+        self.assertTrue(propose_report["proposal"].endswith(".json"))
+        self.assertEqual("git-index", propose_report["source_mode"])
+        self.assertEqual(
+            fixture.lock["bundle"]["source_git_commit"],
+            propose_report["source_git_commit"],
+        )
+
+    def test_git_index_commit_after_proposal_fails_before_target_writes(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index v3\n")
+        candidate = fixture.verify()
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+        before = (self.target / "managed.bin").read_bytes()
+        (fixture.root / "managed.bin").write_bytes(b"committed v4\n")
+        fixture.commit_all("change source after proposal")
+
+        with self.assertRaisesRegex(BundleError, "does not match the local Git HEAD"):
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+
+        self.assertEqual(before, (self.target / "managed.bin").read_bytes())
+        self.assertFalse((self.target / "addon.txt").exists())
 
     def test_bundle_apply_rejects_non_materialization_proposal(self) -> None:
         proposal = self.target / "not-materialization.json"


### PR DESCRIPTION
﻿## What's in this PR

- retain the exact bytes verified by `verify_bundle`
- materialize those verified bytes for both directory and Git-index sources
- add CRLF, smudge-equivalent, unstaged-edit, compose, upgrade, and CLI regression controls

Closes #104.

## Verification

- `python -m unittest tests.test_materializer tests.test_bundle_lock` ? 44 tests passed, 3 skipped
- `bash scripts/validate-all.sh` ? 461 tests passed, 36 skipped; all repository gates passed

## Checklist

### Skills & commands
- [x] No skills or commands changed
- [x] Portable workflow boundaries remain unchanged

### Repo hygiene
- [x] No sensitive data committed
- [x] `CHANGELOG.md` updated
- [x] Local validation passes

## Exact-SHA review record

Final reviewed SHA: `a325044321965b53f0b7a0dd6ebfc7b01130d03f`

- Claude `claude-opus-5`: core byte-integrity fix is correct; no blocking finding. Repair cycle 1 added source-mode/commit disclosure, trusted-Git documentation, ambient-config isolation, and commit-after-proposal rejection coverage.
- Hermes `nvidia/nemotron-3-ultra-550b-a55b:free` (live prompt/completion price: zero): confirmed clean/smudge bypass and proposal digest binding. Its claim that CLI apply skips candidate verification was rejected after tracing `bundle apply -> apply_proposal -> _materialization_context -> _load_bundle_spec -> verify_bundle`; the new commit-after-proposal test exercises that exact path. Its Windows mode-report claim was also rejected because the Git-index branch explicitly performs the executable comparison on every host.
- Verified scaling concern: repeated whole-bundle Git verification and retained payload memory are tracked in #106 rather than expanding this correctness fix.
- Setup failure excluded: the first Claude invocation supplied no prompt because a variadic CLI flag consumed it; the corrected authenticated review completed.

Repair budget used: 1 of 3 cycles.
