### PR TITLE
perf: bound Git-index materialization verification

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,9 @@ jobs:
           chmod +x scripts/*.sh tests/*.sh
           bash scripts/validate-all.sh
 
+      - name: Measure full-bundle materialization bounds
+        run: python scripts/measure-bundle-materialization.py --check
+
   # The Python suite shells out to helpers and hashes file bytes, so it is exposed
   # to three things a Linux-only matrix cannot see. All three were live on main
   # until 2026-08-19 and every one of them was invisible here:
@@ -36,6 +39,9 @@ jobs:
 
       - name: Run the Python test suite on Windows
         run: python -m unittest discover -s tests -p "test_*.py" -v
+
+      - name: Measure full-bundle materialization bounds
+        run: python scripts/measure-bundle-materialization.py --check
 
   # Nothing exercised the oldest supported Python: the Linux job uses whatever
   # the runner ships and the Windows job pins 3.13. A floor no job executes is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Changed
+- Git-index bundle verification now streams locked blobs through one bounded
+  `git cat-file --batch` process per pass, retains only requested candidate
+  write payloads, discards current-bundle payloads after validation, and removes
+  redundant same-boundary apply checks while preserving planner-end and
+  immediate pre-mutation source revalidation. Linux and Windows CI report the
+  full-bundle Git process, wall-time, and logical payload-memory bounds.
 - The v0.12 root contract now names `KernelRoot`, `ContextRoot`, and
   `WorkingRoot`, versions their colocated compatibility mode, separates the
   nominal WorkingRoot path from a possibly enclosing read-only Git evidence

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -324,6 +324,10 @@
                     "policy": "managed"
                 },
                 {
+                    "path": "scripts/measure-bundle-materialization.py",
+                    "policy": "development"
+                },
+                {
                     "path": "scripts/pre-commit-hook.sh",
                     "policy": "managed"
                 },

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -9,7 +9,7 @@ import stat
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Iterator, Sequence
 
 from .component_schema import (
     COMPONENT_MANIFEST_SCHEMA_VERSION,
@@ -274,8 +274,11 @@ def _git_index(root: Path) -> dict[str, tuple[str, bool]]:
             metadata, raw_path = entry.split(b"\t", 1)
             mode, oid, stage = metadata.split(b" ")
             path = raw_path.decode("utf-8")
+            oid_text = oid.decode("ascii")
         except (ValueError, UnicodeDecodeError):
             _fail("source_mode", "Git index returned an invalid record")
+        if not GIT_COMMIT_RE.fullmatch(oid_text):
+            _fail("source_mode", "Git index returned an invalid object identifier")
         if stage != b"0":
             _fail("source_mode", f"Git index has unresolved stages for {path}")
         if mode not in {b"100644", b"100755"}:
@@ -285,25 +288,79 @@ def _git_index(root: Path) -> dict[str, tuple[str, bool]]:
             )
         if path in entries:
             _fail("source_mode", f"Git index returned duplicate path {path!r}")
-        entries[path] = (oid.decode("ascii"), mode == b"100755")
+        entries[path] = (oid_text, mode == b"100755")
     return entries
 
 
-def _git_blob(root: Path, oid: str, field: str) -> bytes:
+def _git_blobs(
+    root: Path, requests: Sequence[tuple[str, str, bool, int | None]],
+) -> Iterator[tuple[str, bytes, bool]]:
+    """Stream index blobs through one bounded ``git cat-file --batch`` process."""
     import subprocess
 
     try:
-        result = subprocess.run(
-            [*git_command(root), "cat-file", "blob", oid], check=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=git_environment(),
+        process = subprocess.Popen(
+            [*git_command(root), "cat-file", "--batch"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            env=git_environment(),
         )
-    except (OSError, subprocess.CalledProcessError) as exc:
-        detail = (
-            exc.stderr.decode("utf-8", errors="replace").strip()
-            if isinstance(exc, subprocess.CalledProcessError) else str(exc)
-        )
-        _fail(field, f"cannot read local Git blob: {detail}")
-    return result.stdout
+    except OSError as exc:
+        _fail("source_mode", f"cannot start local Git blob reader: {exc}")
+    if process.stdin is None or process.stdout is None:
+        process.kill()
+        process.wait()
+        _fail("source_mode", "local Git blob reader has invalid pipes")
+    completed = False
+    try:
+        for relative, oid, executable, expected_size in requests:
+            field = f"source.{relative}"
+            try:
+                process.stdin.write(oid.encode("ascii") + b"\n")
+                process.stdin.flush()
+                header = process.stdout.readline()
+            except (OSError, UnicodeError) as exc:
+                _fail(field, f"cannot query local Git blob: {exc}")
+            parts = header.rstrip(b"\n").split(b" ")
+            if len(parts) != 3 or parts[0] != oid.encode("ascii") or parts[1] != b"blob":
+                detail = header.decode("utf-8", errors="replace").strip()
+                _fail(field, f"local Git blob reader returned an invalid record: {detail}")
+            if re.fullmatch(rb"0|[1-9][0-9]*", parts[2]) is None:
+                _fail(field, "local Git blob reader returned an invalid size")
+            size = int(parts[2])
+            if expected_size is not None and size != expected_size:
+                _fail(field, "local Git blob reader size does not match the bundle lock")
+            data = process.stdout.read(size)
+            if len(data) != size:
+                _fail(field, "local Git blob reader returned a truncated payload")
+            if process.stdout.read(1) != b"\n":
+                _fail(field, "local Git blob reader returned invalid framing")
+            yield relative, data, executable
+        process.stdin.close()
+        try:
+            trailer = process.stdout.read()
+            return_code = process.wait()
+        except OSError as exc:
+            _fail("source_mode", f"cannot finish local Git blob reader: {exc}")
+        if return_code != 0:
+            detail = trailer.decode("utf-8", errors="replace").strip()
+            _fail("source_mode", f"local Git blob reader failed: {detail}")
+        if trailer:
+            _fail("source_mode", "local Git blob reader returned trailing output")
+        completed = True
+    finally:
+        if not completed and process.poll() is None:
+            try:
+                process.kill()
+                process.wait()
+            except OSError:
+                pass
+        for pipe in (process.stdin, process.stdout):
+            if pipe.closed:
+                continue
+            try:
+                pipe.close()
+            except OSError:
+                pass
 
 
 def _git_repository_identity(root: Path) -> str:
@@ -316,26 +373,27 @@ def _git_repository_identity(root: Path) -> str:
 
 
 def _source_entries(
-    root: Path, paths: Iterable[str], *, source_mode: str,
-) -> dict[str, tuple[bytes, bool]]:
+    root: Path, records: dict[str, dict[str, Any] | None], *, source_mode: str,
+) -> Iterator[tuple[str, bytes, bool]]:
     if source_mode not in {"directory", "git-index"}:
         _fail("source_mode", "must equal 'directory' or 'git-index'")
-    result: dict[str, tuple[bytes, bool]] = {}
     if source_mode == "git-index":
         index = _git_index(root)
-        for relative in paths:
+        requests: list[tuple[str, str, bool, int | None]] = []
+        for relative, record in records.items():
             if relative not in index:
                 _fail(f"source.{relative}", "is absent from the local Git index")
             oid, executable = index[relative]
-            result[relative] = (_git_blob(root, oid, f"source.{relative}"), executable)
-        return result
-    for relative in paths:
+            requests.append((
+                relative, oid, executable,
+                record["size"] if record is not None else None,
+            ))
+        yield from _git_blobs(root, requests)
+        return
+    for relative in records:
         path = _safe_path(root, relative, f"source.{relative}", missing_ok=False)
         data, metadata = _read_snapshot(path, f"source.{relative}")
-        result[relative] = (
-            data, bool(stat.S_IMODE(metadata.st_mode) & 0o111),
-        )
-    return result
+        yield relative, data, bool(stat.S_IMODE(metadata.st_mode) & 0o111)
 
 
 def _validated_runtimes(
@@ -379,7 +437,12 @@ def create_bundle_lock(
         _git_repository_identity(root) if source_mode == "git-index" else None
     )
     manifest_relative = "components/manifest.json"
-    source = _source_entries(root, [manifest_relative], source_mode=source_mode)
+    source = {
+        path: (data, executable)
+        for path, data, executable in _source_entries(
+            root, {manifest_relative: None}, source_mode=source_mode
+        )
+    }
     try:
         manifest_value = strict_json_loads(
             source[manifest_relative][0].decode("utf-8"), source=manifest_relative
@@ -397,9 +460,12 @@ def create_bundle_lock(
             _fail("source_root", "owned paths absent from Git index: " + ", ".join(absent[:20]))
     all_components = [item["id"] for item in manifest["components"]]
     paths = resolved_component_paths(manifest, all_components)
-    source = _source_entries(
-        root, (item["path"] for item in paths), source_mode=source_mode
-    )
+    source = {
+        path: (data, executable)
+        for path, data, executable in _source_entries(
+            root, {item["path"]: None for item in paths}, source_mode=source_mode
+        )
+    }
     _validated_runtimes(
         {path: data for path, (data, _) in source.items()}, manifest, root=root
     )
@@ -536,8 +602,16 @@ def _validate_compatibility(lock: dict[str, Any], role: str) -> None:
 def verify_bundle(
     lock_path: Path, source_root: Path, *, expected_sha256: str,
     source_mode: str = "directory", role: str = "candidate",
+    retain_paths: Iterable[str] | None = None,
 ) -> VerifiedBundle:
-    """Verify one caller-pinned lock and all of its local bytes without fetching."""
+    """Verify all bytes, retaining either every payload or only requested paths.
+
+    Verification streams one source payload at a time. With ``retain_paths`` the
+    peak raw-payload-buffer bound is the retained set plus the manifest/runtime
+    descriptor bytes needed for schema validation plus the current and
+    preceding source payloads during generator handoff. Text normalization and
+    directory snapshot assembly have separate transient allocations.
+    """
     expected_sha256 = _sha256(expected_sha256, "expected_sha256")
     lock_path = lock_path.absolute()
     lock = load_bundle_lock(lock_path)
@@ -553,18 +627,40 @@ def verify_bundle(
         if actual_commit != locked_commit:
             _fail("bundle.source_git_commit", "does not match the local Git HEAD commit")
     records = {item["path"]: item for item in lock["bundle"]["files"]}
-    source = _source_entries(root, records, source_mode=source_mode)
-    verified_bytes: dict[str, bytes] = {}
-    for relative, record in records.items():
-        data, executable = source[relative]
-        if len(data) != record["size"] or sha256_bytes(data) != record["sha256_raw"]:
-            _fail(f"source.{relative}", "raw bytes do not match the bundle lock")
-        if _text_lf_digest(data) != record["sha256_text_lf"]:
-            _fail(f"source.{relative}", "text normalization does not match the bundle lock")
-        if (source_mode == "git-index" or os.name != "nt") and executable != record["executable"]:
-            _fail(f"source.{relative}", "executable mode does not match the bundle lock")
-        verified_bytes[relative] = data
+    requested = set(records) if retain_paths is None else set(retain_paths)
+    unknown = requested - set(records)
+    if unknown:
+        _fail("retain_paths", "contains paths absent from the bundle: " + ", ".join(sorted(unknown)))
     manifest_relative = lock["bundle"]["component_manifest_path"]
+    schema_paths = {manifest_relative}
+    if role == "candidate":
+        schema_paths.update(
+            path for path in records
+            if len(PurePosixPath(path).parts) == 2
+            and PurePosixPath(path).parts[0] == "runtimes"
+            and path.endswith(".json")
+            and path != "runtimes/schema.json"
+        )
+    retained_during_validation = requested | schema_paths
+    verified_bytes: dict[str, bytes] = {}
+    source_entries = _source_entries(root, records, source_mode=source_mode)
+    try:
+        for relative, data, executable in source_entries:
+            record = records[relative]
+            if len(data) != record["size"] or sha256_bytes(data) != record["sha256_raw"]:
+                _fail(f"source.{relative}", "raw bytes do not match the bundle lock")
+            if _text_lf_digest(data) != record["sha256_text_lf"]:
+                _fail(f"source.{relative}", "text normalization does not match the bundle lock")
+            if (source_mode == "git-index" or os.name != "nt") and executable != record["executable"]:
+                _fail(f"source.{relative}", "executable mode does not match the bundle lock")
+            if relative in retained_during_validation:
+                verified_bytes[relative] = data
+    finally:
+        source_entries.close()
+    if source_mode == "git-index":
+        locked_commit = lock["bundle"]["source_git_commit"]
+        if _git_repository_identity(root) != locked_commit:
+            _fail("bundle.source_git_commit", "changed during Git-index verification")
     try:
         manifest_value = strict_json_loads(
             verified_bytes[manifest_relative].decode("utf-8"), source=manifest_relative
@@ -589,6 +685,13 @@ def verify_bundle(
         _validated_runtimes(verified_bytes, manifest, root=root)
         if role == "candidate" else {}
     )
+    missing_retained = requested - set(verified_bytes)
+    if missing_retained:
+        _fail(
+            "source_mode",
+            "did not verify requested paths: " + ", ".join(sorted(missing_retained)),
+        )
+    verified_bytes = {path: verified_bytes[path] for path in requested}
     return VerifiedBundle(
         root=root, lock_path=lock_path, source_mode=source_mode, role=role,
         mode_verified=(source_mode == "git-index" or os.name != "nt"), lock=lock,
@@ -678,6 +781,7 @@ def _assert_bundle_current(bundle: VerifiedBundle, field: str) -> None:
         verify_bundle(
             bundle.lock_path, bundle.root, expected_sha256=bundle.digest,
             source_mode=bundle.source_mode, role=bundle.role,
+            retain_paths=(),
         )
     except BundleError as exc:
         raise BundleError(f"{field}: source or lock became stale: {exc}") from exc

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -262,6 +262,7 @@ def _bundle_main(args: argparse.Namespace) -> int:
     candidate = verify_bundle(
         args.lock, args.source, expected_sha256=args.expect_sha256,
         source_mode=args.source_mode,
+        retain_paths=(),
     )
     if args.bundle_command == "check":
         emit({
@@ -298,6 +299,7 @@ def _bundle_main(args: argparse.Namespace) -> int:
             expected_sha256=args.expect_current_sha256,
             source_mode=args.current_source_mode,
             role="current",
+            retain_paths=(),
         )
         current_components = component_selection(
             args.current_components, "current_components"

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1802,10 +1802,17 @@ def _validate_agent_proposal_shape(
     return operation, created_at
 
 
-def _validate_proposal_shape(root: Path, proposal: Path, document: dict[str, Any]) -> tuple[str, datetime]:
+def _validate_proposal_shape(
+    root: Path, proposal: Path, document: dict[str, Any],
+    *, validated_agent_shape: tuple[str, datetime] | None = None,
+) -> tuple[str, datetime]:
     workflow = document.get("workflow")
     if workflow == AGENT_LIFECYCLE_WORKFLOW:
-        operation, created_at = _validate_agent_proposal_shape(root, document)
+        operation, created_at = (
+            validated_agent_shape
+            if validated_agent_shape is not None
+            else _validate_agent_proposal_shape(root, document)
+        )
         workflow_value = AGENT_LIFECYCLE_WORKFLOW
     else:
         operation = "content-lifecycle"
@@ -3273,6 +3280,7 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
             "generic runtime is reserved for agent-config and materialization proposals"
         )
     validate_execution_runtime(root, runtime)
+    prepared_materialization_payloads: dict[str, bytes] | None = None
     with transaction_lock(root):
         # A completed crash journal has priority over every later lifecycle
         # operation, including generic content proposals.
@@ -3284,8 +3292,20 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                 raise ContextOSError(
                     f"refusing to replay proposal with existing receipt: {receipt_candidate}"
                 )
-            workflow, _ = _validate_proposal_shape(root, proposal, document)
-            _validate_agent_preflight(root, document)
+            if document.get("operation") == MATERIALIZE_OPERATION:
+                from .materializer import prepare_materialization_preflight
+
+                created_at, prepared_materialization_payloads = (
+                    prepare_materialization_preflight(root, document)
+                )
+                _validate_proposal_shape(
+                    root, proposal, document,
+                    validated_agent_shape=(MATERIALIZE_OPERATION, created_at),
+                )
+                workflow = AGENT_LIFECYCLE_WORKFLOW
+            else:
+                workflow, _ = _validate_proposal_shape(root, proposal, document)
+                _validate_agent_preflight(root, document)
         else:
             workflow, created_at = _validate_proposal_shape(root, proposal, document)
             for change in document.get("changes", []):
@@ -3321,7 +3341,9 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
         publication_anchors: dict[Path, Path] = {}
         journal_path: Path | None = None
         receipt_published = False
-        materialization_payloads: dict[str, bytes] = {}
+        materialization_payloads: dict[str, bytes] = (
+            prepared_materialization_payloads or {}
+        )
         staging_root = root / ".context-os" / "staging" / document["proposal_id"]
         receipt_path = root / ".context-os" / "receipts" / f"{document['proposal_id']}.json"
         _guard_local_artifact_path(root, staging_root)
@@ -3339,10 +3361,6 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                     staging_root,
                 )
             staging_root.mkdir(parents=True)
-            if document.get("operation") == MATERIALIZE_OPERATION:
-                from .materializer import materialization_payloads as load_payloads
-
-                materialization_payloads = load_payloads(root, document)
             for change_index, change in enumerate(document["changes"]):
                 path = _transaction_target(
                     root, change["path"], document.get("operation")
@@ -3371,6 +3389,7 @@ def apply_proposal(root: Path, proposal: Path, confirmation: str, runtime: str) 
                         mode=target_mode,
                     )
                     staged[path] = stage
+            materialization_payloads.clear()
             journal_path = (
                 root / ".context-os" / "journals" / document["proposal_id"]
             )

--- a/contextos/materializer.py
+++ b/contextos/materializer.py
@@ -81,7 +81,9 @@ def _bundle_spec(bundle: VerifiedBundle) -> dict[str, str]:
     }
 
 
-def _load_bundle_spec(value: Any, field: str, *, role: str) -> VerifiedBundle:
+def _load_bundle_spec(
+    value: Any, field: str, *, role: str, retain_paths: Sequence[str] = (),
+) -> VerifiedBundle:
     if not isinstance(value, dict) or set(value) != BUNDLE_SPEC_KEYS:
         raise BundleError(f"{field}: invalid bundle input shape")
     for key in ("lock", "source", "expected_sha256", "source_mode"):
@@ -101,6 +103,7 @@ def _load_bundle_spec(value: Any, field: str, *, role: str) -> VerifiedBundle:
         expected_sha256=value["expected_sha256"],
         source_mode=value["source_mode"],
         role=role,
+        retain_paths=retain_paths,
     )
 
 
@@ -494,7 +497,7 @@ def create_composition_proposal(
 
 
 def _materialization_context(
-    root: Path, document: dict[str, Any]
+    root: Path, document: dict[str, Any], *, candidate_retain_paths: Sequence[str] = (),
 ) -> tuple[VerifiedBundle, VerifiedBundle | None, dict[str, Any], list[dict[str, Any]]]:
     authorization = document.get("authorization")
     if not isinstance(authorization, dict) or set(authorization) != MATERIALIZE_AUTHORIZATION_KEYS:
@@ -505,7 +508,8 @@ def _materialization_context(
     if mode not in {"compose", "upgrade"}:
         raise BundleError("materialization authorization mode is invalid")
     candidate = _load_bundle_spec(
-        authorization.get("candidate"), "authorization.candidate", role="candidate"
+        authorization.get("candidate"), "authorization.candidate", role="candidate",
+        retain_paths=candidate_retain_paths,
     )
     current_spec = authorization.get("current")
     current = (
@@ -577,9 +581,30 @@ def _materialization_context(
     return candidate, current, recomputed, changes
 
 
-def validate_materialization_proposal_shape(
-    root: Path, document: dict[str, Any]
-) -> tuple[str, datetime]:
+def _candidate_payload_paths(document: dict[str, Any]) -> tuple[str, ...]:
+    """Return untrusted bundle references solely as bounded retention hints."""
+    paths: set[str] = set()
+    changes = document.get("changes")
+    if not isinstance(changes, list):
+        return ()
+    for change in changes:
+        if not isinstance(change, dict):
+            continue
+        reference = change.get("content_ref")
+        if (
+            change.get("action") == "write"
+            and isinstance(reference, dict)
+            and reference.get("kind") == "bundle"
+            and reference.get("role") == "candidate"
+            and isinstance(reference.get("path"), str)
+        ):
+            paths.add(reference["path"])
+    return tuple(sorted(paths, key=portable_path_identity))
+
+
+def _validate_materialization_document(
+    root: Path, document: dict[str, Any], *, candidate_retain_paths: Sequence[str] = (),
+) -> tuple[datetime, VerifiedBundle, list[dict[str, Any]]]:
     kernel = _kernel()
     required = {
         "schema_version", "workflow", "operation", "created_at", "proposal_id",
@@ -591,7 +616,9 @@ def validate_materialization_proposal_shape(
     if document.get("invariants") != MATERIALIZE_INVARIANTS:
         raise BundleError("materialization proposal invariants are invalid")
     created_at = kernel.parse_now(kernel.ensure_text(document.get("created_at"), "created_at"))
-    candidate, _current, plan, expected_changes = _materialization_context(root, document)
+    candidate, _current, plan, expected_changes = _materialization_context(
+        root, document, candidate_retain_paths=candidate_retain_paths
+    )
     changes = document.get("changes")
     if changes != expected_changes:
         raise BundleError("materialization changes are stale or invalid")
@@ -630,6 +657,15 @@ def validate_materialization_proposal_shape(
         expected_sources[current_spec["lock"]] = sha256_bytes(Path(current_spec["lock"]).read_bytes())
     if document.get("source_hashes") != dict(sorted(expected_sources.items())):
         raise BundleError("materialization source hashes are stale or invalid")
+    return created_at, candidate, expected_changes
+
+
+def validate_materialization_proposal_shape(
+    root: Path, document: dict[str, Any]
+) -> tuple[str, datetime]:
+    created_at, _candidate, _changes = _validate_materialization_document(
+        root, document
+    )
     return MATERIALIZE_OPERATION, created_at
 
 
@@ -640,8 +676,9 @@ def validate_materialization_preflight(root: Path, document: dict[str, Any]) -> 
     validate_materialization_proposal_shape(root, document)
 
 
-def materialization_payloads(root: Path, document: dict[str, Any]) -> dict[str, bytes]:
-    candidate, _current, _plan, changes = _materialization_context(root, document)
+def _payloads_from_verified_context(
+    candidate: VerifiedBundle, changes: Sequence[dict[str, Any]],
+) -> dict[str, bytes]:
     payloads: dict[str, bytes] = {}
     for change in changes:
         if change["action"] != "write":
@@ -666,3 +703,17 @@ def materialization_payloads(root: Path, document: dict[str, Any]) -> dict[str, 
             raise BundleError(f"materialization payload hash is invalid: {change['path']}")
         payloads[change["path"]] = payload
     return payloads
+
+
+def prepare_materialization_preflight(
+    root: Path, document: dict[str, Any]
+) -> tuple[datetime, dict[str, bytes]]:
+    """Validate one apply boundary and retain only candidate write payloads."""
+    kernel = _kernel()
+    if document.get("source_git_head") != kernel.git_head(root):
+        raise BundleError("refusing stale materialization proposal; git HEAD changed")
+    retain_paths = _candidate_payload_paths(document)
+    created_at, candidate, changes = _validate_materialization_document(
+        root, document, candidate_retain_paths=retain_paths
+    )
+    return created_at, _payloads_from_verified_context(candidate, changes)

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -108,6 +108,45 @@ applies to materialization as well as `bundle check`. On Windows, Git-index
 source modes are verified, but the materialized target cannot preserve a POSIX
 executable bit; the plan records that destination limitation explicitly.
 
+Git-index verification uses one `git cat-file --batch` child process per bundle
+verification, independent of the number of locked files. Payload verification
+is streaming: at most the current and immediately preceding source payload are
+live in addition to payloads the caller explicitly asks to retain. During
+candidate schema validation, the component manifest and runtime descriptor
+payloads are also retained; current bundle validation retains only the
+component manifest. Thus the explicit logical raw-buffer bound is:
+
+```text
+retained requested payload bytes
++ retained schema payload bytes not already requested
++ two times the largest single locked payload bytes
+```
+
+The last term bounds the payload currently being verified plus the preceding
+loop payload, which remains live until the next generator result is unpacked;
+it may double-count requested or schema payloads. Text decoding and LF
+normalization, directory-source snapshot assembly, parsed JSON objects, lock
+and plan metadata, filesystem snapshots, and interpreter overhead are outside
+this raw-buffer metric. Proposal planning requests no bundle payload retention.
+Apply retains only candidate bundle payloads referenced by write changes; those
+verified bytes are released when transaction staging completes.
+
+Maintainers can report the current full-component compose and upgrade bounds on
+Linux or Windows with:
+
+```bash
+python scripts/measure-bundle-materialization.py --check
+```
+
+The JSON report includes Git subprocess counts, elapsed wall time, the logical
+payload peak and bound, observed staging-payload retention, and Python's traced
+allocation peak. The upgrade measurement changes one managed bundle path so
+its retained-payload observation is nonzero. CI checks process batching and
+exact subprocess counts on
+both platforms, but records time and memory without platform-sensitive
+thresholds because shared-runner measurements are not stable correctness
+signals. Exact subset-retention tests enforce the payload policy separately.
+
 ## Materializing a clean workspace
 
 Prepare a canonical workspace JSON file whose template name and version match

--- a/scripts/measure-bundle-materialization.py
+++ b/scripts/measure-bundle-materialization.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Measure full-bundle Git-index composition and upgrade resource bounds."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from contextos.bundle_schema import create_bundle_lock, verify_bundle  # noqa: E402
+from contextos import materializer  # noqa: E402
+from contextos.kernel import apply_proposal  # noqa: E402
+from contextos.materializer import (  # noqa: E402
+    create_composition_proposal,
+    create_materialization_proposal,
+)
+from contextos.primitives import git_environment  # noqa: E402
+
+
+NOW = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
+EXPECTED_GIT_PROCESSES = {"compose": 48, "upgrade": 96}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def _run(command: Sequence[str], *, cwd: Path) -> None:
+    subprocess.run(
+        list(command), cwd=cwd, check=True, capture_output=True,
+        env=git_environment(),
+    )
+
+
+def _build_source(source: Path) -> None:
+    """Create a clean Git source containing every manifest-classified path."""
+    manifest = json.loads(
+        (ROOT / "components" / "manifest.json").read_text(encoding="utf-8")
+    )
+    paths = sorted({
+        entry["path"]
+        for component in manifest["components"]
+        for entry in component["paths"]
+    })
+    source.mkdir()
+    for relative in paths:
+        source_path = ROOT / Path(relative)
+        target_path = source / Path(relative)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(source_path.read_bytes())
+    _run(["git", "init", "--quiet"], cwd=source)
+    _run(["git", "config", "user.email", "measure@example.invalid"], cwd=source)
+    _run(["git", "config", "user.name", "Bundle Measurement"], cwd=source)
+    _run(["git", "config", "core.autocrlf", "false"], cwd=source)
+    _run(["git", "add", "--force", "--all"], cwd=source)
+    _run(["git", "commit", "--quiet", "-m", "measurement source"], cwd=source)
+
+
+def _commit_candidate_delta(source: Path, manifest: dict[str, Any]) -> str:
+    relative = next(
+        entry["path"]
+        for component in manifest["components"]
+        for entry in component["paths"]
+        if entry["policy"] == "managed" and entry["path"].endswith(".md")
+    )
+    path = source / relative
+    path.write_bytes(path.read_bytes() + b"\nCandidate measurement delta.\n")
+    _run(["git", "add", "--", relative], cwd=source)
+    _run(["git", "commit", "--quiet", "-m", "candidate delta"], cwd=source)
+    return relative
+
+
+def _is_git_command(command: object) -> bool:
+    if not isinstance(command, (list, tuple)) or not command:
+        return False
+    executable = Path(str(command[0])).name.casefold()
+    return executable in {"git", "git.exe"}
+
+
+@contextmanager
+def _git_process_measurement() -> Iterator[list[list[str]]]:
+    commands: list[list[str]] = []
+    original_popen = subprocess.Popen
+
+    def measured_popen(
+        command: object, *args: Any, **kwargs: Any
+    ) -> subprocess.Popen[Any]:
+        if _is_git_command(command):
+            commands.append([str(item) for item in command])  # type: ignore[union-attr]
+        return original_popen(command, *args, **kwargs)
+
+    with mock.patch("subprocess.Popen", side_effect=measured_popen):
+        yield commands
+
+
+@contextmanager
+def _retained_payload_measurement() -> Iterator[list[int]]:
+    samples: list[int] = []
+    original = materializer.prepare_materialization_preflight
+
+    def measured(*args: Any, **kwargs: Any) -> tuple[datetime, dict[str, bytes]]:
+        result = original(*args, **kwargs)
+        samples.append(sum(len(payload) for payload in result[1].values()))
+        return result
+
+    with mock.patch.object(
+        materializer, "prepare_materialization_preflight", side_effect=measured
+    ):
+        yield samples
+
+
+@contextmanager
+def _python_peak_measurement() -> Iterator[list[int]]:
+    peak = [0]
+    tracemalloc.start()
+    try:
+        yield peak
+    finally:
+        _current, peak[0] = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+
+def _schema_paths(lock: dict[str, Any], role: str) -> set[str]:
+    records = lock["bundle"]["files"]
+    paths = {lock["bundle"]["component_manifest_path"]}
+    if role == "candidate":
+        paths.update(
+            item["path"]
+            for item in records
+            if item["path"].startswith("runtimes/")
+            and item["path"].endswith(".json")
+            and item["path"] != "runtimes/schema.json"
+        )
+    return paths
+
+
+def _logical_verification_peak(
+    lock: dict[str, Any], *, role: str, retain_paths: set[str]
+) -> int:
+    """Mirror verify_bundle's payload lifetime without sampling process RSS."""
+    retained_paths = retain_paths | _schema_paths(lock, role)
+    retained_bytes = 0
+    peak_bytes = 0
+    previous_unretained_bytes = 0
+    for item in lock["bundle"]["files"]:
+        peak_bytes = max(
+            peak_bytes,
+            retained_bytes + previous_unretained_bytes + item["size"],
+        )
+        if item["path"] in retained_paths:
+            retained_bytes += item["size"]
+            previous_unretained_bytes = 0
+        else:
+            previous_unretained_bytes = item["size"]
+    return peak_bytes
+
+
+def _logical_verification_bound(
+    lock: dict[str, Any], *, role: str, retain_paths: set[str]
+) -> int:
+    records = {item["path"]: item["size"] for item in lock["bundle"]["files"]}
+    schema_only = _schema_paths(lock, role) - retain_paths
+    return (
+        sum(records[path] for path in retain_paths)
+        + sum(records[path] for path in schema_only)
+        + 2 * max(records.values())
+    )
+
+
+def _bundle_references(proposal: dict[str, Any]) -> set[str]:
+    return {
+        reference["path"]
+        for change in proposal["changes"]
+        if change["action"] == "write"
+        for reference in [change["content_ref"]]
+        if reference["kind"] == "bundle" and reference["role"] == "candidate"
+    }
+
+
+def _metric(
+    name: str,
+    started: float,
+    commands: list[list[str]],
+    lock: dict[str, Any],
+    retained_paths: set[str],
+    observed_retained_payload_bytes: int,
+    traced_python_peak_bytes: int,
+) -> dict[str, Any]:
+    batch_commands = [
+        command for command in commands if "cat-file" in command and "--batch" in command
+    ]
+    per_blob_commands = [
+        command
+        for command in commands
+        if "cat-file" in command and "blob" in command and "--batch" not in command
+    ]
+    logical_peak = max(
+        _logical_verification_peak(lock, role="candidate", retain_paths=set()),
+        _logical_verification_peak(
+            lock, role="candidate", retain_paths=retained_paths
+        ),
+    )
+    logical_bound = max(
+        _logical_verification_bound(lock, role="candidate", retain_paths=set()),
+        _logical_verification_bound(
+            lock, role="candidate", retain_paths=retained_paths
+        ),
+    )
+    return {
+        "git_subprocess_count": len(commands),
+        "git_batch_process_count": len(batch_commands),
+        "git_per_blob_process_count": len(per_blob_commands),
+        "wall_seconds": round(time.perf_counter() - started, 6),
+        "logical_peak_retained_payload_bytes": logical_peak,
+        "logical_retained_payload_bound_bytes": logical_bound,
+        "observed_staging_payload_bytes": observed_retained_payload_bytes,
+        "tracemalloc_peak_bytes": traced_python_peak_bytes,
+        "retained_bundle_path_count": len(retained_paths),
+        "matches_expected_git_process_count": (
+            len(commands) == EXPECTED_GIT_PROCESSES[name]
+        ),
+    }
+
+
+def measure() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="contextos-bundle-measure-") as temporary:
+        root = Path(temporary)
+        current_source = root / "current-source"
+        candidate_source = root / "candidate-source"
+        _build_source(current_source)
+        shutil.copytree(current_source, candidate_source)
+
+        manifest = json.loads(
+            (current_source / "components" / "manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        changed_path = _commit_candidate_delta(candidate_source, manifest)
+
+        current_lock = create_bundle_lock(
+            current_source, name="agent-context-os-template", version="1.0.0"
+        )
+        candidate_lock = create_bundle_lock(
+            candidate_source, name="agent-context-os-template", version="2.0.0"
+        )
+        current_lock_path = root / "current.lock.json"
+        candidate_lock_path = root / "candidate.lock.json"
+        _write_json(current_lock_path, current_lock)
+        _write_json(candidate_lock_path, candidate_lock)
+
+        all_components = [item["id"] for item in manifest["components"]]
+        runtime_ids = sorted(
+            path.stem for path in (current_source / "runtimes").glob("*.json")
+            if path.name != "schema.json"
+        )
+        target = root / "target"
+        target.mkdir()
+        config_input = root / "workspace-v1.json"
+        _write_json(config_input, {
+            "schema_version": 1,
+            "mode": "full-template",
+            "agents": runtime_ids,
+            "paths": {
+                "state_dir": "state",
+                "sessions_dir": "sessions",
+                "task_file": "TODO.md",
+            },
+            "template": {
+                "source": "agent-context-os-template",
+                "version": "1.0.0",
+            },
+        })
+
+        with (
+            _git_process_measurement() as compose_commands,
+            _retained_payload_measurement() as compose_retained,
+            _python_peak_measurement() as compose_python_peak,
+        ):
+            compose_started = time.perf_counter()
+            current = verify_bundle(
+                current_lock_path, current_source,
+                expected_sha256=current_lock["bundle_sha256"],
+                source_mode="git-index", retain_paths=(),
+            )
+            compose_path, compose_proposal = create_composition_proposal(
+                target_root=target,
+                workspace_config_path=target / "contextos.workspace.json",
+                workspace_config_input_path=config_input,
+                expected_config_input_sha256=_sha256(config_input),
+                candidate=current,
+                desired_components=all_components,
+                now=NOW,
+            )
+            apply_proposal(
+                target, compose_path, compose_proposal["proposal_digest"], "generic"
+            )
+        compose = _metric(
+            "compose", compose_started, compose_commands, current_lock,
+            _bundle_references(compose_proposal),
+            max(compose_retained, default=0), compose_python_peak[0],
+        )
+
+        with (
+            _git_process_measurement() as upgrade_commands,
+            _retained_payload_measurement() as upgrade_retained,
+            _python_peak_measurement() as upgrade_python_peak,
+        ):
+            upgrade_started = time.perf_counter()
+            candidate = verify_bundle(
+                candidate_lock_path, candidate_source,
+                expected_sha256=candidate_lock["bundle_sha256"],
+                source_mode="git-index", retain_paths=(),
+            )
+            current = verify_bundle(
+                current_lock_path, current_source,
+                expected_sha256=current_lock["bundle_sha256"],
+                source_mode="git-index", role="current", retain_paths=(),
+            )
+            config_path = target / "contextos.workspace.json"
+            upgrade_path, upgrade_proposal = create_materialization_proposal(
+                target_root=target,
+                workspace_config_path=config_path,
+                expected_config_sha256=_sha256(config_path),
+                candidate=candidate,
+                desired_components=all_components,
+                current=current,
+                current_components=all_components,
+                now=NOW.replace(second=1),
+            )
+            apply_proposal(
+                target, upgrade_path, upgrade_proposal["proposal_digest"], "generic"
+            )
+        upgrade = _metric(
+            "upgrade", upgrade_started, upgrade_commands, candidate_lock,
+            _bundle_references(upgrade_proposal),
+            max(upgrade_retained, default=0), upgrade_python_peak[0],
+        )
+
+        return {
+            "schema_version": 1,
+            "measurement": "full-bundle-materialization-resource-bounds",
+            "bundle_file_count": len(candidate_lock["bundle"]["files"]),
+            "bundle_payload_bytes": sum(
+                item["size"] for item in candidate_lock["bundle"]["files"]
+            ),
+            "upgrade_changed_bundle_path": changed_path,
+            "compose": compose,
+            "upgrade": upgrade,
+        }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true",
+        help="fail on per-blob Git processes or a fixed process-count regression",
+    )
+    args = parser.parse_args(argv)
+    report = measure()
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if args.check:
+        for name in ("compose", "upgrade"):
+            metric = report[name]
+            if metric["git_per_blob_process_count"] != 0:
+                print(f"{name}: per-blob Git subprocesses detected", file=sys.stderr)
+                return 1
+            if not metric["matches_expected_git_process_count"]:
+                print(
+                    f"{name}: expected {EXPECTED_GIT_PROCESSES[name]} Git subprocesses, "
+                    f"observed {metric['git_subprocess_count']}",
+                    file=sys.stderr,
+                )
+                return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import io
 import json
 import os
 import shutil
@@ -19,6 +20,7 @@ from contextos.bundle_schema import (
     create_structural_plan,
     validate_bundle_lock,
     verify_bundle,
+    _git_blobs,
     _git_index,
     _safe_path,
 )
@@ -297,6 +299,135 @@ class BundleLockTest(unittest.TestCase):
         self.assertEqual("1", environment["GIT_NO_LAZY_FETCH"])
         self.assertEqual("1", environment["GIT_NO_REPLACE_OBJECTS"])
         self.assertEqual("0", environment["GIT_OPTIONAL_LOCKS"])
+
+    def test_git_index_verification_uses_one_batch_process_for_all_files(self) -> None:
+        git_source = self.root / "git-source"
+        git_source.mkdir()
+        fixture = BundleFixture(
+            git_source, version="1.0.0", managed=b"binary\x00v1\r\n", addon=True,
+            source_mode="git-index",
+        )
+        self.assertGreater(len(fixture.lock["bundle"]["files"]), 1)
+
+        real_popen = subprocess.Popen
+        real_run = subprocess.run
+        with (
+            mock.patch("subprocess.Popen", wraps=real_popen) as popen,
+            mock.patch("subprocess.run", wraps=real_run) as run,
+        ):
+            verified = fixture.verify()
+
+        self.assertEqual(set(verified.records), set(verified.verified_bytes))
+        batch_calls = [
+            call for call in popen.call_args_list
+            if call.args[0][-2:] == ["cat-file", "--batch"]
+        ]
+        self.assertEqual(1, len(batch_calls))
+        per_blob_popen_calls = [
+            call for call in popen.call_args_list
+            if any(
+                call.args[0][index:index + 2] == ["cat-file", "blob"]
+                for index in range(len(call.args[0]) - 1)
+            )
+        ]
+        self.assertEqual([], per_blob_popen_calls)
+        per_blob_calls = [
+            call for call in run.call_args_list
+            if any(
+                call.args[0][index:index + 2] == ["cat-file", "blob"]
+                for index in range(len(call.args[0]) - 1)
+            )
+        ]
+        self.assertEqual([], per_blob_calls)
+
+    def test_git_index_retain_paths_bounds_results_but_verifies_every_blob(self) -> None:
+        git_source = self.root / "git-retain-source"
+        git_source.mkdir()
+        fixture = BundleFixture(
+            git_source, version="1.0.0", managed=b"binary\x00v1\r\n", addon=True,
+            source_mode="git-index",
+        )
+
+        retained = verify_bundle(
+            fixture.lock_path, fixture.root,
+            expected_sha256=fixture.lock["bundle_sha256"],
+            source_mode="git-index", retain_paths=("managed.bin", "seed.txt"),
+        )
+        self.assertEqual(
+            {"managed.bin": b"binary\x00v1\r\n", "seed.txt": b"seed\n"},
+            retained.verified_bytes,
+        )
+        unretained = verify_bundle(
+            fixture.lock_path, fixture.root,
+            expected_sha256=fixture.lock["bundle_sha256"],
+            source_mode="git-index", retain_paths=(),
+        )
+        self.assertEqual({}, unretained.verified_bytes)
+
+        (git_source / "managed.bin").write_bytes(b"binary\x00v2\r\n")
+        fixture.commit_all("tamper fixture")
+        rebound = copy.deepcopy(fixture.lock)
+        rebound["bundle"]["source_git_commit"] = fixture._git(
+            "rev-parse", "HEAD"
+        ).stdout.decode("ascii").strip()
+        rebound["bundle_sha256"] = hashlib.sha256(
+            canonical_json(rebound["bundle"]).encode("utf-8")
+        ).hexdigest()
+        fixture.lock_path.write_text(
+            json.dumps(rebound, indent=2) + "\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(BundleError, "raw bytes"):
+            verify_bundle(
+                fixture.lock_path, fixture.root,
+                expected_sha256=rebound["bundle_sha256"],
+                source_mode="git-index", retain_paths=(),
+            )
+
+    def test_git_batch_reader_rejects_malformed_and_truncated_records(self) -> None:
+        class BatchProcess:
+            def __init__(self, output: bytes, *, returncode: int = 0) -> None:
+                self.stdin = io.BytesIO()
+                self.stdout = io.BytesIO(output)
+                self.returncode = returncode
+
+            def poll(self) -> int:
+                return self.returncode
+
+            def kill(self) -> None:
+                self.returncode = -9
+
+            def wait(self) -> int:
+                return self.returncode
+
+        oid = "a" * 40
+        cases = [
+            (f"{oid} tree 3\nabc\n".encode(), "invalid record", 3),
+            (f"{'b' * 40} blob 3\nabc\n".encode(), "invalid record", 3),
+            (f"{oid} missing\n".encode(), "invalid record", 3),
+            (f"{oid} blob -1\n".encode(), "invalid size", 3),
+            (f"{oid} blob 4\nabc\n".encode(), "size does not match", 3),
+            (f"{oid} blob 3\nab".encode(), "truncated payload", 3),
+            (f"{oid} blob 3\nabc!".encode(), "invalid framing", 3),
+        ]
+        for output, message, expected_size in cases:
+            with self.subTest(message=message):
+                process = BatchProcess(output)
+                with mock.patch("subprocess.Popen", return_value=process):
+                    with self.assertRaisesRegex(BundleError, message):
+                        list(_git_blobs(
+                            self.source,
+                            [("managed.bin", oid, False, expected_size)],
+                        ))
+
+        process = BatchProcess(b"fatal batch failure", returncode=1)
+        with mock.patch("subprocess.Popen", return_value=process):
+            with self.assertRaisesRegex(BundleError, "fatal batch failure"):
+                list(_git_blobs(self.source, []))
+
+        process = BatchProcess(b"unexpected trailing output")
+        with mock.patch("subprocess.Popen", return_value=process):
+            with self.assertRaisesRegex(BundleError, "trailing output"):
+                list(_git_blobs(self.source, []))
 
     def test_git_identity_disables_repository_fsmonitor_for_every_command(self) -> None:
         (self.source / ".git").mkdir()

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -23,6 +23,7 @@ from contextos.materializer import (
     INSTALLED_STATE_PATH,
     create_composition_proposal,
     create_materialization_proposal,
+    prepare_materialization_preflight,
 )
 try:
     from tests.test_bundle_lock import BundleFixture, workspace
@@ -100,6 +101,31 @@ class MaterializerTest(unittest.TestCase):
             managed=managed,
             addon=True,
             source_mode="git-index",
+        )
+
+    def assert_materialization_not_published(
+        self,
+        proposal: dict,
+        *,
+        managed_before: bytes,
+        target: Path | None = None,
+        config: Path | None = None,
+    ) -> None:
+        target = self.target if target is None else target
+        config = self.config if config is None else config
+        self.assertEqual(managed_before, (target / "managed.bin").read_bytes())
+        self.assertFalse((target / "addon.txt").exists())
+        self.assertEqual(
+            "1.0.0",
+            json.loads(config.read_text(encoding="utf-8"))["template"]["version"],
+        )
+        self.assertFalse(
+            (
+                target
+                / ".context-os"
+                / "receipts"
+                / f"{proposal['proposal_id']}.json"
+            ).exists()
         )
 
     def compose(self, target: Path, config_input: Path):
@@ -304,8 +330,233 @@ class MaterializerTest(unittest.TestCase):
                 self.target, proposal_path, proposal["proposal_digest"], "generic"
             )
 
-        self.assertEqual(before, (self.target / "managed.bin").read_bytes())
-        self.assertFalse((self.target / "addon.txt").exists())
+        self.assert_materialization_not_published(proposal, managed_before=before)
+
+    def test_git_index_staged_drift_before_apply_fails_before_target_writes(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index v3\n")
+        candidate = fixture.verify()
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+        before = (self.target / "managed.bin").read_bytes()
+        (fixture.root / "managed.bin").write_bytes(b"staged v4\n")
+        fixture._git("add", "managed.bin")
+
+        with self.assertRaisesRegex(BundleError, "index differs from HEAD"):
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+
+        self.assert_materialization_not_published(proposal, managed_before=before)
+
+    def test_git_index_staged_drift_after_journal_fails_before_target_writes(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index v3\n")
+        candidate = fixture.verify()
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+        before = (self.target / "managed.bin").read_bytes()
+        kernel = __import__("contextos.kernel", fromlist=["_create_agent_journal"])
+        original_create_journal = kernel._create_agent_journal
+
+        def stage_source_drift(*args, **kwargs):
+            result = original_create_journal(*args, **kwargs)
+            (fixture.root / "managed.bin").write_bytes(b"staged v4\n")
+            fixture._git("add", "managed.bin")
+            return result
+
+        with mock.patch(
+            "contextos.kernel._create_agent_journal", side_effect=stage_source_drift
+        ), self.assertRaisesRegex(
+            (BundleError, ContextOSError), "index differs from HEAD"
+        ):
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+
+        self.assert_materialization_not_published(proposal, managed_before=before)
+
+    def test_git_index_commit_after_journal_fails_before_target_writes(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index v3\n")
+        candidate = fixture.verify()
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+        before = (self.target / "managed.bin").read_bytes()
+        kernel = __import__("contextos.kernel", fromlist=["_create_agent_journal"])
+        original_create_journal = kernel._create_agent_journal
+
+        def commit_source_drift(*args, **kwargs):
+            result = original_create_journal(*args, **kwargs)
+            (fixture.root / "managed.bin").write_bytes(b"committed v4\n")
+            fixture.commit_all("change source during apply")
+            return result
+
+        with mock.patch(
+            "contextos.kernel._create_agent_journal", side_effect=commit_source_drift
+        ), self.assertRaisesRegex(
+            (BundleError, ContextOSError), "does not match the local Git HEAD"
+        ):
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+
+        self.assert_materialization_not_published(proposal, managed_before=before)
+
+    def test_git_index_current_staged_drift_after_journal_fails_before_target_writes(
+        self,
+    ) -> None:
+        current_root = self.root / "git-current-source"
+        current_root.mkdir()
+        current_fixture = BundleFixture(
+            current_root,
+            version="1.0.0",
+            managed=b"current index v1\n",
+            addon=False,
+            source_mode="git-index",
+        )
+        current = current_fixture.verify(role="current")
+        target = self.root / "git-current-target"
+        shutil.copytree(
+            current_fixture.root,
+            target,
+            ignore=shutil.ignore_patterns(".git"),
+        )
+        config = target / "contextos.workspace.json"
+        config.write_text(
+            json.dumps(workspace("fixture-template", "1.0.0"), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=target,
+            workspace_config_path=config,
+            expected_config_sha256=digest(config),
+            candidate=self.candidate,
+            desired_components=["addon"],
+            current=current,
+            current_components=["core"],
+            now=NOW,
+        )
+        before = (target / "managed.bin").read_bytes()
+        kernel = __import__("contextos.kernel", fromlist=["_create_agent_journal"])
+        original_create_journal = kernel._create_agent_journal
+
+        def stage_current_source_drift(*args, **kwargs):
+            result = original_create_journal(*args, **kwargs)
+            (current_fixture.root / "managed.bin").write_bytes(b"staged current v2\n")
+            current_fixture._git("add", "managed.bin")
+            return result
+
+        with mock.patch(
+            "contextos.kernel._create_agent_journal",
+            side_effect=stage_current_source_drift,
+        ), self.assertRaisesRegex(
+            (BundleError, ContextOSError), "index differs from HEAD"
+        ):
+            apply_proposal(target, proposal_path, proposal["proposal_digest"], "generic")
+
+        self.assert_materialization_not_published(
+            proposal,
+            managed_before=before,
+            target=target,
+            config=config,
+        )
+
+    def test_git_index_apply_uses_two_context_passes_with_planner_end_rechecks(self) -> None:
+        fixture = self.git_candidate(version="3.0.0", managed=b"index v3\n")
+        candidate = fixture.verify()
+        proposal_path, proposal = create_materialization_proposal(
+            target_root=self.target,
+            workspace_config_path=self.config,
+            expected_config_sha256=digest(self.config),
+            candidate=candidate,
+            desired_components=["addon"],
+            current=self.current,
+            current_components=["core"],
+            now=NOW,
+        )
+        materializer = __import__(
+            "contextos.materializer", fromlist=["_materialization_context"]
+        )
+        bundle_schema = __import__(
+            "contextos.bundle_schema", fromlist=["_git_repository_identity"]
+        )
+
+        with mock.patch(
+            "contextos.materializer._materialization_context",
+            wraps=materializer._materialization_context,
+        ) as context_pass, mock.patch(
+            "contextos.bundle_schema._git_repository_identity",
+            wraps=bundle_schema._git_repository_identity,
+        ) as repository_identity:
+            apply_proposal(
+                self.target, proposal_path, proposal["proposal_digest"], "generic"
+            )
+
+        self.assertEqual(2, context_pass.call_count)
+        # Each context verifies the candidate at load and again at the planner's
+        # end boundary; each verification checks Git identity before and after.
+        self.assertEqual(8, repository_identity.call_count)
+
+    def test_preflight_retains_only_candidate_write_payloads(self) -> None:
+        _proposal_path, proposal = self.propose()
+        materializer = __import__("contextos.materializer", fromlist=["verify_bundle"])
+        original_verify = materializer.verify_bundle
+        observations: list[tuple[str, set[str], set[str]]] = []
+
+        def capture_verification(*args, **kwargs):
+            verified = original_verify(*args, **kwargs)
+            observations.append((
+                kwargs.get("role", "candidate"),
+                set(kwargs.get("retain_paths", ())),
+                set(verified.verified_bytes),
+            ))
+            return verified
+
+        with mock.patch(
+            "contextos.materializer.verify_bundle", side_effect=capture_verification
+        ):
+            _created_at, payloads = prepare_materialization_preflight(
+                self.target, proposal
+            )
+
+        expected_bundle_paths = {
+            change["content_ref"]["path"]
+            for change in proposal["changes"]
+            if change["action"] == "write"
+            and change["content_ref"]["kind"] == "bundle"
+        }
+        expected_write_paths = {
+            change["path"]
+            for change in proposal["changes"]
+            if change["action"] == "write"
+        }
+        self.assertEqual(expected_write_paths, set(payloads))
+        self.assertEqual([
+            ("candidate", expected_bundle_paths, expected_bundle_paths),
+            ("current", set(), set()),
+        ], observations)
 
     def test_bundle_apply_rejects_non_materialization_proposal(self) -> None:
         proposal = self.target / "not-materialization.json"


### PR DESCRIPTION
Closes #106.

## Summary

- stream Git-index bundle blobs through one bounded `git cat-file --batch` process per verification pass
- retain only candidate write payloads, discard current-bundle payloads after schema validation, and release the apply payload map immediately after staging
- collapse redundant same-boundary apply validation while preserving planner-end and immediate pre-mutation source revalidation
- add index/HEAD race controls, malformed batch-protocol controls, and apply-level retention assertions
- measure the current full bundle on Linux and Windows: exact Git process counts, wall time, logical raw-buffer bounds, observed staging retention, and traced Python allocation peak

## Verification

- canonical `scripts/validate-all.sh`: 552 tests, 43 expected skips; all docs/link, portability, hooks, integration catalog, component manifest, bundle schema, runtime, workspace, and JSON checks passed
- Windows full-bundle measurement: 160 files; compose 48 Git processes / 6 batch readers / 0 per-blob readers; upgrade 96 / 12 / 0, with one changed managed bundle path
- exact head: `70936df80738c682f313e7936eed2fe5acd47672`
- authenticated Claude `claude-opus-5` exact-SHA review: PASS
- free Hermes `thinkingmachines/inkling:free` exact-SHA review: PASS

The review cycle cap was three. Both final reviewers passed the exact head with no blockers.
