### PR TITLE
fix: normalize readiness roots and doctor races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,9 +103,10 @@
   documented pre-JSON internal linked `state_dir` exception remains readable
   for compatibility, then snapshots its files without following further links.
   `doctor` now names the link and resolved target and directs migration.
-  Diagnostics derive labels only after the guard, accept equivalent Windows 8.3
-  and canonical root spellings, and degrade concurrent path changes to unknown
-  instead of crashing.
+  Direct start and hook API calls canonicalize their exact supplied root without
+  upward discovery. Diagnostics derive labels only after the guard, accept
+  equivalent POSIX symlink, Windows 8.3, and canonical root spellings, and
+  degrade concurrent path changes to unknown instead of crashing.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,10 +103,12 @@
   documented pre-JSON internal linked `state_dir` exception remains readable
   for compatibility, then snapshots its files without following further links.
   `doctor` now names the link and resolved target and directs migration.
-  Direct start and hook API calls canonicalize their exact supplied root without
-  upward discovery. Diagnostics derive labels only after the guard, accept
-  equivalent POSIX symlink, Windows 8.3, and canonical root spellings, and
-  degrade concurrent path changes to unknown instead of crashing.
+  Direct start, hook, and doctor API calls canonicalize their exact supplied
+  root without upward discovery. Diagnostics derive labels only after the
+  guard, accept equivalent POSIX symlink, Windows junction/8.3, and canonical
+  root spellings, and degrade concurrent path changes to explicit unknown
+  warnings instead of crashing. The diagnostic remains non-failing at the CLI
+  level, so a late race returns the structured warnings with exit status zero.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,9 +106,10 @@
   Direct start, hook, and doctor API calls canonicalize their exact supplied
   root without upward discovery. Diagnostics derive labels only after the
   guard, accept equivalent POSIX symlink, Windows junction/8.3, and canonical
-  root spellings, and degrade concurrent path changes to explicit unknown
-  warnings instead of crashing. The diagnostic remains non-failing at the CLI
-  level, so a late race returns the structured warnings with exit status zero.
+  root spellings, and degrade concurrent path changes to structured diagnostics
+  instead of crashing. Initialization and freshness become explicit unknown
+  warnings; a required state file that becomes link-like is a failing check and
+  makes the doctor CLI exit with status one.
 - Git-index materialization now stages the exact index blobs verified against
   the bundle lock, so CRLF checkout transforms, clean/smudge filters, and
   unrelated unstaged source edits cannot replace or invalidate approved bytes.

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3832,7 +3832,7 @@ def _initialization_state(
         try:
             _guard_local_state_path(workspace.root, path)
             state[relative] = _state_freshness(path, today, threshold)
-        except ContextOSError:
+        except ContextOSError as exc:
             if not tolerate_unsafe:
                 raise
             state[relative] = {
@@ -3842,6 +3842,7 @@ def _initialization_state(
                 "stale_after_days": threshold,
                 "freshness_status": "unknown",
                 "stale": None,
+                "unavailable_reason": str(exc),
             }
     gate = (state_dir_relative / INITIALIZATION_FILE).as_posix()
     return _is_initialized(state[gate]), state
@@ -4261,32 +4262,36 @@ def doctor(
             initialized, initialization_files = _initialization_state(
                 workspace, effective_today, tolerate_unsafe=True
             )
-            initialization_detail = (
-                "ready"
-                if initialized
-                else (
-                    f"recovery required; {gate} carries a future **Last Updated:** "
-                    "date; "
-                    + FUTURE_DATE_NEXT_ACTION
-                    if initialization_files[gate]["freshness_status"] == "future"
-                    else (
+            gate_state = initialization_files[gate]
+            initialization_detail = "ready"
+            if not initialized:
+                if gate_state.get("unavailable_reason"):
+                    initialization_detail = (
+                        f"initialization state is unknown; cannot inspect {gate}: "
+                        f"{gate_state['unavailable_reason']}"
+                    )
+                elif gate_state["freshness_status"] == "future":
+                    initialization_detail = (
+                        f"recovery required; {gate} carries a future "
+                        f"**Last Updated:** date; {FUTURE_DATE_NEXT_ACTION}"
+                    )
+                else:
+                    initialization_detail = (
                         f"guided setup required; {gate} carries no real "
                         "**Last Updated:** date"
                     )
-                )
-            )
         except ContextOSError as exc:
             add(
                 "initialization-state",
                 "warn",
-                f"initialization state is unknown because state changed during "
-                f"diagnosis: {exc}",
+                f"initialization state is unknown because state could not be "
+                f"revalidated during diagnosis: {exc}",
             )
             add(
                 "state-freshness",
                 "warn",
-                f"state freshness is unknown because state changed during "
-                f"diagnosis: {exc}",
+                f"state freshness is unknown because state could not be "
+                f"revalidated during diagnosis: {exc}",
             )
         else:
             add(
@@ -4299,12 +4304,18 @@ def doctor(
                 for path, item in initialization_files.items()
                 if item["freshness_status"] == "future"
             ]
+            unavailable = {
+                path: str(item["unavailable_reason"])
+                for path, item in initialization_files.items()
+                if item.get("unavailable_reason")
+            }
             unusable = [
                 path
                 for path, item in initialization_files.items()
                 if item["freshness_status"] in {"missing", "unknown"}
+                and path not in unavailable
             ]
-            unresolved = future + unusable
+            unresolved = future + list(unavailable) + unusable
             freshness_details = []
             if future:
                 freshness_details.append(
@@ -4313,6 +4324,14 @@ def doctor(
             if unusable:
                 freshness_details.append(
                     "no usable **Last Updated:** date in: " + ", ".join(unusable)
+                )
+            if unavailable:
+                freshness_details.append(
+                    "could not inspect: "
+                    + "; ".join(
+                        f"{path}: {reason}"
+                        for path, reason in unavailable.items()
+                    )
                 )
             add(
                 "state-freshness",

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -3860,6 +3860,7 @@ def _initialization_next_action(
 
 
 def start_report(root: Path, now: datetime) -> dict[str, Any]:
+    root = root.resolve()
     workspace = load_workspace(root)
     initialized, files = _initialization_state(workspace, now.date())
     sessions = sorted(workspace.sessions_dir.glob("????-??-??.md"), reverse=True) if workspace.sessions_dir.exists() else []
@@ -4256,48 +4257,70 @@ def doctor(
             "cannot inspect unsafe state path(s): " + ", ".join(unsafe_freshness),
         )
     else:
-        initialized, initialization_files = _initialization_state(
-            workspace, effective_today, tolerate_unsafe=True
-        )
-        add(
-            "initialization-state",
-            "pass" if initialized else "warn",
-            "ready"
-            if initialized
-            else (
-                f"recovery required; {gate} carries a future **Last Updated:** date; "
-                + _initialization_next_action(workspace, initialization_files)
-                if initialization_files[gate]["freshness_status"] == "future"
-                else f"guided setup required; {gate} carries no real **Last Updated:** date"
-            ),
-        )
-        future = [
-            path
-            for path, item in initialization_files.items()
-            if item["freshness_status"] == "future"
-        ]
-        unusable = [
-            path
-            for path, item in initialization_files.items()
-            if item["freshness_status"] in {"missing", "unknown"}
-        ]
-        unresolved = future + unusable
-        freshness_details = []
-        if future:
-            freshness_details.append(
-                "future **Last Updated:** date in: " + ", ".join(future)
+        try:
+            initialized, initialization_files = _initialization_state(
+                workspace, effective_today, tolerate_unsafe=True
             )
-        if unusable:
-            freshness_details.append(
-                "no usable **Last Updated:** date in: " + ", ".join(unusable)
+            initialization_detail = (
+                "ready"
+                if initialized
+                else (
+                    f"recovery required; {gate} carries a future **Last Updated:** "
+                    "date; "
+                    + FUTURE_DATE_NEXT_ACTION
+                    if initialization_files[gate]["freshness_status"] == "future"
+                    else (
+                        f"guided setup required; {gate} carries no real "
+                        "**Last Updated:** date"
+                    )
+                )
             )
-        add(
-            "state-freshness",
-            "pass" if not unresolved else "warn",
-            "all tracked state files carry a real date"
-            if not unresolved
-            else "; ".join(freshness_details),
-        )
+        except ContextOSError as exc:
+            add(
+                "initialization-state",
+                "warn",
+                f"initialization state is unknown because state changed during "
+                f"diagnosis: {exc}",
+            )
+            add(
+                "state-freshness",
+                "warn",
+                f"state freshness is unknown because state changed during "
+                f"diagnosis: {exc}",
+            )
+        else:
+            add(
+                "initialization-state",
+                "pass" if initialized else "warn",
+                initialization_detail,
+            )
+            future = [
+                path
+                for path, item in initialization_files.items()
+                if item["freshness_status"] == "future"
+            ]
+            unusable = [
+                path
+                for path, item in initialization_files.items()
+                if item["freshness_status"] in {"missing", "unknown"}
+            ]
+            unresolved = future + unusable
+            freshness_details = []
+            if future:
+                freshness_details.append(
+                    "future **Last Updated:** date in: " + ", ".join(future)
+                )
+            if unusable:
+                freshness_details.append(
+                    "no usable **Last Updated:** date in: " + ", ".join(unusable)
+                )
+            add(
+                "state-freshness",
+                "pass" if not unresolved else "warn",
+                "all tracked state files carry a real date"
+                if not unresolved
+                else "; ".join(freshness_details),
+            )
 
     local_hosts = {"schema_version": HOST_STATE_SCHEMA_VERSION, "hosts": {}}
     local_hosts_valid = False
@@ -4980,6 +5003,7 @@ def hook_report(
     *,
     today: date | None = None,
 ) -> dict[str, Any]:
+    root = root.resolve()
     findings: list[dict[str, str]] = []
     workspace = load_workspace(root)
     if event == "session-start":

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -4234,10 +4234,38 @@ def doctor(
     for path in required_paths:
         rel = state_path_labels[path]
         error = state_path_errors.get(path)
+        required_status = "fail" if error else "warn"
+        required_detail = error or rel
+        if error is None:
+            try:
+                metadata = path.lstat()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                required_status = "fail"
+                required_detail = f"cannot inspect required state path: {exc}"
+            else:
+                link_tags = {
+                    getattr(stat, "IO_REPARSE_TAG_SYMLINK", -1),
+                    getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", -2),
+                }
+                if stat.S_ISLNK(metadata.st_mode) or getattr(
+                    metadata, "st_reparse_tag", 0
+                ) in link_tags:
+                    required_status = "fail"
+                    required_detail = (
+                        "required state path became a symlink or reparse point "
+                        f"during diagnosis: {rel}"
+                    )
+                elif stat.S_ISREG(metadata.st_mode):
+                    required_status = "pass"
+                else:
+                    required_status = "fail"
+                    required_detail = f"required state path is not a regular file: {rel}"
         add(
             f"file:{rel}",
-            "fail" if error else "pass" if path.exists() else "warn",
-            error or rel,
+            required_status,
+            required_detail,
         )
     unsafe_freshness = [
         state_path_labels[path]
@@ -4249,7 +4277,7 @@ def doctor(
         add(
             "initialization-state",
             "warn",
-            "guided setup required; unsafe state path(s): "
+            "initialization state is unknown; cannot inspect unsafe state path(s): "
             + ", ".join(unsafe_freshness),
         )
         add(

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -124,8 +124,9 @@ containment or identity checks.
   first. Direct callers and CLI callers share one canonical readiness contract.
 - Strict lifecycle reads and hooks fail closed when a path changes identity or
   becomes link-like after canonicalization. `doctor` remains diagnostic: a
-  late race produces a structured `unknown`/warning result rather than a
-  traceback or a followed link.
+  late race produces structured results rather than a traceback or followed
+  link. Initialization and freshness become `unknown` warnings; a required
+  state file that becomes link-like remains a failing check.
 - Discovery never falls through an invalid nearer marker or climbs past a
   nested Git boundary to capture an outer ContextRoot.
 

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -118,10 +118,10 @@ for containment or identity checks.
 
 - In v0.12, CLI discovery returns the canonical ContextRoot and nominal
   WorkingRoot; full-template wrapper execution also loads KernelRoot there.
-- Direct Python `start_report` and `hook_report` calls normalize the exact
-  supplied root to the same canonical ContextRoot spelling before workspace
-  resolution; they do not search upward. The CLI performs discovery first.
-  Direct callers and CLI callers share one canonical readiness contract.
+- Direct Python `start_report`, `hook_report`, and `doctor` calls normalize the
+  exact supplied root to the same canonical ContextRoot spelling before
+  workspace resolution; they do not search upward. The CLI performs discovery
+  first. Direct callers and CLI callers share one canonical readiness contract.
 - Strict lifecycle reads and hooks fail closed when a path changes identity or
   becomes link-like after canonicalization. `doctor` remains diagnostic: a
   late race produces a structured `unknown`/warning result rather than a

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -113,8 +113,8 @@ composition.
 
 ## Resolution and canonicalization
 
-Every public readiness/report entrypoint canonicalizes its root before using it
-for containment or identity checks.
+The public readiness entrypoints canonicalize their root before using it for
+containment or identity checks.
 
 - In v0.12, CLI discovery returns the canonical ContextRoot and nominal
   WorkingRoot; full-template wrapper execution also loads KernelRoot there.

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -113,15 +113,15 @@ composition.
 
 ## Resolution and canonicalization
 
-Before v0.12 release, every public lifecycle/report entrypoint must canonicalize
-its root exactly once before using it for containment or identity checks.
+Every public readiness/report entrypoint canonicalizes its root before using it
+for containment or identity checks.
 
 - In v0.12, CLI discovery returns the canonical ContextRoot and nominal
   WorkingRoot; full-template wrapper execution also loads KernelRoot there.
-- Public Python lifecycle/report functions that accept a raw root path must
-  normalize it to the same canonical ContextRoot spelling before workspace
-  resolution. Direct callers and CLI callers are one contract, not separate
-  safety tiers. Issue #113 implements and tests this release requirement.
+- Direct Python `start_report` and `hook_report` calls normalize the exact
+  supplied root to the same canonical ContextRoot spelling before workspace
+  resolution; they do not search upward. The CLI performs discovery first.
+  Direct callers and CLI callers share one canonical readiness contract.
 - Strict lifecycle reads and hooks fail closed when a path changes identity or
   becomes link-like after canonicalization. `doctor` remains diagnostic: a
   late race produces a structured `unknown`/warning result rather than a

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -2566,7 +2566,7 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
     def test_doctor_normalizes_an_unresolved_root(self) -> None:
         unresolved = self.root / "nested" / ".."
 
-        report = doctor(unresolved)
+        report = doctor(unresolved, today=NOW.date())
 
         self.assertIn(report["status"], {"pass", "warn"})
         self.assertTrue(any(

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1532,70 +1532,81 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         canonical_hook = hook_report(
             self.root.resolve(), "session-start", {}, today=NOW.date()
         )
-        with tempfile.TemporaryDirectory() as external:
-            linked_root = Path(external) / "linked-root"
-            try:
-                make_directory_link(linked_root, self.root.resolve())
-            except OSError:
-                self.skipTest("directory link creation is unavailable")
+        external = tempfile.TemporaryDirectory()
+        self.addCleanup(external.cleanup)
+        linked_root = Path(external.name) / "linked-root"
+        try:
+            make_directory_link(linked_root, self.root.resolve())
+        except OSError:
+            self.skipTest("directory link creation is unavailable")
 
-            self.assertEqual(canonical_report, start_report(linked_root, NOW))
+        def remove_linked_root() -> None:
+            if os.name == "nt" and linked_root.exists():
+                linked_root.rmdir()
+            elif linked_root.is_symlink():
+                linked_root.unlink()
+
+        # Cleanups run LIFO, so remove the cross-fixture link before deleting
+        # its containing temporary directory on every supported Python version.
+        self.addCleanup(remove_linked_root)
+
+        self.assertEqual(canonical_report, start_report(linked_root, NOW))
+        self.assertEqual(
+            canonical_hook,
+            hook_report(
+                linked_root, "session-start", {}, today=NOW.date()
+            )
+        )
+
+        output = io.StringIO()
+        with mock.patch("sys.stdout", new=output):
             self.assertEqual(
-                canonical_hook,
-                hook_report(
-                    linked_root, "session-start", {}, today=NOW.date()
-                ),
+                0,
+                cli_main([
+                    "--root",
+                    str(linked_root),
+                    "start",
+                    "--now",
+                    NOW.isoformat(),
+                ]),
             )
+        self.assertEqual(canonical_report, json.loads(output.getvalue()))
 
-            output = io.StringIO()
-            with mock.patch("sys.stdout", new=output):
-                self.assertEqual(
-                    0,
-                    cli_main([
-                        "--root",
-                        str(linked_root),
-                        "start",
-                        "--now",
-                        NOW.isoformat(),
-                    ]),
-                )
-            self.assertEqual(canonical_report, json.loads(output.getvalue()))
+        (self.root / "state/current.md").write_text(
+            "# Current State\n\n**Last Updated:** [DATE]\n", encoding="utf-8"
+        )
+        canonical_advisory = hook_report(
+            self.root.resolve(), "session-start", {}, today=NOW.date()
+        )
+        self.assertEqual(
+            canonical_advisory,
+            hook_report(
+                linked_root, "session-start", {}, today=NOW.date()
+            ),
+        )
+        self.assertTrue(any(
+            "not initialized" in finding["message"]
+            for finding in canonical_advisory["findings"]
+        ))
 
-            (self.root / "state/current.md").write_text(
-                "# Current State\n\n**Last Updated:** [DATE]\n", encoding="utf-8"
-            )
-            canonical_advisory = hook_report(
-                self.root.resolve(), "session-start", {}, today=NOW.date()
-            )
+        hook_output = io.StringIO()
+        with mock.patch("sys.stdin", new=io.StringIO("{}")), mock.patch(
+            "sys.stdout", new=hook_output
+        ):
             self.assertEqual(
-                canonical_advisory,
-                hook_report(
-                    linked_root, "session-start", {}, today=NOW.date()
-                ),
+                0,
+                cli_main([
+                    "--root",
+                    str(linked_root),
+                    "hook",
+                    "session-start",
+                    "--runtime",
+                    "codex",
+                ]),
             )
-            self.assertTrue(any(
-                "not initialized" in finding["message"]
-                for finding in canonical_advisory["findings"]
-            ))
-
-            hook_output = io.StringIO()
-            with mock.patch("sys.stdin", new=io.StringIO("{}")), mock.patch(
-                "sys.stdout", new=hook_output
-            ):
-                self.assertEqual(
-                    0,
-                    cli_main([
-                        "--root",
-                        str(linked_root),
-                        "hook",
-                        "session-start",
-                        "--runtime",
-                        "codex",
-                    ]),
-                )
-            rendered_hook = json.loads(hook_output.getvalue())
-            self.assertIn("not initialized", rendered_hook["systemMessage"])
-            self.assertNotIn("could not run", rendered_hook["systemMessage"])
+        rendered_hook = json.loads(hook_output.getvalue())
+        self.assertIn("not initialized", rendered_hook["systemMessage"])
+        self.assertNotIn("could not run", rendered_hook["systemMessage"])
 
     def test_future_dated_state_is_not_treated_as_initialized(self) -> None:
         (self.root / "state/current.md").write_text(
@@ -1641,6 +1652,7 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
                 "# External\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
             )
             current = self.root / "state/current.md"
+            original_current = current.read_bytes()
             current.unlink()
             try:
                 current.symlink_to(outside)
@@ -2558,6 +2570,74 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         report = doctor(unresolved)
 
         self.assertIn(report["status"], {"pass", "warn"})
+        self.assertTrue(any(
+            item["name"] == "file:state/current.md"
+            and item["status"] == "pass"
+            for item in report["checks"]
+        ))
+
+    @unittest.skipIf(os.name == "nt", "POSIX file-link race regression")
+    def test_doctor_required_file_probe_does_not_follow_a_late_link(self) -> None:
+        with tempfile.TemporaryDirectory() as external:
+            outside = Path(external) / "outside-current.md"
+            outside.write_text(
+                "# External\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
+            )
+            current = self.root / "state/current.md"
+            original_guard = __import__(
+                "contextos.kernel", fromlist=["_guard_local_state_path"]
+            )._guard_local_state_path
+            original_freshness = __import__(
+                "contextos.kernel", fromlist=["_state_freshness"]
+            )._state_freshness
+            swapped = False
+
+            def swap_after_label(root: Path, path: Path) -> Path:
+                nonlocal swapped
+                relative = original_guard(root, path)
+                if path == current and not swapped:
+                    current.unlink()
+                    try:
+                        current.symlink_to(outside)
+                    except OSError:
+                        self.skipTest("file symlink creation is unavailable")
+                    swapped = True
+                return relative
+
+            def reject_replacement_snapshot(
+                path: Path, today: date, threshold: int
+            ) -> dict[str, object]:
+                if path == current:
+                    raise AssertionError("replacement state must not be read")
+                return original_freshness(path, today, threshold)
+
+            try:
+                with mock.patch(
+                    "contextos.kernel._guard_local_state_path",
+                    side_effect=swap_after_label,
+                ), mock.patch(
+                    "contextos.kernel._state_freshness",
+                    side_effect=reject_replacement_snapshot,
+                ):
+                    report = doctor(self.root, today=NOW.date())
+            finally:
+                if current.is_symlink():
+                    current.unlink()
+                if not current.exists():
+                    current.write_bytes(original_current)
+
+        required = next(
+            item
+            for item in report["checks"]
+            if item["name"] == "file:state/current.md"
+        )
+        initialization = next(
+            item for item in report["checks"] if item["name"] == "initialization-state"
+        )
+        self.assertEqual("fail", required["status"])
+        self.assertIn("symlink or reparse point", required["detail"])
+        self.assertEqual("warn", initialization["status"])
+        self.assertIn("unknown", initialization["detail"])
 
     def test_doctor_reports_linked_state_file_without_crashing(self) -> None:
         with tempfile.TemporaryDirectory() as external:

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1527,6 +1527,77 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         )
         self.assertEqual("pass", initialization["status"])
 
+    @unittest.skipIf(os.name == "nt", "POSIX symlink-root regression")
+    def test_direct_reports_and_cli_normalize_a_symlinked_root(self) -> None:
+        canonical_report = start_report(self.root.resolve(), NOW)
+        canonical_hook = hook_report(
+            self.root.resolve(), "session-start", {}, today=NOW.date()
+        )
+        with tempfile.TemporaryDirectory() as external:
+            linked_root = Path(external) / "linked-root"
+            try:
+                linked_root.symlink_to(self.root.resolve(), target_is_directory=True)
+            except OSError:
+                self.skipTest("directory symlink creation is unavailable")
+
+            self.assertEqual(canonical_report, start_report(linked_root, NOW))
+            self.assertEqual(
+                canonical_hook,
+                hook_report(
+                    linked_root, "session-start", {}, today=NOW.date()
+                ),
+            )
+
+            output = io.StringIO()
+            with mock.patch("sys.stdout", new=output):
+                self.assertEqual(
+                    0,
+                    cli_main([
+                        "--root",
+                        str(linked_root),
+                        "start",
+                        "--now",
+                        NOW.isoformat(),
+                    ]),
+                )
+            self.assertEqual(canonical_report, json.loads(output.getvalue()))
+
+            (self.root / "state/current.md").write_text(
+                "# Current State\n\n**Last Updated:** [DATE]\n", encoding="utf-8"
+            )
+            canonical_advisory = hook_report(
+                self.root.resolve(), "session-start", {}, today=NOW.date()
+            )
+            self.assertEqual(
+                canonical_advisory,
+                hook_report(
+                    linked_root, "session-start", {}, today=NOW.date()
+                ),
+            )
+            self.assertTrue(any(
+                "not initialized" in finding["message"]
+                for finding in canonical_advisory["findings"]
+            ))
+
+            hook_output = io.StringIO()
+            with mock.patch("sys.stdin", new=io.StringIO("{}")), mock.patch(
+                "sys.stdout", new=hook_output
+            ):
+                self.assertEqual(
+                    0,
+                    cli_main([
+                        "--root",
+                        str(linked_root),
+                        "hook",
+                        "session-start",
+                        "--runtime",
+                        "codex",
+                    ]),
+                )
+            rendered_hook = json.loads(hook_output.getvalue())
+            self.assertIn("not initialized", rendered_hook["systemMessage"])
+            self.assertNotIn("could not run", rendered_hook["systemMessage"])
+
     def test_future_dated_state_is_not_treated_as_initialized(self) -> None:
         (self.root / "state/current.md").write_text(
             "# Current State\n\n**Last Updated:** 2099-01-01\n",
@@ -1749,6 +1820,62 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         )
         self.assertEqual("warn", initialization["status"])
         self.assertEqual("warn", freshness["status"])
+
+    def test_doctor_degrades_post_label_state_swap_to_unknown(self) -> None:
+        original = __import__(
+            "contextos.kernel", fromlist=["_initialization_state"]
+        )._initialization_state
+        state = self.root / "state"
+        swapped = False
+
+        with tempfile.TemporaryDirectory() as external:
+            outside = Path(external) / "outside-state"
+
+            def swap_before_snapshot(
+                workspace,
+                today: date,
+                *,
+                tolerate_unsafe: bool = False,
+            ):
+                nonlocal swapped
+                if not swapped:
+                    state.rename(outside)
+                    try:
+                        make_directory_link(state, outside)
+                    except OSError:
+                        outside.rename(state)
+                        self.skipTest("directory link creation is unavailable")
+                    swapped = True
+                return original(
+                    workspace, today, tolerate_unsafe=tolerate_unsafe
+                )
+
+            try:
+                with mock.patch(
+                    "contextos.kernel._initialization_state",
+                    side_effect=swap_before_snapshot,
+                ), mock.patch(
+                    "contextos.kernel._state_freshness",
+                    side_effect=AssertionError("replacement state must not be read"),
+                ):
+                    report = doctor(self.root, today=NOW.date())
+            finally:
+                if swapped:
+                    state.rmdir() if os.name == "nt" else state.unlink()
+                    outside.rename(state)
+
+        initialization = next(
+            item for item in report["checks"] if item["name"] == "initialization-state"
+        )
+        freshness = next(
+            item for item in report["checks"] if item["name"] == "state-freshness"
+        )
+        self.assertEqual("warn", initialization["status"])
+        self.assertIn("unknown", initialization["detail"])
+        self.assertIn("state changed during diagnosis", initialization["detail"])
+        self.assertEqual("warn", freshness["status"])
+        self.assertIn("unknown", freshness["detail"])
+        self.assertNotEqual("pass", report["status"])
 
     def test_shipped_state_templates_retain_date_placeholders(self) -> None:
         for filename in ("current.md", "weekly-priorities.md", "blockers.md"):

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1652,7 +1652,6 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
                 "# External\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
             )
             current = self.root / "state/current.md"
-            original_current = current.read_bytes()
             current.unlink()
             try:
                 current.symlink_to(outside)
@@ -2584,6 +2583,7 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
                 "# External\n\n**Last Updated:** 2026-08-23\n", encoding="utf-8"
             )
             current = self.root / "state/current.md"
+            original_current = current.read_bytes()
             original_guard = __import__(
                 "contextos.kernel", fromlist=["_guard_local_state_path"]
             )._guard_local_state_path

--- a/tests/test_contextos_kernel.py
+++ b/tests/test_contextos_kernel.py
@@ -1527,8 +1527,7 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         )
         self.assertEqual("pass", initialization["status"])
 
-    @unittest.skipIf(os.name == "nt", "POSIX symlink-root regression")
-    def test_direct_reports_and_cli_normalize_a_symlinked_root(self) -> None:
+    def test_direct_reports_and_cli_normalize_a_linked_root(self) -> None:
         canonical_report = start_report(self.root.resolve(), NOW)
         canonical_hook = hook_report(
             self.root.resolve(), "session-start", {}, today=NOW.date()
@@ -1536,9 +1535,9 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         with tempfile.TemporaryDirectory() as external:
             linked_root = Path(external) / "linked-root"
             try:
-                linked_root.symlink_to(self.root.resolve(), target_is_directory=True)
+                make_directory_link(linked_root, self.root.resolve())
             except OSError:
-                self.skipTest("directory symlink creation is unavailable")
+                self.skipTest("directory link creation is unavailable")
 
             self.assertEqual(canonical_report, start_report(linked_root, NOW))
             self.assertEqual(
@@ -1820,6 +1819,8 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         )
         self.assertEqual("warn", initialization["status"])
         self.assertEqual("warn", freshness["status"])
+        self.assertIn("unknown", initialization["detail"])
+        self.assertIn("could not inspect", freshness["detail"])
 
     def test_doctor_degrades_post_label_state_swap_to_unknown(self) -> None:
         original = __import__(
@@ -1861,8 +1862,12 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
                     report = doctor(self.root, today=NOW.date())
             finally:
                 if swapped:
-                    state.rmdir() if os.name == "nt" else state.unlink()
-                    outside.rename(state)
+                    if os.name == "nt" and state.exists():
+                        state.rmdir()
+                    elif state.is_symlink():
+                        state.unlink()
+                    if outside.exists() and not state.exists():
+                        outside.rename(state)
 
         initialization = next(
             item for item in report["checks"] if item["name"] == "initialization-state"
@@ -1872,7 +1877,7 @@ with mock.patch("contextos.kernel._fsync_directory", side_effect=crash_after_tar
         )
         self.assertEqual("warn", initialization["status"])
         self.assertIn("unknown", initialization["detail"])
-        self.assertIn("state changed during diagnosis", initialization["detail"])
+        self.assertIn("could not be revalidated", initialization["detail"])
         self.assertEqual("warn", freshness["status"])
         self.assertIn("unknown", freshness["detail"])
         self.assertNotEqual("pass", report["status"])


### PR DESCRIPTION
Closes #113.

Canonicalizes the exact root supplied to direct `start_report` and `hook_report` calls without adding upward discovery, keeping direct and CLI readiness behavior aligned for POSIX aliases. Doctor now converts post-label state identity changes into explicit unknown/warning diagnostics without retrying or reading the replacement path. Strict start/session-hook no-follow failures remain unchanged.

Controls cover direct start/hook and CLI start/hook through a POSIX symlinked root, Windows 8.3 equivalence, a deterministic post-label/pre-snapshot directory-link swap with snapshots forbidden, and the existing strict link-swap regressions.

Local verification: `scripts/validate-all.sh`; 542 tests passed with 43 expected skips; all repository checks passed. Exact-SHA Claude Opus and free Hermes Inkling reviews will be posted before merge.