### PR TITLE
docs: align integration proposal and PR guidance with catalog schema v2

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/integration-proposal.md
@@ -92,7 +92,7 @@ The catalog must describe the full surface; it does not disable tools or enforce
 
 ## Evidence & Health
 
-- `evidence`: <!-- Links to first-party documentation for verified fields -->
+- `evidence`: <!-- Non-empty list of first-party links supporting the fields you verified. Listed or experimental entries still require evidence for the claims they make. -->
 - `health_check`:
 
 ## Uninstall

--- a/.github/ISSUE_TEMPLATE/integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/integration-proposal.md
@@ -18,7 +18,7 @@ IMPORTANT: This is a metadata-only catalog change.
 - Do NOT authenticate to the integration.
 - Do NOT call/use the integration.
 No external account, credential, installation, or live integration call is required.
-Please use first-party documentation/evidence for all fields.
+Please provide first-party documentation/evidence for all verified fields. Unverified fields must be explicitly disclosed.
 -->
 
 ## Job it closes
@@ -40,11 +40,12 @@ maintaining durable context in a git repo.
 - `source_url`:
 - `kind`: <!-- mcp_server | skill_catalog | workspace_template | resource_catalog | agent_extension | connector | editor_guide | local_workspace -->
 - `supported_agents`: <!-- claude_code | codex | cursor | gemini_cli | opencode | generic - list only what you verified -->
-- `maturity`: <!-- verified if you checked the fields yourself; listed if you could not -->
+- `maturity`: <!-- verified | listed | experimental -->
 - `last_verified`: <!-- YYYY-MM-DD -->
 
 ## Installation
 
+- `automatic`: false
 - `scope`: <!-- none | project | user | project_or_user -->
 - `prerequisites`:
 
@@ -84,7 +85,7 @@ The catalog must describe the full surface; it does not disable tools or enforce
 
 ## Evidence & Health
 
-- `evidence`: <!-- Links to first-party documentation -->
+- `evidence`: <!-- Links to first-party documentation for verified fields -->
 - `health_check`:
 
 ## Uninstall
@@ -95,7 +96,7 @@ The catalog must describe the full surface; it does not disable tools or enforce
 ## What you could not verify
 
 <!--
-Required. "Nothing" is an acceptable answer, but an empty section is not.
+Required for listed or experimental entries. "Nothing" is an acceptable answer, but an empty section is not.
 Unverified per-client setup matrices, undocumented delete tools, and unclear
 maintenance status all belong here rather than being quietly asserted.
 -->

--- a/.github/ISSUE_TEMPLATE/integration-proposal.md
+++ b/.github/ISSUE_TEMPLATE/integration-proposal.md
@@ -8,10 +8,17 @@ labels: enhancement
 <!--
 The catalog is deliberately small and opt-in. Nothing is installed or enabled at
 setup. An entry is a discovery and risk document, so the bar is an honest
-description of what a tool can reach — not popularity.
+description of what a tool can reach - not popularity.
 
 Read CONTRIBUTING.md ("Adding an integration to the catalog") before filling
 this in. An entry that undersells a capability is worse than no entry.
+
+IMPORTANT: This is a metadata-only catalog change.
+- Do NOT install the integration.
+- Do NOT authenticate to the integration.
+- Do NOT call/use the integration.
+No external account, credential, installation, or live integration call is required.
+Please use first-party documentation/evidence for all fields.
 -->
 
 ## Job it closes
@@ -22,30 +29,39 @@ what reviewed output does it get OUT? Name the loop it closes for someone
 maintaining durable context in a git repo.
 
 "It's popular" or "lots of people use it" is not a job. If the honest answer is
-"it would be nice to have," say so — that is useful information.
+"it would be nice to have," say so - that is useful information.
 -->
-
-## Source
-
-- Canonical documentation:
-- Repository (if any):
-- Hosted endpoint (if any):
-- First-party, or community-maintained?
-- Latest release and date, as of when you checked:
 
 ## Proposed catalog fields
 
 - `id`:
+- `name`:
+- `summary`:
+- `source_url`:
 - `kind`: <!-- mcp_server | skill_catalog | workspace_template | resource_catalog | agent_extension | connector | editor_guide | local_workspace -->
-- `supported_agents`: <!-- claude_code | codex | cursor | gemini_cli | opencode | generic — list only what you verified -->
+- `supported_agents`: <!-- claude_code | codex | cursor | gemini_cli | opencode | generic - list only what you verified -->
 - `maturity`: <!-- verified if you checked the fields yourself; listed if you could not -->
+- `last_verified`: <!-- YYYY-MM-DD -->
+
+## Installation
+
+- `scope`: <!-- none | project | user | project_or_user -->
+- `prerequisites`:
+
+## Data Boundary
+
+Disclosure must be complete.
+- `credentials`:
+- `reads`:
+- `writes`:
 
 ## Capabilities
 
-Describe the real surface, including the parts you would rather not advertise.
+Describe the complete reachable surface, even if recommended use is read-only.
+The catalog must describe the full surface; it does not disable tools or enforce allowlists or default profiles.
 
-- [ ] `oauth`
-- [ ] `sensitive_read` — what specifically can it read?
+- [ ] `read`
+- [ ] `sensitive_read`
 - [ ] `write`
 - [ ] `remote_write`
 - [ ] `publish`
@@ -53,18 +69,28 @@ Describe the real surface, including the parts you would rather not advertise.
 - [ ] `delete`
 - [ ] `destructive`
 - [ ] `arbitrary_execution`
+- [ ] `oauth`
 
-Notes on anything above, particularly anything that surprised you:
+- `details`: <!-- Recommended client-side scope/tool restrictions belong here -->
 
-## Recommended default profile
+## Confirmation
 
-<!--
-The narrowest useful configuration. Which tools or scopes are on by default,
-and what sits behind a separate confirmation group?
+- `required_for`: <!-- credential_setup, external_install, read_sensitive, write, write_remote, publish, overwrite, delete, arbitrary_execution, oauth, destructive -->
+- `notes`: <!-- Recommended confirmation guidance belongs here -->
 
-If the service has a genuine server-side read-only scope, say so — that is a
-meaningful advantage and belongs in the entry.
--->
+## Risk Tags
+
+- `risk_tags`: <!-- e.g., sensitive-read, remote-write, publish-capable, overwrite-capable, delete-capable, arbitrary-execution, oauth, destructive-capable -->
+
+## Evidence & Health
+
+- `evidence`: <!-- Links to first-party documentation -->
+- `health_check`:
+
+## Uninstall
+
+- `instructions`:
+- `removes_user_data`: <!-- true | false -->
 
 ## What you could not verify
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 - [ ] Data boundary is fully disclosed
 - [ ] Every verified field is supported by first-party evidence, and unverified fields are explicitly disclosed (no live installation or testing used)
 - [ ] `last_verified` is the personally checked date
-- [ ] Confirmation gates and risk tags are derived from capabilities
+- [ ] Confirmation gates are derived from capabilities, installation scope, and credential boundaries; risk tags are derived from capabilities
 - [ ] `references/integrations.md` was regenerated via script
 - [ ] `CHANGELOG.md` updated
 - [ ] Full validation (`bash scripts/validate-all.sh`) passes locally

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,16 @@
 - [ ] Portable workflows keep provider-specific tools and paths in thin host adapters
 - [ ] New `.agents/skills/` entries include explicit invocation policy when timing or side effects must remain user-controlled
 
+### Integrations (if adding to catalog)
+- [ ] Full-surface capabilities are declared, including `read`
+- [ ] Data boundary is fully disclosed
+- [ ] Every field is supported by first-party evidence (no live installation or testing used)
+- [ ] `last_verified` is the personally checked date
+- [ ] Confirmation gates and risk tags are derived from capabilities
+- [ ] `references/integrations.md` was regenerated via script
+- [ ] `CHANGELOG.md` updated
+- [ ] Full validation (`bash scripts/validate-all.sh`) passes locally
+
 ### Repo hygiene
 - [ ] No sensitive data committed (passwords, API keys, tokens)
 - [ ] `CHANGELOG.md` updated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 ### Integrations (if adding to catalog)
 - [ ] Full-surface capabilities are declared, including `read`
 - [ ] Data boundary is fully disclosed
-- [ ] Every field is supported by first-party evidence (no live installation or testing used)
+- [ ] Every verified field is supported by first-party evidence, and unverified fields are explicitly disclosed (no live installation or testing used)
 - [ ] `last_verified` is the personally checked date
 - [ ] Confirmation gates and risk tags are derived from capabilities
 - [ ] `references/integrations.md` was regenerated via script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Aligned integration proposal, contributor guidance, and PR templates with catalog schema v2 (documentation and template changes only).
 - Workspace validation treats `.cursor/` as user-extensible while strict
   maintainer validation still requires ownership for every shipped path.
 - `doctor` is set-aware when tracked workspace configuration exists. It reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,11 @@ to check the entry is wanted before writing it.
    to read-only scopes with writes behind a separate confirmation group.
 6. Regenerate `references/integrations.md` and run the validator.
 
-`maturity` is a claim about metadata, not about testing. `verified` means you
-checked the fields against the linked source on the stated date. If you could
-not confirm something, `listed` is the honest value — and saying "I could not
+`maturity` is a claim about metadata, not about testing. `verified` means
+every submitted field is supported by current first-party evidence on the stated date.
+It does NOT mean that you created an account, installed the integration, authenticated,
+or performed a live end-to-end test. If you could
+not confirm something, `listed` is the honest value - and saying "I could not
 verify X" in the pull request is genuinely useful, not a failure.
 
 Nothing in this repository is installed or enabled at setup. A catalog entry is


### PR DESCRIPTION
## What's in this PR

This PR updates the integration-related templates and guidelines to match catalog schema v2 and clearly establish that the catalog is metadata-only.

## Changes made
- **Issue Template**: Rewrote `.github/ISSUE_TEMPLATE/integration-proposal.md` to directly map 1:1 with all schema v2 requirements (Installation, Data Boundary, Capabilities, Confirmation, Risk Tags, Evidence, Health Check, and Uninstall). Fixed visible mojibake.
- **Contributor Guidelines**: Clarified in `CONTRIBUTING.md` that `verified` maturity relies strictly on checking first-party evidence, and does not require contributors to perform a live installation, create an account, or authenticate.
- **PR Template**: Added an `Integrations` section to `.github/PULL_REQUEST_TEMPLATE.md` to ensure the contributor checklist covers full-surface disclosure and validations prior to merging.
- **General Guidance**: Clarified that the catalog simply documents the tool's completely reachable surface area and does not configure tools, disable functionality, or enforce default profiles (recommended restrictions are guided to `capabilities.details` and `confirmation.notes`).

## Checklist

### Integrations (if adding to catalog)
- [x] Full-surface capabilities are declared, including `read`
- [x] Data boundary is fully disclosed
- [x] Every field is supported by first-party evidence (no live installation or testing used)
- [x] `last_verified` is the personally checked date
- [x] Confirmation gates and risk tags are derived from capabilities
- [x] `references/integrations.md` was regenerated via script
- [x] `CHANGELOG.md` updated
- [x] Full validation (`bash scripts/validate-all.sh`) passes locally

### Repo hygiene
- [x] No sensitive data committed (passwords, API keys, tokens)
- [x] `CHANGELOG.md` updated
- [x] CI passes
