### PR TITLE
fix: diagnose legacy linked state readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,11 +98,14 @@
 - Lifecycle readiness now gives recovery-specific guidance for future-dated
   `state/current.md`, protects shipped `[DATE]` placeholders, and controls
   missing-Git advisory behavior plus exact PowerShell child-exit propagation.
-  Start and automatic session hooks also reject linked or reparse-point state
-  paths through stable no-follow snapshots, derive diagnostic labels only after
-  that guard, and accept equivalent Windows 8.3 and canonical root spellings.
-  Doctor degrades concurrent path changes to an unknown diagnostic instead of
-  crashing.
+  Start and automatic session hooks keep readiness files no-follow in every
+  mode; canonical JSON also rejects a linked configured `state_dir`. The
+  documented pre-JSON internal linked `state_dir` exception remains readable
+  for compatibility, then snapshots its files without following further links.
+  `doctor` now names the link and resolved target and directs migration.
+  Diagnostics derive labels only after the guard, accept equivalent Windows 8.3
+  and canonical root spellings, and degrade concurrent path changes to unknown
+  instead of crashing.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -354,6 +354,24 @@ def _legacy_repo_path(root: Path, raw: str, field: str) -> Path:
     return resolved
 
 
+def _legacy_link_component(root: Path, raw: str) -> str | None:
+    """Return the first link-like pre-JSON path component without following it."""
+    relative = Path(raw)
+    if relative.is_absolute():
+        return None
+    current = root
+    for part in relative.parts:
+        if part in {"", "."}:
+            continue
+        current /= part
+        if _is_link_like(current):
+            try:
+                return current.relative_to(root).as_posix()
+            except ValueError:
+                return raw
+    return None
+
+
 def _workspace_from_paths(
     root: Path, paths: dict[str, str], *, legacy: bool = False
 ) -> Workspace:
@@ -460,11 +478,26 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
                 "and agent intent is unknown"
             ),
         })
+    workspace = _workspace_from_paths(root, values, legacy=True)
+    linked_state = _legacy_link_component(root, values["state_dir"])
+    if linked_state is not None:
+        resolved_state = relative_path(root, workspace.state_dir)
+        notices.append({
+            "code": "legacy-linked-state-dir",
+            "message": (
+                f"pre-JSON linked state_dir compatibility is active: {linked_state!r} "
+                f"resolves inside the repository to {resolved_state!r}; start and "
+                "session-start may read that resolved target, but canonical JSON "
+                "rejects linked paths. Replace the link or change workspace.yaml to "
+                "the resolved repository-relative path, then preview and propose "
+                "migration"
+            ),
+        })
     return WorkspaceResolution(
         # Repositories without tracked configuration use the same historical
         # path semantics as workspace.yaml. Tight path rules begin only after
         # a canonical JSON configuration is explicitly adopted.
-        workspace=_workspace_from_paths(root, values, legacy=True),
+        workspace=workspace,
         config=None,
         source=source,
         agents=None,
@@ -4148,6 +4181,9 @@ def doctor(
                 notice["message"] for notice in workspace_resolution.notices
             )
         add("workspace-config", workspace_status, detail)
+        for notice in workspace_resolution.notices:
+            if notice["code"] == "legacy-linked-state-dir":
+                add("legacy-linked-state-dir", "warn", notice["message"])
     except ContextOSError as exc:
         add("workspace-config", "fail", str(exc))
         # Keep diagnostics total even when the default path itself is the

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -481,16 +481,29 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
     workspace = _workspace_from_paths(root, values, legacy=True)
     linked_state = _legacy_link_component(root, values["state_dir"])
     if linked_state is not None:
-        resolved_state = relative_path(root, workspace.state_dir)
+        try:
+            resolved_state = workspace.state_dir.relative_to(root.resolve()).as_posix()
+        except ValueError as exc:
+            raise ContextOSError(
+                "resolved pre-JSON state_dir escaped the repository during "
+                "diagnostic labeling"
+            ) from exc
+        remediation = (
+            "Replace the link with a real directory, then run setup to complete "
+            "migration to canonical JSON"
+            if source == "defaults"
+            else (
+                "Replace the link or change workspace.yaml to the resolved "
+                "repository-relative path, then preview and propose migration"
+            )
+        )
         notices.append({
             "code": "legacy-linked-state-dir",
             "message": (
                 f"pre-JSON linked state_dir compatibility is active: {linked_state!r} "
                 f"resolves inside the repository to {resolved_state!r}; start and "
                 "session-start may read that resolved target, but canonical JSON "
-                "rejects linked paths. Replace the link or change workspace.yaml to "
-                "the resolved repository-relative path, then preview and propose "
-                "migration"
+                f"rejects linked paths. {remediation}"
             ),
         })
     return WorkspaceResolution(

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -143,13 +143,16 @@ v0.12 preserves the explicitly tested pre-JSON behavior for an internal linked
 readiness may read the resolved internal target, and update/end proposal/apply
 uses that resolved internal path rather than the link spelling. Migration and
 activation continue to reject the link. This is a compatibility exception, not
-part of the canonical no-follow guarantee.
+part of the canonical no-follow guarantee. Readiness files beneath the resolved
+target remain no-follow in every mode; the exception covers only the pre-JSON
+`state_dir` indirection and never a linked `current.md` or other descendant.
 
-`doctor` must identify the linked pre-JSON path, scope the exception, and direct
-the owner to migrate. Canonical JSON workspaces continue to reject linked or
+`doctor` identifies the link spelling and resolved internal target, scopes the
+exception, and directs the owner to replace or retarget the link before
+migration. Canonical JSON workspaces continue to reject linked or
 reparse-point state paths for `start`, hooks, and diagnostics. A future
 distinct-root mode requires canonical tracked configuration and does not inherit
-the exception. Issue #112 owns the diagnostic and control work.
+the exception.
 
 ## Future attachment binding
 

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -145,7 +145,9 @@ uses that resolved internal path rather than the link spelling. Migration and
 activation continue to reject the link. This is a compatibility exception, not
 part of the canonical no-follow guarantee. Readiness files beneath the resolved
 target remain no-follow in every mode; the exception covers only the pre-JSON
-`state_dir` indirection and never a linked `current.md` or other descendant.
+`state_dir` indirection for readiness and never a linked `current.md` or other
+descendant. Other legacy path fields retain their historical resolution
+semantics outside this readiness guarantee.
 
 `doctor` identifies the link spelling and resolved internal target, scopes the
 exception, and directs the owner to replace or retarget the link before

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -54,11 +54,11 @@ mode. The transaction-backed migration path can create the root JSON and record
 choices explicitly rather than inferring from installed binaries; setup-time
 selection and adapter composition remain separate work.
 
-Paths use canonical POSIX repository-relative syntax on every platform. Drives,
-UNC and absolute paths, backslashes, dot segments, Windows device aliases,
-`.git`, `.context-os`, and symlink traversal fail closed. The current defaults
-remain `state`, `sessions`, and `TODO.md`; migration does not silently move the
-task file to `state/tasks.md`.
+Canonical JSON paths use POSIX repository-relative syntax on every platform.
+Drives, UNC and absolute paths, backslashes, dot segments, Windows device
+aliases, `.git`, `.context-os`, and symlink traversal fail closed. The current
+defaults remain `state`, `sessions`, and `TODO.md`; migration does not silently
+move the task file to `state/tasks.md`.
 
 Path syntax validity is not write authorization. Update/end proposal
 publication, apply, and recovery also reject configured state/session targets
@@ -85,6 +85,17 @@ meaning differs across operating systems; replace them with POSIX `/` first.
 Duplicate keys, empty values, nested structures, anchors, block scalars,
 unknown keys, and unsafe paths block a supposedly lossless preview instead of
 being silently dropped.
+
+Pre-JSON readiness preserves one narrower host-compatibility exception: an
+internal linked `state_dir` is resolved inside the repository, so `start` and
+the session-start hook read the resolved target. `doctor` reports the link and
+resolved target as a warning with migration guidance. Migration remains blocked
+until the link is replaced or `workspace.yaml` names the resolved
+repository-relative directory directly; activation remains blocked until that
+canonical JSON migration is applied. Canonical JSON does not inherit this
+exception and rejects linked or reparse-point configured paths. Readiness files
+beneath the resolved pre-JSON target remain no-follow; a linked `current.md` or
+other descendant is rejected in every mode.
 
 Inspect effective state:
 

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -22,6 +22,7 @@ from contextos.kernel import (
     create_agent_activation_proposal,
     create_proposal,
     create_workspace_migration_proposal,
+    create_workspace_setup_proposal,
     discover_root,
     doctor,
     git_head,
@@ -1581,6 +1582,101 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
             with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
                 hook_report(self.root, "session-start", {}, today=NOW.date())
 
+    def test_legacy_linked_state_readiness_is_compatible_and_diagnosed(self) -> None:
+        real_state = self.root / "real-state"
+        (self.root / "state").rename(real_state)
+        linked_state = self.root / "linked-state"
+        try:
+            make_directory_link(linked_state, real_state)
+        except OSError:
+            self.skipTest("directory link creation is unavailable")
+        (self.root / "workspace.yaml").write_text(
+            "state_dir: linked-state\n", encoding="utf-8"
+        )
+        before = {
+            path.relative_to(self.root).as_posix(): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+
+        report = start_report(self.root, NOW)
+        self.assertTrue(report["initialized"])
+        self.assertIn("real-state/current.md", report["state"])
+        self.assertFalse(any(
+            "not initialized" in finding["message"]
+            for finding in hook_report(
+                self.root, "session-start", {}, today=NOW.date()
+            )["findings"]
+        ))
+
+        checks = {item["name"]: item for item in doctor(self.root)["checks"]}
+        linked = checks["legacy-linked-state-dir"]
+        self.assertEqual("warn", linked["status"])
+        self.assertIn("linked-state", linked["detail"])
+        self.assertIn("real-state", linked["detail"])
+        self.assertIn("migration", linked["detail"])
+        self.assertEqual("pass", checks["initialization-state"]["status"])
+
+        with self.assertRaisesRegex(ContextOSError, "cannot be activated safely"):
+            create_workspace_migration_proposal(self.root, ("codex",), NOW)
+        with self.assertRaisesRegex(ContextOSError, "requires contextos.workspace.json"):
+            create_agent_activation_proposal(self.root, "codex", True, NOW)
+        after = {
+            path.relative_to(self.root).as_posix(): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(before, after)
+        self.assertFalse((self.root / "contextos.workspace.json").exists())
+        self.assertFalse((self.root / ".context-os/proposals").exists())
+
+        (real_state / "current.md").write_text(
+            "# Current State\n\n**Last Updated:** [DATE]\n", encoding="utf-8"
+        )
+        self.assertFalse(start_report(self.root, NOW)["initialized"])
+        self.assertTrue(any(
+            "not initialized" in finding["message"]
+            for finding in hook_report(
+                self.root, "session-start", {}, today=NOW.date()
+            )["findings"]
+        ))
+
+        (self.root / "workspace.yaml").write_text(
+            "state_dir: real-state\n", encoding="utf-8"
+        )
+        direct_checks = {
+            item["name"]: item for item in doctor(self.root)["checks"]
+        }
+        self.assertNotIn("legacy-linked-state-dir", direct_checks)
+
+    def test_default_linked_state_uses_the_same_pre_json_diagnostic(self) -> None:
+        real_state = self.root / "real-state"
+        (self.root / "state").rename(real_state)
+        try:
+            make_directory_link(self.root / "state", real_state)
+        except OSError:
+            self.skipTest("directory link creation is unavailable")
+
+        report = start_report(self.root, NOW)
+        self.assertTrue(report["initialized"])
+        self.assertIn("real-state/current.md", report["state"])
+        self.assertFalse(any(
+            "not initialized" in finding["message"]
+            for finding in hook_report(
+                self.root, "session-start", {}, today=NOW.date()
+            )["findings"]
+        ))
+        checks = {item["name"]: item for item in doctor(self.root)["checks"]}
+        linked = checks["legacy-linked-state-dir"]
+        self.assertEqual("warn", linked["status"])
+        self.assertIn("'state'", linked["detail"])
+        self.assertIn("real-state", linked["detail"])
+        self.assertIn("migration", linked["detail"])
+        with self.assertRaisesRegex(ContextOSError, "cannot be activated safely"):
+            create_workspace_setup_proposal(self.root, ("codex",), NOW)
+        self.assertFalse((self.root / "contextos.workspace.json").exists())
+        self.assertFalse((self.root / ".context-os/proposals").exists())
+
     def test_readiness_snapshot_rejects_link_swap_after_guard(self) -> None:
         with tempfile.TemporaryDirectory() as external:
             outside = Path(external) / "outside-current.md"
@@ -2327,10 +2423,14 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
             (self.root / "state").rename(outside)
             state = self.root / "state"
             try:
-                state.symlink_to(outside, target_is_directory=True)
+                make_directory_link(state, outside)
             except OSError:
                 outside.rename(state)
-                self.skipTest("directory symlink creation is unavailable")
+                self.skipTest("directory link creation is unavailable")
+            with self.assertRaisesRegex(ContextOSError, "escapes the repository root"):
+                start_report(self.root, NOW)
+            with self.assertRaisesRegex(ContextOSError, "escapes the repository root"):
+                hook_report(self.root, "session-start", {}, today=NOW.date())
             report = doctor(self.root)
         self.assertEqual("fail", report["status"])
         self.assertEqual("invalid", report["scope"])

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1672,10 +1672,37 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         self.assertIn("'state'", linked["detail"])
         self.assertIn("real-state", linked["detail"])
         self.assertIn("migration", linked["detail"])
+        self.assertIn("run setup", linked["detail"])
+        self.assertNotIn("change workspace.yaml", linked["detail"])
         with self.assertRaisesRegex(ContextOSError, "cannot be activated safely"):
             create_workspace_setup_proposal(self.root, ("codex",), NOW)
         self.assertFalse((self.root / "contextos.workspace.json").exists())
         self.assertFalse((self.root / ".context-os/proposals").exists())
+
+    def test_legacy_linked_state_still_rejects_linked_readiness_descendant(self) -> None:
+        real_state = self.root / "real-state"
+        (self.root / "state").rename(real_state)
+        linked_state = self.root / "linked-state"
+        try:
+            make_directory_link(linked_state, real_state)
+        except OSError:
+            self.skipTest("directory link creation is unavailable")
+        (self.root / "workspace.yaml").write_text(
+            "state_dir: linked-state\n", encoding="utf-8"
+        )
+        current = real_state / "current.md"
+        real_current = real_state / "real-current.md"
+        current.rename(real_current)
+        try:
+            current.symlink_to(real_current)
+        except OSError:
+            real_current.rename(current)
+            self.skipTest("file symlink creation is unavailable")
+
+        with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
+            start_report(self.root, NOW)
+        with self.assertRaisesRegex(ContextOSError, "symlink or reparse point"):
+            hook_report(self.root, "session-start", {}, today=NOW.date())
 
     def test_readiness_snapshot_rejects_link_swap_after_guard(self) -> None:
         with tempfile.TemporaryDirectory() as external:


### PR DESCRIPTION
Closes #112.

Preserves the v0.12 pre-JSON compatibility boundary for an internal linked state_dir while making it explicit and diagnosable. start and session-start may read the resolved in-repository target; doctor names the link and resolved target with migration guidance; migration/setup and activation remain fail-closed; canonical JSON and descendant readiness files retain no-follow behavior.

Verification:
- scripts/validate-all.sh
- 539 tests passed, 41 expected skips
- portability, hooks, integration catalog, manifests, bundle lock, runtime registry, workspace config, docs/links, and JSON checks passed

Exact-SHA Claude Opus and free Hermes Inkling reviews will be posted before merge.