### PR TITLE
Add Trello MCP to the integration catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
   runtime, a deprecated singleton alias, and local-only `auto` behavior.
 - A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
+- A reviewed Trello MCP catalog entry covering its official Atlassian-hosted OAuth 2.0 workspace-scoped boundary, read and search plus create/update/move/archive capabilities, and a no-destructive-delete surface.
 - Provider-neutral root discovery through validated `contextos.workspace.json`,
   with legacy compound-marker compatibility, nearest-root selection, explicit
   nested Git boundaries, fail-closed invalid markers, and actionable migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
   runtime, a deprecated singleton alias, and local-only `auto` behavior.
 - A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
-- A reviewed Trello MCP catalog entry covering its official Atlassian-hosted OAuth 2.0 workspace-scoped boundary, read and search plus create/update/move/archive capabilities, and a no-destructive-delete surface.
+- A reviewed Trello MCP catalog entry covering one authorized workspace plus account-level Inbox and Planner permissions, connected-calendar reads, create/update/move/archive capabilities, and a no-permanent-delete surface.
 - Provider-neutral root discovery through validated `contextos.workspace.json`,
   with legacy compound-marker compatibility, nearest-root selection, explicit
   nested Git boundaries, fail-closed invalid markers, and actionable migration

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -13,7 +13,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Discover creator-oriented tools without installing one | [AI Tools for Creators](../references/integrations.md#ai-tools-for-creators) | Listings can drift and are not endorsements |
 | Inspect repositories, issues, pull requests, or CI context | [GitHub MCP](../references/integrations.md#github-mcp) | Private-repository reads, public comments, branch or file changes, and enabled toolsets |
 | Read or update product work in Linear | [Linear MCP](../references/integrations.md#linear-mcp) | Workspace-wide reads and remote issue, project, relationship, or comment changes |
-| Read or manage Trello boards, lists, and cards | [Trello MCP](../references/integrations.md#trello-mcp) | OAuth 2.0 workspace consent, sensitive board reads, and remote create/update/move/archive writes |
+| Read or manage Trello boards, lists, and cards | [Trello MCP](../references/integrations.md#trello-mcp) | OAuth 2.0 consent for one workspace plus account-level Inbox/Planner access, connected-calendar reads, and remote create/update/move/archive writes |
 | Search a personal reading library or organize highlights | [Readwise MCP](../references/integrations.md#readwise-mcp) | Full-library indexing, sensitive reading history, bulk edits, and highlight deletion |
 | Read calendar, email, Drive, or Sheets data | [Google Workspace CLI](../references/integrations.md#google-workspace-cli) | OAuth identity, sensitive reads, and the CLI's broader write-capable surface |
 | Search or change a Notion workspace | [Notion MCP](../references/integrations.md#notion-mcp) | OAuth, sensitive and connected-source reads, remote writes, and overwrite-capable updates |

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -13,6 +13,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Discover creator-oriented tools without installing one | [AI Tools for Creators](../references/integrations.md#ai-tools-for-creators) | Listings can drift and are not endorsements |
 | Inspect repositories, issues, pull requests, or CI context | [GitHub MCP](../references/integrations.md#github-mcp) | Private-repository reads, public comments, branch or file changes, and enabled toolsets |
 | Read or update product work in Linear | [Linear MCP](../references/integrations.md#linear-mcp) | Workspace-wide reads and remote issue, project, relationship, or comment changes |
+| Read or manage Trello boards, lists, and cards | [Trello MCP](../references/integrations.md#trello-mcp) | OAuth 2.0 workspace consent, sensitive board reads, and remote create/update/move/archive writes |
 | Search a personal reading library or organize highlights | [Readwise MCP](../references/integrations.md#readwise-mcp) | Full-library indexing, sensitive reading history, bulk edits, and highlight deletion |
 | Read calendar, email, Drive, or Sheets data | [Google Workspace CLI](../references/integrations.md#google-workspace-cli) | OAuth identity, sensitive reads, and the CLI's broader write-capable surface |
 | Search or change a Notion workspace | [Notion MCP](../references/integrations.md#notion-mcp) | OAuth, sensitive and connected-source reads, remote writes, and overwrite-capable updates |

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -686,11 +686,16 @@
           "Per-user OAuth 2.0 consent authorizing a single Trello workspace, managed by the MCP client and hosted service"
         ],
         "reads": [
-          "Sensitive workspace boards, lists, cards, labels, checklists, members, search results, inbox cards, and planner calendar events allowed to the connected user in the authorized workspace"
+          "Sensitive workspace boards, lists, cards, labels, checklists, members, and search results allowed to the connected user in the authorized workspace",
+          "Account-level Inbox cards and Planner calendar events, including events read from a connected Google or Outlook calendar, which follow organization controls and can remain available without a connected workspace"
         ],
         "writes": [
-          "Remote create, update, move, and archive of boards, lists, cards, checklists, inbox cards, and planner focus-time events in the authorized workspace",
-          "Checklist item and label additions and updates on cards"
+          "Remote board creation (board update, move, and archive are not supported)",
+          "Remote list moves (list creation is not supported)",
+          "Remote card creation, update, move, archive, mark-done, and label attach or detach",
+          "Remote checklist creation and update, plus checklist-item add and update",
+          "Remote Inbox card creation, update, and archive",
+          "Planner focus-time event creation and card link or unlink, which requires Trello Premium or Enterprise"
         ]
       },
       "capabilities": {
@@ -699,16 +704,17 @@
         "write": true,
         "remote_write": true,
         "publish": false,
-        "overwrite": false,
+        "overwrite": true,
         "delete": false,
         "arbitrary_execution": false,
         "oauth": true,
-        "destructive": false,
+        "destructive": true,
         "details": [
           "Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace on the OAuth consent screen; the connection cannot act beyond the connected user's Trello permissions",
           "Cards and lists can be archived but not permanently destroyed; archiving is the strongest action the server exposes",
-          "Card, list, board, and checklist creation and edits are remote writes; show the exact board, list, card, and field change before every create, update, move, or archive",
-          "Reads and search surface board, card, checklist, member, inbox, and planner data that may be sensitive depending on the workspace"
+          "Card, checklist, checklist-item, and Inbox card updates replace existing remote field values, so type them as overwrite-capable and destructive and show the exact field change before every create, update, move, archive, link, or unlink",
+          "Inbox and Planner permissions are account-level and tied to organization controls, so they can remain available even without a connected workspace; Planner can read events from a connected Google or Outlook calendar, and creating focus time requires Trello Premium or Enterprise",
+          "Reads and search surface board, card, checklist, member, inbox, and planner data that may be sensitive depending on the workspace and account"
         ]
       },
       "confirmation": {
@@ -718,9 +724,11 @@
           "read_sensitive",
           "write",
           "write_remote",
-          "oauth"
+          "overwrite",
+          "oauth",
+          "destructive"
         ],
-        "notes": "Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, and show the exact board, list, card, checklist, or inbox change before every remote create, update, move, or archive."
+        "notes": "Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, show the exact board, list, card, checklist, Inbox card, or planner field change before every remote create, update, move, archive, link, or unlink, and separately confirm account-level Inbox and Planner access plus any connected Google or Outlook calendar."
       },
       "risk_tags": [
         "credentials",
@@ -728,7 +736,11 @@
         "project-management",
         "sensitive-read",
         "remote-write",
+        "overwrite-capable",
         "oauth",
+        "destructive-capable",
+        "connected-sources",
+        "account-level",
         "prompt-injection"
       ],
       "maturity": "verified",
@@ -737,7 +749,7 @@
         "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/",
         "https://github.com/atlassian/trello-mcp-server"
       ],
-      "health_check": "After OAuth, read the connected member profile and one explicitly named board, then confirm the authorized workspace and permissions before any search, write, or archive.",
+      "health_check": "After OAuth, read the connected member profile and one explicitly named board to confirm the authorized workspace and its read/write permissions, then separately verify account-level Inbox and Planner access and any connected Google or Outlook calendar before any search, write, move, archive, link, or unlink.",
       "uninstall": {
         "instructions": "Remove the Trello MCP entry from the MCP client and revoke the authorized connection in Trello; archived cards and lists remain in place unless the user manages them separately in Trello.",
         "removes_user_data": false

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -660,6 +660,88 @@
         "instructions": "Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them; review any separately installed PDF engine independently.",
         "removes_user_data": false
       }
+    },
+    {
+      "id": "trello-mcp",
+      "name": "Trello MCP",
+      "summary": "Trello's official cloud-hosted MCP server for reading, searching, and managing boards, lists, cards, checklists, inbox cards, and planner events in a single OAuth-authorized workspace.",
+      "source_url": "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/",
+      "kind": "mcp_server",
+      "supported_agents": [
+        "claude_code",
+        "cursor",
+        "gemini_cli",
+        "generic"
+      ],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": [
+          "A Trello account on any plan",
+          "An MCP client supporting remote Streamable HTTP and browser OAuth"
+        ]
+      },
+      "data_boundary": {
+        "credentials": [
+          "Per-user OAuth 2.0 consent authorizing a single Trello workspace, managed by the MCP client and hosted service"
+        ],
+        "reads": [
+          "Sensitive workspace boards, lists, cards, labels, checklists, members, search results, inbox cards, and planner calendar events allowed to the connected user in the authorized workspace"
+        ],
+        "writes": [
+          "Remote create, update, move, and archive of boards, lists, cards, checklists, inbox cards, and planner focus-time events in the authorized workspace",
+          "Checklist item and label additions and updates on cards"
+        ]
+      },
+      "capabilities": {
+        "read": true,
+        "sensitive_read": true,
+        "write": true,
+        "remote_write": true,
+        "publish": false,
+        "overwrite": false,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": true,
+        "destructive": false,
+        "details": [
+          "Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace on the OAuth consent screen; the connection cannot act beyond the connected user's Trello permissions",
+          "Cards and lists can be archived but not permanently destroyed; archiving is the strongest action the server exposes",
+          "Card, list, board, and checklist creation and edits are remote writes; show the exact board, list, card, and field change before every create, update, move, or archive",
+          "Reads and search surface board, card, checklist, member, inbox, and planner data that may be sensitive depending on the workspace"
+        ]
+      },
+      "confirmation": {
+        "required_for": [
+          "credential_setup",
+          "external_install",
+          "read_sensitive",
+          "write",
+          "write_remote",
+          "oauth"
+        ],
+        "notes": "Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, and show the exact board, list, card, checklist, or inbox change before every remote create, update, move, or archive."
+      },
+      "risk_tags": [
+        "credentials",
+        "hosted",
+        "project-management",
+        "sensitive-read",
+        "remote-write",
+        "oauth",
+        "prompt-injection"
+      ],
+      "maturity": "verified",
+      "last_verified": "2026-08-29",
+      "evidence": [
+        "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/",
+        "https://github.com/atlassian/trello-mcp-server"
+      ],
+      "health_check": "After OAuth, read the connected member profile and one explicitly named board, then confirm the authorized workspace and permissions before any search, write, or archive.",
+      "uninstall": {
+        "instructions": "Remove the Trello MCP entry from the MCP client and revoke the authorized connection in Trello; archived cards and lists remain in place unless the user manages them separately in Trello.",
+        "removes_user_data": false
+      }
     }
   ]
 }

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -664,7 +664,7 @@
     {
       "id": "trello-mcp",
       "name": "Trello MCP",
-      "summary": "Trello's official cloud-hosted MCP server for reading, searching, and managing boards, lists, cards, checklists, inbox cards, and planner events in a single OAuth-authorized workspace.",
+      "summary": "Trello's official cloud-hosted MCP server for workspace-scoped boards, lists, cards, and checklists plus account-level Inbox and Planner access under per-user OAuth.",
       "source_url": "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/",
       "kind": "mcp_server",
       "supported_agents": [
@@ -683,7 +683,7 @@
       },
       "data_boundary": {
         "credentials": [
-          "Per-user OAuth 2.0 consent authorizing a single Trello workspace, managed by the MCP client and hosted service"
+          "Per-user OAuth 2.0 consent authorizing one Trello workspace plus separately controlled account-level Inbox and Planner permissions, managed by the MCP client and hosted service"
         ],
         "reads": [
           "Sensitive workspace boards, lists, cards, labels, checklists, members, and search results allowed to the connected user in the authorized workspace",
@@ -691,7 +691,7 @@
         ],
         "writes": [
           "Remote board creation (board update, move, and archive are not supported)",
-          "Remote list moves (list creation is not supported)",
+          "Remote list creation, move, and archive",
           "Remote card creation, update, move, archive, mark-done, and label attach or detach",
           "Remote checklist creation and update, plus checklist-item add and update",
           "Remote Inbox card creation, update, and archive",
@@ -710,7 +710,7 @@
         "oauth": true,
         "destructive": true,
         "details": [
-          "Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace on the OAuth consent screen; the connection cannot act beyond the connected user's Trello permissions",
+          "Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace for boards, lists, cards, and checklists; separately review account-level Inbox and Planner permissions, and note that the connection cannot act beyond the connected user's Trello permissions",
           "Cards and lists can be archived but not permanently destroyed; archiving is the strongest action the server exposes",
           "Card, checklist, checklist-item, and Inbox card updates replace existing remote field values, so type them as overwrite-capable and destructive and show the exact field change before every create, update, move, archive, link, or unlink",
           "Inbox and Planner permissions are account-level and tied to organization controls, so they can remain available even without a connected workspace; Planner can read events from a connected Google or Outlook calendar, and creating focus time requires Trello Premium or Enterprise",
@@ -744,10 +744,10 @@
         "prompt-injection"
       ],
       "maturity": "verified",
-      "last_verified": "2026-08-29",
+      "last_verified": "2026-08-30",
       "evidence": [
         "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/",
-        "https://github.com/atlassian/trello-mcp-server"
+        "https://github.com/atlassian/trello-mcp-server/blob/d37a70182902b71f36821f140d92c22c3a9f74a4/skills/trello-use/SKILL.md"
       ],
       "health_check": "After OAuth, read the connected member profile and one explicitly named board to confirm the authorized workspace and its read/write permissions, then separately verify account-level Inbox and Planner access and any connected Google or Outlook calendar before any search, write, move, archive, link, or unlink.",
       "uninstall": {

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -20,7 +20,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
-| [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-29 |
+| [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
 
 ## Agent Skills
 
@@ -394,25 +394,25 @@ Capabilities and limits:
 
 ## Trello MCP
 
-Trello's official cloud-hosted MCP server for reading, searching, and managing boards, lists, cards, checklists, inbox cards, and planner events in a single OAuth-authorized workspace.
+Trello's official cloud-hosted MCP server for workspace-scoped boards, lists, cards, and checklists plus account-level Inbox and Planner access under per-user OAuth.
 
 - **Supported agents:** `claude_code`, `cursor`, `gemini_cli`, `generic`
 - **Install scope:** `project_or_user`; never automatic
 - **Prerequisites:** A Trello account on any plan; An MCP client supporting remote Streamable HTTP and browser OAuth
-- **Credentials:** Per-user OAuth 2.0 consent authorizing a single Trello workspace, managed by the MCP client and hosted service
+- **Credentials:** Per-user OAuth 2.0 consent authorizing one Trello workspace plus separately controlled account-level Inbox and Planner permissions, managed by the MCP client and hosted service
 - **Reads:** Sensitive workspace boards, lists, cards, labels, checklists, members, and search results allowed to the connected user in the authorized workspace; Account-level Inbox cards and Planner calendar events, including events read from a connected Google or Outlook calendar, which follow organization controls and can remain available without a connected workspace
-- **Writes / external effects:** Remote board creation (board update, move, and archive are not supported); Remote list moves (list creation is not supported); Remote card creation, update, move, archive, mark-done, and label attach or detach; Remote checklist creation and update, plus checklist-item add and update; Remote Inbox card creation, update, and archive; Planner focus-time event creation and card link or unlink, which requires Trello Premium or Enterprise
+- **Writes / external effects:** Remote board creation (board update, move, and archive are not supported); Remote list creation, move, and archive; Remote card creation, update, move, archive, mark-done, and label attach or detach; Remote checklist creation and update, plus checklist-item add and update; Remote Inbox card creation, update, and archive; Planner focus-time event creation and card link or unlink, which requires Trello Premium or Enterprise
 - **Typed safety signals:** sensitive read, remote write, overwrite, oauth
 - **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `overwrite`, `oauth`, `destructive`
 - **Confirmation:** Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, show the exact board, list, card, checklist, Inbox card, or planner field change before every remote create, update, move, archive, link, or unlink, and separately confirm account-level Inbox and Planner access plus any connected Google or Outlook calendar.
 - **Risk tags:** `credentials`, `hosted`, `project-management`, `sensitive-read`, `remote-write`, `overwrite-capable`, `oauth`, `destructive-capable`, `connected-sources`, `account-level`, `prompt-injection`
-- **Evidence:** [1](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/); [2](https://github.com/atlassian/trello-mcp-server)
+- **Evidence:** [1](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/); [2](https://github.com/atlassian/trello-mcp-server/blob/d37a70182902b71f36821f140d92c22c3a9f74a4/skills/trello-use/SKILL.md)
 - **Health check:** After OAuth, read the connected member profile and one explicitly named board to confirm the authorized workspace and its read/write permissions, then separately verify account-level Inbox and Planner access and any connected Google or Outlook calendar before any search, write, move, archive, link, or unlink.
 - **Uninstall:** Remove the Trello MCP entry from the MCP client and revoke the authorized connection in Trello; archived cards and lists remain in place unless the user manages them separately in Trello. (removes user data: No)
 
 Capabilities and limits:
 
-- Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace on the OAuth consent screen; the connection cannot act beyond the connected user's Trello permissions
+- Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace for boards, lists, cards, and checklists; separately review account-level Inbox and Planner permissions, and note that the connection cannot act beyond the connected user's Trello permissions
 - Cards and lists can be archived but not permanently destroyed; archiving is the strongest action the server exposes
 - Card, checklist, checklist-item, and Inbox card updates replace existing remote field values, so type them as overwrite-capable and destructive and show the exact field change before every create, update, move, archive, link, or unlink
 - Inbox and Planner permissions are account-level and tied to organization controls, so they can remain available even without a connected workspace; Planner can read events from a connected Google or Outlook calendar, and creating focus time requires Trello Premium or Enterprise

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -20,6 +20,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
+| [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | No | 2026-08-29 |
 
 ## Agent Skills
 
@@ -390,3 +391,28 @@ Capabilities and limits:
 - Prefer get\_note, diff review, and expectedMtime before update\_note
 - The MCP content-mutation surface is limited to create, append, update, attach, and local clone operations; open, highlight, and refresh also change transient UI state
 - Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them
+
+## Trello MCP
+
+Trello's official cloud-hosted MCP server for reading, searching, and managing boards, lists, cards, checklists, inbox cards, and planner events in a single OAuth-authorized workspace.
+
+- **Supported agents:** `claude_code`, `cursor`, `gemini_cli`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** A Trello account on any plan; An MCP client supporting remote Streamable HTTP and browser OAuth
+- **Credentials:** Per-user OAuth 2.0 consent authorizing a single Trello workspace, managed by the MCP client and hosted service
+- **Reads:** Sensitive workspace boards, lists, cards, labels, checklists, members, search results, inbox cards, and planner calendar events allowed to the connected user in the authorized workspace
+- **Writes / external effects:** Remote create, update, move, and archive of boards, lists, cards, checklists, inbox cards, and planner focus-time events in the authorized workspace; Checklist item and label additions and updates on cards
+- **Typed safety signals:** sensitive read, remote write, oauth
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `oauth`
+- **Confirmation:** Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, and show the exact board, list, card, checklist, or inbox change before every remote create, update, move, or archive.
+- **Risk tags:** `credentials`, `hosted`, `project-management`, `sensitive-read`, `remote-write`, `oauth`, `prompt-injection`
+- **Evidence:** [1](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/); [2](https://github.com/atlassian/trello-mcp-server)
+- **Health check:** After OAuth, read the connected member profile and one explicitly named board, then confirm the authorized workspace and permissions before any search, write, or archive.
+- **Uninstall:** Remove the Trello MCP entry from the MCP client and revoke the authorized connection in Trello; archived cards and lists remain in place unless the user manages them separately in Trello. (removes user data: No)
+
+Capabilities and limits:
+
+- Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace on the OAuth consent screen; the connection cannot act beyond the connected user's Trello permissions
+- Cards and lists can be archived but not permanently destroyed; archiving is the strongest action the server exposes
+- Card, list, board, and checklist creation and edits are remote writes; show the exact board, list, card, and field change before every create, update, move, or archive
+- Reads and search surface board, card, checklist, member, inbox, and planner data that may be sensitive depending on the workspace

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -20,7 +20,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
-| [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | No | 2026-08-29 |
+| [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-29 |
 
 ## Agent Skills
 
@@ -400,19 +400,20 @@ Trello's official cloud-hosted MCP server for reading, searching, and managing b
 - **Install scope:** `project_or_user`; never automatic
 - **Prerequisites:** A Trello account on any plan; An MCP client supporting remote Streamable HTTP and browser OAuth
 - **Credentials:** Per-user OAuth 2.0 consent authorizing a single Trello workspace, managed by the MCP client and hosted service
-- **Reads:** Sensitive workspace boards, lists, cards, labels, checklists, members, search results, inbox cards, and planner calendar events allowed to the connected user in the authorized workspace
-- **Writes / external effects:** Remote create, update, move, and archive of boards, lists, cards, checklists, inbox cards, and planner focus-time events in the authorized workspace; Checklist item and label additions and updates on cards
-- **Typed safety signals:** sensitive read, remote write, oauth
-- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `oauth`
-- **Confirmation:** Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, and show the exact board, list, card, checklist, or inbox change before every remote create, update, move, or archive.
-- **Risk tags:** `credentials`, `hosted`, `project-management`, `sensitive-read`, `remote-write`, `oauth`, `prompt-injection`
+- **Reads:** Sensitive workspace boards, lists, cards, labels, checklists, members, and search results allowed to the connected user in the authorized workspace; Account-level Inbox cards and Planner calendar events, including events read from a connected Google or Outlook calendar, which follow organization controls and can remain available without a connected workspace
+- **Writes / external effects:** Remote board creation (board update, move, and archive are not supported); Remote list moves (list creation is not supported); Remote card creation, update, move, archive, mark-done, and label attach or detach; Remote checklist creation and update, plus checklist-item add and update; Remote Inbox card creation, update, and archive; Planner focus-time event creation and card link or unlink, which requires Trello Premium or Enterprise
+- **Typed safety signals:** sensitive read, remote write, overwrite, oauth
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `overwrite`, `oauth`, `destructive`
+- **Confirmation:** Confirm the exact Trello account, workspace, and OAuth permissions during connection; ask before broad board or search reads, show the exact board, list, card, checklist, Inbox card, or planner field change before every remote create, update, move, archive, link, or unlink, and separately confirm account-level Inbox and Planner access plus any connected Google or Outlook calendar.
+- **Risk tags:** `credentials`, `hosted`, `project-management`, `sensitive-read`, `remote-write`, `overwrite-capable`, `oauth`, `destructive-capable`, `connected-sources`, `account-level`, `prompt-injection`
 - **Evidence:** [1](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/); [2](https://github.com/atlassian/trello-mcp-server)
-- **Health check:** After OAuth, read the connected member profile and one explicitly named board, then confirm the authorized workspace and permissions before any search, write, or archive.
+- **Health check:** After OAuth, read the connected member profile and one explicitly named board to confirm the authorized workspace and its read/write permissions, then separately verify account-level Inbox and Planner access and any connected Google or Outlook calendar before any search, write, move, archive, link, or unlink.
 - **Uninstall:** Remove the Trello MCP entry from the MCP client and revoke the authorized connection in Trello; archived cards and lists remain in place unless the user manages them separately in Trello. (removes user data: No)
 
 Capabilities and limits:
 
 - Use the official hosted endpoint https://mcp.trello.com/v1 and authorize exactly one workspace on the OAuth consent screen; the connection cannot act beyond the connected user's Trello permissions
 - Cards and lists can be archived but not permanently destroyed; archiving is the strongest action the server exposes
-- Card, list, board, and checklist creation and edits are remote writes; show the exact board, list, card, and field change before every create, update, move, or archive
-- Reads and search surface board, card, checklist, member, inbox, and planner data that may be sensitive depending on the workspace
+- Card, checklist, checklist-item, and Inbox card updates replace existing remote field values, so type them as overwrite-capable and destructive and show the exact field change before every create, update, move, archive, link, or unlink
+- Inbox and Planner permissions are account-level and tied to organization controls, so they can remain available even without a connected workspace; Planner can read events from a connected Google or Outlook calendar, and creating focus time requires Trello Premium or Enterprise
+- Reads and search surface board, card, checklist, member, inbox, and planner data that may be sensitive depending on the workspace and account

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -27,7 +27,7 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
         self.assertEqual(self.catalog["schema_version"], 2)
-        self.assertEqual(len(self.catalog["integrations"]), 15)
+        self.assertEqual(len(self.catalog["integrations"]), 16)
         self.assertTrue(
             {
                 "github-mcp",
@@ -166,6 +166,35 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_empty_catalog_and_old_schema_are_rejected(self) -> None:
         self.assert_invalid(lambda catalog: catalog.update({"integrations": []}))
         self.assert_invalid(lambda catalog: catalog.update({"schema_version": 1}))
+
+    def test_trello_mcp_has_no_destructive_delete_surface(self) -> None:
+        item = self.entry("trello-mcp")
+        self.assertTrue(item["capabilities"]["read"])
+        self.assertTrue(item["capabilities"]["sensitive_read"])
+        self.assertTrue(item["capabilities"]["write"])
+        self.assertTrue(item["capabilities"]["remote_write"])
+        self.assertTrue(item["capabilities"]["oauth"])
+        self.assertFalse(item["capabilities"]["overwrite"])
+        self.assertFalse(item["capabilities"]["delete"])
+        self.assertFalse(item["capabilities"]["destructive"])
+        self.assertFalse(item["capabilities"]["arbitrary_execution"])
+        for gate in ("credential_setup", "external_install", "read_sensitive", "write", "write_remote", "oauth"):
+            self.assertIn(gate, item["confirmation"]["required_for"])
+        self.assertNotIn("destructive", item["confirmation"]["required_for"])
+        self.assertNotIn("delete", item["confirmation"]["required_for"])
+        for agent in ("claude_code", "cursor", "gemini_cli", "generic"):
+            self.assertIn(agent, item["supported_agents"])
+        self.assertNotIn("codex", item["supported_agents"])
+        details = " ".join(item["capabilities"]["details"])
+        self.assertIn("https://mcp.trello.com/v1", details)
+        self.assertIn("archived but not permanently destroyed", details)
+        self.assertTrue(
+            any(
+                url
+                == "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/"
+                for url in item["evidence"]
+            )
+        )
 
     def test_agent_skills_discloses_replacement_removal_and_uninstall_loss(self) -> None:
         item = self.entry("agent-skills")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -183,6 +183,8 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assertNotIn("delete", item["confirmation"]["required_for"])
         self.assertIn("overwrite-capable", item["risk_tags"])
         self.assertIn("destructive-capable", item["risk_tags"])
+        self.assertIn("connected-sources", item["risk_tags"])
+        self.assertIn("account-level", item["risk_tags"])
         self.assertNotIn("delete-capable", item["risk_tags"])
         for agent in ("claude_code", "cursor", "gemini_cli", "generic"):
             self.assertIn(agent, item["supported_agents"])
@@ -190,17 +192,30 @@ class IntegrationCatalogTests(unittest.TestCase):
         details = " ".join(item["capabilities"]["details"])
         self.assertIn("https://mcp.trello.com/v1", details)
         self.assertIn("archived but not permanently destroyed", details)
+        self.assertIn("account-level Inbox and Planner", item["summary"])
+        credentials = " ".join(item["data_boundary"]["credentials"])
+        self.assertIn("account-level Inbox and Planner", credentials)
         reads = " ".join(item["data_boundary"]["reads"])
         self.assertIn("account-level", reads.casefold())
         self.assertIn("Google or Outlook", reads)
         writes = " ".join(item["data_boundary"]["writes"])
+        self.assertIn(
+            "Remote list creation, move, and archive",
+            item["data_boundary"]["writes"],
+        )
+        self.assertNotIn("list creation is not supported", writes)
         self.assertIn("Trello Premium or Enterprise", writes)
+        self.assertIn("account-level Inbox and Planner", item["health_check"])
         self.assertTrue(
             any(
                 url
                 == "https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/"
                 for url in item["evidence"]
             )
+        )
+        self.assertIn(
+            "https://github.com/atlassian/trello-mcp-server/blob/d37a70182902b71f36821f140d92c22c3a9f74a4/skills/trello-use/SKILL.md",
+            item["evidence"],
         )
 
     def test_agent_skills_discloses_replacement_removal_and_uninstall_loss(self) -> None:

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -167,27 +167,34 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assert_invalid(lambda catalog: catalog.update({"integrations": []}))
         self.assert_invalid(lambda catalog: catalog.update({"schema_version": 1}))
 
-    def test_trello_mcp_has_no_destructive_delete_surface(self) -> None:
+    def test_trello_mcp_types_overwrite_but_not_delete_surface(self) -> None:
         item = self.entry("trello-mcp")
         self.assertTrue(item["capabilities"]["read"])
         self.assertTrue(item["capabilities"]["sensitive_read"])
         self.assertTrue(item["capabilities"]["write"])
         self.assertTrue(item["capabilities"]["remote_write"])
         self.assertTrue(item["capabilities"]["oauth"])
-        self.assertFalse(item["capabilities"]["overwrite"])
+        self.assertTrue(item["capabilities"]["overwrite"])
+        self.assertTrue(item["capabilities"]["destructive"])
         self.assertFalse(item["capabilities"]["delete"])
-        self.assertFalse(item["capabilities"]["destructive"])
         self.assertFalse(item["capabilities"]["arbitrary_execution"])
-        for gate in ("credential_setup", "external_install", "read_sensitive", "write", "write_remote", "oauth"):
+        for gate in ("credential_setup", "external_install", "read_sensitive", "write", "write_remote", "overwrite", "oauth", "destructive"):
             self.assertIn(gate, item["confirmation"]["required_for"])
-        self.assertNotIn("destructive", item["confirmation"]["required_for"])
         self.assertNotIn("delete", item["confirmation"]["required_for"])
+        self.assertIn("overwrite-capable", item["risk_tags"])
+        self.assertIn("destructive-capable", item["risk_tags"])
+        self.assertNotIn("delete-capable", item["risk_tags"])
         for agent in ("claude_code", "cursor", "gemini_cli", "generic"):
             self.assertIn(agent, item["supported_agents"])
         self.assertNotIn("codex", item["supported_agents"])
         details = " ".join(item["capabilities"]["details"])
         self.assertIn("https://mcp.trello.com/v1", details)
         self.assertIn("archived but not permanently destroyed", details)
+        reads = " ".join(item["data_boundary"]["reads"])
+        self.assertIn("account-level", reads.casefold())
+        self.assertIn("Google or Outlook", reads)
+        writes = " ".join(item["data_boundary"]["writes"])
+        self.assertIn("Trello Premium or Enterprise", writes)
         self.assertTrue(
             any(
                 url


### PR DESCRIPTION
## What's in this PR

Adds Atlassian's official cloud-hosted Trello MCP server to `integrations/catalog.json`, regenerates the reference, and documents its workspace, account, and write boundaries. Closes #46.

### Catalog entry (`id: trello-mcp`, `kind: mcp_server`, `maturity: verified`)

- **Supported agents:** `claude_code`, `cursor`, `gemini_cli`, and `generic`, based on Atlassian's documented Claude, Cursor, Google Gemini CLI, ChatGPT, VS Code, and generic MCP support.
- **Access boundary:** Per-user OAuth authorizes one Trello workspace for boards, lists, cards, and checklists. Inbox and Planner permissions are separately controlled at the account level, and Planner can read a connected Google or Outlook calendar.
- **Capabilities:** `read`, `sensitive_read`, `write`, `remote_write`, `overwrite`, `oauth`, and `destructive` are `true`. `publish`, `delete`, and `arbitrary_execution` are `false`. Remote updates replace existing field values, while the server exposes archiving but no permanent-delete tools.
- **Write surface:** Board creation; list creation, move, and archive; card creation, update, move, archive, mark-done, and label attach/detach; checklist and checklist-item creation or update; Inbox creation, update, and archive; and Planner focus-time creation plus card link/unlink. Planner focus-time creation requires Trello Premium or Enterprise.
- **Confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `overwrite`, `oauth`, and `destructive`.
- **Risk metadata:** Includes `connected-sources`, `account-level`, `overwrite-capable`, and `destructive-capable`; excludes `delete-capable`.
- **Last verified:** `2026-08-30`.
- **Evidence:** Atlassian's Trello MCP support documentation plus the official `trello-use/SKILL.md` pinned to commit `d37a70182902b71f36821f140d92c22c3a9f74a4`.

### Regenerated and companion changes

- Regenerates `references/integrations.md` with `scripts/integrations.py render`.
- Adds the Trello outcome-chooser row to `docs/integrations-guide.md`.
- Adds the Trello entry to `CHANGELOG.md` with its one-workspace, account-level Inbox/Planner, connected-calendar, and no-permanent-delete boundaries.
- Increments the catalog-count assertion from 15 to 16.
- Extends `test_trello_mcp_types_overwrite_but_not_delete_surface` to lock the account-level risk tags and wording, exact list write mapping, removed unsupported-list claim, health check, and pinned evidence URL.

## Verification

- `python3 scripts/integrations.py render`: passed.
- `python3 -m unittest discover -s tests -p 'test_integrations.py'`: 22 tests passed.
- `bash scripts/validate-all.sh`: 525 tests passed with 42 skipped; portability, hooks, catalog, component manifest, bundle lock, runtime registry, workspace configuration, and JSON checks passed.
- `git diff --check`: passed.
- Claude Sonnet and Hermes/Inkling independently reviewed the complete maintainer diff and found no blockers.

## Not verified

Per the issue's contributor contract, this PR does not install, authenticate, or call the hosted server. The metadata was checked against the linked first-party sources.

## Checklist

### Repo hygiene

- [x] No sensitive data committed
- [x] `CHANGELOG.md` updated
- [x] Generated integration reference is current
- [x] Full local validation passes
