### PR TITLE
Harden lifecycle readiness edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,8 @@
   `state/current.md`, protects shipped `[DATE]` placeholders, and controls
   missing-Git advisory behavior plus exact PowerShell child-exit propagation.
   Start and automatic session hooks also reject linked or reparse-point state
-  paths before reading them.
+  paths through stable no-follow snapshots, while doctor degrades concurrent
+  path changes to an unknown diagnostic instead of crashing.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
 - First-class Codex onboarding with a root `AGENTS.md`, four explicit-invocation lifecycle skills under `.agents/skills/`, generated skill UI metadata, `--agent codex` setup support, portability tests, and a host-boundary guide.
 
 ### Fixed
+- Lifecycle readiness now gives recovery-specific guidance for future-dated
+  `state/current.md`, protects shipped `[DATE]` placeholders, and controls
+  missing-Git advisory behavior plus exact PowerShell child-exit propagation.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@
 - Lifecycle readiness now gives recovery-specific guidance for future-dated
   `state/current.md`, protects shipped `[DATE]` placeholders, and controls
   missing-Git advisory behavior plus exact PowerShell child-exit propagation.
+  Start and automatic session hooks also reject linked or reparse-point state
+  paths before reading them.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3699,7 +3699,7 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     }
 
 
-def _is_initialized(workspace: Workspace, today: date | None = None) -> bool:
+def _is_initialized(freshness: dict[str, Any]) -> bool:
     """Single readiness predicate shared by start, doctor, and the session hook.
 
     Only current.md gates readiness. weekly-priorities.md and blockers.md are
@@ -3707,12 +3707,6 @@ def _is_initialized(workspace: Workspace, today: date | None = None) -> bool:
     requiring a real date on all three would report an initialized workspace as
     needing setup forever. Their freshness is still reported separately.
     """
-    current = workspace.state_dir / INITIALIZATION_FILE
-    freshness = _state_freshness(
-        current,
-        today if today is not None else utc_now().date(),
-        STATE_THRESHOLDS[INITIALIZATION_FILE],
-    )
     return freshness["freshness_status"] in {"fresh", "stale"}
 
 
@@ -3726,7 +3720,10 @@ def _initialization_state(
         state[relative_path(workspace.root, path)] = _state_freshness(
             path, today, threshold
         )
-    return _is_initialized(workspace, today), state
+    gate = relative_path(
+        workspace.root, workspace.state_dir / INITIALIZATION_FILE
+    )
+    return _is_initialized(state[gate]), state
 
 
 def _initialization_next_action(

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -105,6 +105,10 @@ SETUP_NEXT_ACTION = (
     "Run the explicit setup workflow (bash scripts/setup.sh, then the $context-setup "
     "skill) before starting a session."
 )
+FUTURE_DATE_NEXT_ACTION = (
+    "Check the system clock, then run the explicit setup workflow to replace the "
+    "future-dated **Last Updated:** value in state/current.md before starting a session."
+)
 class ContextOSError(RuntimeError):
     pass
 
@@ -3724,6 +3728,17 @@ def _initialization_state(
     return _is_initialized(workspace, today), state
 
 
+def _initialization_next_action(
+    workspace: Workspace, state: dict[str, dict[str, Any]]
+) -> str:
+    gate = relative_path(
+        workspace.root, workspace.state_dir / INITIALIZATION_FILE
+    )
+    if state[gate]["freshness_status"] == "future":
+        return FUTURE_DATE_NEXT_ACTION
+    return SETUP_NEXT_ACTION
+
+
 def start_report(root: Path, now: datetime) -> dict[str, Any]:
     workspace = load_workspace(root)
     initialized, files = _initialization_state(workspace, now.date())
@@ -3732,7 +3747,9 @@ def start_report(root: Path, now: datetime) -> dict[str, Any]:
         "schema_version": SCHEMA_VERSION,
         "generated_at": now.isoformat(),
         "initialized": initialized,
-        "next_action": None if initialized else SETUP_NEXT_ACTION,
+        "next_action": (
+            None if initialized else _initialization_next_action(workspace, files)
+        ),
         "state": files,
         "latest_session": relative_path(root, sessions[0]) if sessions else None,
         "task_file": relative_path(root, workspace.task_file),
@@ -4089,19 +4106,39 @@ def doctor(
             "pass" if initialized else "warn",
             "ready"
             if initialized
-            else f"guided setup required; {gate} carries no real **Last Updated:** date",
+            else (
+                f"recovery required; {gate} carries a future **Last Updated:** date; "
+                + _initialization_next_action(workspace, initialization_files)
+                if initialization_files[gate]["freshness_status"] == "future"
+                else f"guided setup required; {gate} carries no real **Last Updated:** date"
+            ),
         )
-        unresolved = [
+        future = [
             path
             for path, item in initialization_files.items()
-            if item["freshness_status"] in {"missing", "unknown", "future"}
+            if item["freshness_status"] == "future"
         ]
+        unusable = [
+            path
+            for path, item in initialization_files.items()
+            if item["freshness_status"] in {"missing", "unknown"}
+        ]
+        unresolved = future + unusable
+        freshness_details = []
+        if future:
+            freshness_details.append(
+                "future **Last Updated:** date in: " + ", ".join(future)
+            )
+        if unusable:
+            freshness_details.append(
+                "no usable **Last Updated:** date in: " + ", ".join(unusable)
+            )
         add(
             "state-freshness",
             "pass" if not unresolved else "warn",
             "all tracked state files carry a real date"
             if not unresolved
-            else f"no usable **Last Updated:** date in: {', '.join(unresolved)}",
+            else "; ".join(freshness_details),
         )
 
     local_hosts = {"schema_version": HOST_STATE_SCHEMA_VERSION, "hosts": {}}
@@ -4782,8 +4819,17 @@ def hook_report(root: Path, event: str, payload: dict[str, Any]) -> dict[str, An
     findings: list[dict[str, str]] = []
     workspace = load_workspace(root)
     if event == "session-start":
-        if not _is_initialized(workspace):
-            findings.append({"severity": "advisory", "message": f"Context OS is not initialized. {SETUP_NEXT_ACTION}"})
+        initialized, initialization_files = _initialization_state(
+            workspace, utc_now().date()
+        )
+        if not initialized:
+            findings.append({
+                "severity": "advisory",
+                "message": (
+                    "Context OS is not initialized. "
+                    + _initialization_next_action(workspace, initialization_files)
+                ),
+            })
         lock = root / ".context-os" / "apply.lock"
         if lock.exists():
             findings.append({"severity": "warning", "message": f"A lifecycle apply lock exists at {lock}. Run context-os doctor before writing."})

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3719,12 +3719,13 @@ def _is_initialized(workspace: Workspace, today: date | None = None) -> bool:
 def _initialization_state(
     workspace: Workspace, today: date
 ) -> tuple[bool, dict[str, dict[str, Any]]]:
-    state = {
-        relative_path(workspace.root, workspace.state_dir / filename): _state_freshness(
-            workspace.state_dir / filename, today, threshold
+    state: dict[str, dict[str, Any]] = {}
+    for filename, threshold in STATE_THRESHOLDS.items():
+        path = workspace.state_dir / filename
+        _guard_local_state_path(workspace.root, path)
+        state[relative_path(workspace.root, path)] = _state_freshness(
+            path, today, threshold
         )
-        for filename, threshold in STATE_THRESHOLDS.items()
-    }
     return _is_initialized(workspace, today), state
 
 
@@ -4815,12 +4816,18 @@ def _hook_targets(payload: dict[str, Any]) -> set[str]:
     return targets
 
 
-def hook_report(root: Path, event: str, payload: dict[str, Any]) -> dict[str, Any]:
+def hook_report(
+    root: Path,
+    event: str,
+    payload: dict[str, Any],
+    *,
+    today: date | None = None,
+) -> dict[str, Any]:
     findings: list[dict[str, str]] = []
     workspace = load_workspace(root)
     if event == "session-start":
         initialized, initialization_files = _initialization_state(
-            workspace, utc_now().date()
+            workspace, today if today is not None else utc_now().date()
         )
         if not initialized:
             findings.append({

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3667,19 +3667,33 @@ def render_hook_payload(
 def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     updated = None
     age = None
-    if path.exists():
+    exists = False
+    raw: bytes | None = None
+    try:
+        raw, _metadata = read_regular_file_snapshot(
+            path, subject=f"state freshness file {path.name}"
+        )
+        exists = True
+    except SnapshotError as exc:
+        if isinstance(exc.__cause__, FileNotFoundError):
+            exists = False
+        elif isinstance(exc.__cause__, PermissionError):
+            exists = True
+        else:
+            raise ContextOSError(str(exc)) from exc
+    if raw is not None:
         try:
-            match = LAST_UPDATED_RE.search(path.read_text(encoding="utf-8"))
+            match = LAST_UPDATED_RE.search(raw.decode("utf-8"))
             if match and REAL_DATE_RE.fullmatch(match.group(1).strip()):
                 candidate = match.group(1).strip()
                 parsed = datetime.strptime(candidate, "%Y-%m-%d").date()
                 updated = candidate
                 age = (today - parsed).days
-        except (OSError, UnicodeError, ValueError):
+        except (UnicodeError, ValueError):
             # Diagnostics and advisory hooks must report unreadable or invalid
             # state as unknown rather than crashing on the file they diagnose.
             pass
-    if not path.exists():
+    if not exists:
         status = "missing"
     elif age is None:
         status = "unknown"
@@ -3690,7 +3704,7 @@ def _state_freshness(path: Path, today: date, threshold: int) -> dict[str, Any]:
     else:
         status = "fresh"
     return {
-        "exists": path.exists(),
+        "exists": exists,
         "last_updated": updated,
         "age_days": age,
         "stale_after_days": threshold,
@@ -3711,15 +3725,26 @@ def _is_initialized(freshness: dict[str, Any]) -> bool:
 
 
 def _initialization_state(
-    workspace: Workspace, today: date
+    workspace: Workspace, today: date, *, tolerate_unsafe: bool = False
 ) -> tuple[bool, dict[str, dict[str, Any]]]:
     state: dict[str, dict[str, Any]] = {}
     for filename, threshold in STATE_THRESHOLDS.items():
         path = workspace.state_dir / filename
-        _guard_local_state_path(workspace.root, path)
-        state[relative_path(workspace.root, path)] = _state_freshness(
-            path, today, threshold
-        )
+        relative = relative_path(workspace.root, path)
+        try:
+            _guard_local_state_path(workspace.root, path)
+            state[relative] = _state_freshness(path, today, threshold)
+        except ContextOSError:
+            if not tolerate_unsafe:
+                raise
+            state[relative] = {
+                "exists": False,
+                "last_updated": None,
+                "age_days": None,
+                "stale_after_days": threshold,
+                "freshness_status": "unknown",
+                "stale": None,
+            }
     gate = relative_path(
         workspace.root, workspace.state_dir / INITIALIZATION_FILE
     )
@@ -4097,7 +4122,7 @@ def doctor(
         )
     else:
         initialized, initialization_files = _initialization_state(
-            workspace, effective_today
+            workspace, effective_today, tolerate_unsafe=True
         )
         add(
             "initialization-state",

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -78,6 +78,17 @@ fi
 printf '%s' "$SESSION_READY_OUTPUT" | grep -q 'Tip: Run /start' \
   || fail "Claude session-start omitted the initialized-state /start tip"
 
+# Missing Git is advisory for the legacy Claude adapter: root discovery falls
+# back to the current directory and the shared hook still runs.
+mkdir -p "$TEMP_ROOT/bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 127' > "$TEMP_ROOT/bin/git"
+chmod +x "$TEMP_ROOT/bin/git"
+SESSION_NO_GIT_OUTPUT=$(cd "$SESSION_REPO" && PATH="$TEMP_ROOT/bin:$PATH" \
+  bash .claude/hooks/session-start.sh)
+rm "$TEMP_ROOT/bin/git"
+printf '%s' "$SESSION_NO_GIT_OUTPUT" | grep -q 'Tip: Run /start' \
+  || fail "Claude session-start made Git a prerequisite instead of an advisory"
+
 printf '\377' > "$SESSION_REPO/workspace.yaml"
 SESSION_ENCODING_OUTPUT=$(cd "$SESSION_REPO" && bash .claude/hooks/session-start.sh)
 printf '%s' "$SESSION_ENCODING_OUTPUT" | grep -q 'advisory hook could not run' \

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -83,9 +83,14 @@ printf '%s' "$SESSION_READY_OUTPUT" | grep -q 'Tip: Run /start' \
 mkdir -p "$TEMP_ROOT/bin"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 127' > "$TEMP_ROOT/bin/git"
 chmod +x "$TEMP_ROOT/bin/git"
+set +e
 SESSION_NO_GIT_OUTPUT=$(cd "$SESSION_REPO" && PATH="$TEMP_ROOT/bin:$PATH" \
   bash .claude/hooks/session-start.sh)
+SESSION_NO_GIT_STATUS=$?
+set -e
 rm "$TEMP_ROOT/bin/git"
+[ "$SESSION_NO_GIT_STATUS" -eq 0 ] \
+  || fail "Claude session-start returned $SESSION_NO_GIT_STATUS when Git was absent"
 printf '%s' "$SESSION_NO_GIT_OUTPUT" | grep -q 'Tip: Run /start' \
   || fail "Claude session-start made Git a prerequisite instead of an advisory"
 

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1116,6 +1116,51 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
             with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
                 hook_report(self.root, "session-start", {}, today=NOW.date())
 
+    def test_readiness_snapshot_rejects_link_swap_after_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as external:
+            outside = Path(external) / "outside-current.md"
+            outside.write_text(
+                "# External\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
+            )
+            current = self.root / "state/current.md"
+            original_guard = __import__(
+                "contextos.kernel", fromlist=["_guard_local_state_path"]
+            )._guard_local_state_path
+            swapped = False
+
+            def swap_after_guard(root: Path, path: Path) -> None:
+                nonlocal swapped
+                original_guard(root, path)
+                if path == current and not swapped:
+                    current.unlink()
+                    current.symlink_to(outside)
+                    swapped = True
+
+            try:
+                with mock.patch(
+                    "contextos.kernel._guard_local_state_path",
+                    side_effect=swap_after_guard,
+                ):
+                    with self.assertRaisesRegex(ContextOSError, "link-like"):
+                        start_report(self.root, NOW)
+            except OSError:
+                self.skipTest("symlink creation is unavailable")
+
+    def test_doctor_degrades_snapshot_race_to_unknown(self) -> None:
+        with mock.patch(
+            "contextos.kernel._state_freshness",
+            side_effect=ContextOSError("state changed during snapshot"),
+        ):
+            report = doctor(self.root)
+        initialization = next(
+            item for item in report["checks"] if item["name"] == "initialization-state"
+        )
+        freshness = next(
+            item for item in report["checks"] if item["name"] == "state-freshness"
+        )
+        self.assertEqual("warn", initialization["status"])
+        self.assertEqual("warn", freshness["status"])
+
     def test_shipped_state_templates_retain_date_placeholders(self) -> None:
         for filename in ("current.md", "weekly-priorities.md", "blockers.md"):
             content = (ROOT / "state" / filename).read_text(encoding="utf-8")

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1074,7 +1074,10 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         self.assertIsNone(current["stale"])
         self.assertFalse(report["initialized"])
         messages = [
-            finding["message"] for finding in hook_report(self.root, "session-start", {})["findings"]
+            finding["message"]
+            for finding in hook_report(
+                self.root, "session-start", {}, today=NOW.date()
+            )["findings"]
         ]
         self.assertTrue(any("not initialized" in message for message in messages), messages)
 
@@ -1094,6 +1097,24 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
             item for item in diagnosis["checks"] if item["name"] == "state-freshness"
         )
         self.assertIn("future", freshness["detail"])
+
+    def test_start_and_session_hook_reject_linked_state_before_reading(self) -> None:
+        with tempfile.TemporaryDirectory() as external:
+            outside = Path(external) / "outside-current.md"
+            outside.write_text(
+                "# External\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
+            )
+            current = self.root / "state/current.md"
+            current.unlink()
+            try:
+                current.symlink_to(outside)
+            except OSError:
+                self.skipTest("symlink creation is unavailable")
+
+            with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
+                start_report(self.root, NOW)
+            with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
+                hook_report(self.root, "session-start", {}, today=NOW.date())
 
     def test_shipped_state_templates_retain_date_placeholders(self) -> None:
         for filename in ("current.md", "weekly-priorities.md", "blockers.md"):

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1044,7 +1044,7 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         self.assertTrue(report["initialized"])
         self.assertIsNone(report["next_action"])
 
-    def test_fresh_clone_reports_setup_required_from_real_templates(self) -> None:
+    def test_fresh_clone_reports_setup_required_from_synthetic_templates(self) -> None:
         self._write_undated_state("current.md", "weekly-priorities.md", "blockers.md")
 
         report = start_report(self.root, NOW)
@@ -1084,6 +1084,25 @@ with mock.patch("contextos.kernel._capture_transaction_before", side_effect=cras
         )
         self.assertEqual("warn", initialization["status"])
         self.assertIn("state/current.md", initialization["detail"])
+        self.assertIn("future", initialization["detail"])
+        self.assertIn("Check the system clock", report["next_action"])
+        self.assertTrue(
+            any("Check the system clock" in message for message in messages),
+            messages,
+        )
+        freshness = next(
+            item for item in diagnosis["checks"] if item["name"] == "state-freshness"
+        )
+        self.assertIn("future", freshness["detail"])
+
+    def test_shipped_state_templates_retain_date_placeholders(self) -> None:
+        for filename in ("current.md", "weekly-priorities.md", "blockers.md"):
+            content = (ROOT / "state" / filename).read_text(encoding="utf-8")
+            self.assertEqual(
+                1,
+                content.count("**Last Updated:** [DATE]"),
+                f"state/{filename} must retain exactly one shipped [DATE] placeholder",
+            )
 
     def test_invalid_or_unreadable_dates_are_unknown_in_every_readiness_consumer(self) -> None:
         current = self.root / "state/current.md"

--- a/tests/test_cross_runtime_hooks.py
+++ b/tests/test_cross_runtime_hooks.py
@@ -139,6 +139,25 @@ class CrossRuntimeHookTest(unittest.TestCase):
                 json.loads(accepted_stderr_override.stdout)["systemMessage"],
             )
 
+            failing_python = Path(temporary_directory) / "failing-python.cmd"
+            failing_python.write_text(
+                '@echo off\nif "%~1"=="-c" exit /b 0\n'
+                'echo hook-child-failed 1>&2\nexit /b 23\n',
+                encoding="utf-8",
+            )
+            environment["CONTEXTOS_PYTHON"] = str(failing_python)
+            propagated_failure = subprocess.run(
+                command,
+                cwd=ROOT,
+                env=environment,
+                input="{}",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(23, propagated_failure.returncode)
+            self.assertIn("hook-child-failed", propagated_failure.stderr)
+
         environment["CONTEXTOS_PYTHON"] = sys.executable
         must_not_fire = subprocess.run(
             command,


### PR DESCRIPTION
﻿## What's in this PR

- give future-dated `state/current.md` a recovery path shared by start, doctor, and session hooks
- add an invariant over the actual shipped state templates while keeping readiness fixtures synthetic
- prove exact PowerShell child-exit propagation and missing-Git advisory behavior
- rename the synthetic-template test so it no longer claims to read live templates

Closes #57.

## Verification

- `python -m unittest tests.test_contextos_kernel tests.test_cross_runtime_hooks` ? 104 tests passed, 10 skipped
- `bash tests/test-hooks.sh` ? passed
- `bash scripts/validate-all.sh` ? 463 tests passed, 36 skipped; all repository gates passed

## Checklist

### Skills & commands
- [x] No skills or commands changed
- [x] Host adapters remain advisory and use the shared kernel

### Repo hygiene
- [x] No sensitive data committed
- [x] `CHANGELOG.md` updated
- [x] Local validation passes

## Exact-SHA review record

Final reviewed SHA: `4efeac17fe960248166552b3d835dd507451d04b`

- Claude `claude-sonnet-5`: CLEAN on lifecycle readiness and symlink/reparse hardening. Confirmed stable no-follow snapshots close the check/use race and both hook entry points degrade unsafe reads to advisory exit 0.
- Hermes `thinkingmachines/inkling:free` (live prompt/completion price: zero): CLEAN, 15% blocker confidence; confirmed all three repair cycles and native Windows coverage.
- Repair 1: unified future-date recovery, controls for shipped placeholders, missing Git, and exact PowerShell child exits; then rejected linked readiness state before automatic reads.
- Repair 2: removed the redundant unguarded readiness reread and reused the guarded snapshot.
- Repair 3: used stable no-follow snapshots and made doctor degrade concurrent unsafe changes to `unknown`.
- Rejected finding: `surface_outputs` in `contextos/cli.py` is not dead. Removing it caused `test_cli_invalid_surface_remains_advisory` to fail because it preserves the host output protocol when surface resolution raises; it remains unchanged.
- Setup failure excluded: the first Hermes Nemotron attempt failed after provider overload retries; the free Inkling fallback completed.

Repair budget used: 3 of 3 cycles.
