### PR TITLE
release: prepare immutable v0.12.0 artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Run the canonical validator on the release source
         run: |
-          chmod +x scripts/*.sh tests/*.sh
           bash scripts/validate-all.sh
 
       - name: Build the candidate twice and compare every byte
@@ -86,6 +85,7 @@ jobs:
           path: ${{ runner.temp }}/release-one/*
           compression-level: 0
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   verify-candidate-linux:
@@ -217,8 +217,8 @@ jobs:
           fi
           test "$(git ls-remote origin "refs/tags/$TAG" | cut -f1)" = "$RELEASE_COMMIT"
 
-          if gh release view "$TAG" --json isDraft,isPrerelease > "$RUNNER_TEMP/existing-release.json" 2>/dev/null; then
-            python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/existing-release.json").read_text()); assert value == {"isDraft": True, "isPrerelease": False}'
+          if gh release view "$TAG" --json isDraft,isImmutable,isPrerelease > "$RUNNER_TEMP/existing-release.json" 2>/dev/null; then
+            python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/existing-release.json").read_text()); assert value["isPrerelease"] is False and (value["isDraft"] is True or value["isImmutable"] is True)'
             gh release download "$TAG" --dir "$RUNNER_TEMP/existing-assets"
             python scripts/release-artifacts.py verify \
               --artifacts "$RUNNER_TEMP/existing-assets" \
@@ -337,7 +337,8 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Re-download and verify the exact draft immediately before publication
+      - name: Re-download and verify the exact release immediately before publication
+        id: final
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
@@ -362,9 +363,17 @@ jobs:
             "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             --jq '{draft, prerelease, assets: [.assets[] | {name, size, digest}]}' \
             > "$RUNNER_TEMP/release-state.json"
-          python -c 'import hashlib, json, os, pathlib; root=pathlib.Path(os.environ["RUNNER_TEMP"] + "/final-assets"); value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); remote={item["name"]: item for item in value["assets"]}; local={path.name: path for path in root.iterdir() if path.is_file()}; assert value["draft"] is True and value["prerelease"] is False and set(remote) == set(local); assert all(item["size"] == local[name].stat().st_size and item["digest"] == "sha256:" + hashlib.sha256(local[name].read_bytes()).hexdigest() for name, item in remote.items())'
+          python -c 'import hashlib, json, os, pathlib; root=pathlib.Path(os.environ["RUNNER_TEMP"] + "/final-assets"); value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); remote={item["name"]: item for item in value["assets"]}; local={path.name: path for path in root.iterdir() if path.is_file()}; assert type(value["draft"]) is bool and value["prerelease"] is False and set(remote) == set(local); assert all(item["size"] == local[name].stat().st_size and item["digest"] == "sha256:" + hashlib.sha256(local[name].read_bytes()).hexdigest() for name, item in remote.items())'
+          DRAFT=$(python -c 'import json, os, pathlib; print(str(json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text())["draft"]).lower())')
+          if [[ "$DRAFT" == "false" ]]; then
+            test "$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --jq .immutable)" = true
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Publish the verified draft and require immutability
+      - name: Publish the verified draft
+        if: steps.final.outputs.already_published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
@@ -373,6 +382,12 @@ jobs:
             "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             -F draft=false \
             -f make_latest=true >/dev/null
+
+      - name: Require immutability and verify the release attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
+        run: |
           for attempt in 1 2 3 4 5 6; do
             IMMUTABLE=$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
               "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --jq .immutable 2>/dev/null || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,8 @@ jobs:
   stage-draft:
     needs: [verify-candidate-linux, verify-candidate-windows]
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.stage.outputs.release_id }}
     permissions:
       contents: write
     steps:
@@ -200,6 +202,7 @@ jobs:
             > "$RUNNER_TEMP/stage-candidate.json"
 
       - name: Create or confirm the exact tag, then stage the draft
+        id: stage
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -225,25 +228,33 @@ jobs:
               --commit "$RELEASE_COMMIT" \
               > "$RUNNER_TEMP/existing-verification.json"
             diff --recursive --brief "$RUNNER_TEMP/assets" "$RUNNER_TEMP/existing-assets"
-            exit 0
+          else
+            gh release create "$TAG" \
+              "$RUNNER_TEMP/assets/$ASSET_STEM.tar" \
+              "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
+              "$RUNNER_TEMP/assets/$ASSET_STEM.provenance.json" \
+              "$RUNNER_TEMP/assets/$ASSET_STEM.OFFLINE-VERIFY.md" \
+              "$RUNNER_TEMP/assets/SHA256SUMS" \
+              --draft \
+              --verify-tag \
+              --title "Context OS v0.12.0" \
+              --notes-file docs/releases/v0.12.0.md
+            READY=false
+            for attempt in 1 2 3 4 5; do
+              if gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null | grep -Fx true; then
+                READY=true
+                break
+              fi
+              sleep 2
+            done
+            if [[ "$READY" != "true" ]]; then
+              echo "draft release did not become readable" >&2
+              exit 1
+            fi
           fi
-
-          gh release create "$TAG" \
-            "$RUNNER_TEMP/assets/$ASSET_STEM.tar" \
-            "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
-            "$RUNNER_TEMP/assets/$ASSET_STEM.provenance.json" \
-            "$RUNNER_TEMP/assets/$ASSET_STEM.OFFLINE-VERIFY.md" \
-            "$RUNNER_TEMP/assets/SHA256SUMS" \
-            --draft \
-            --verify-tag \
-            --title "Context OS v0.12.0" \
-            --notes-file docs/releases/v0.12.0.md
-          for attempt in 1 2 3 4 5; do
-            gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null | grep -Fx true && exit 0
-            sleep 2
-          done
-          echo "draft release did not become readable" >&2
-          exit 1
+          RELEASE_ID=$(gh release view "$TAG" --json databaseId --jq .databaseId)
+          [[ "$RELEASE_ID" =~ ^[0-9]+$ ]]
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
   verify-draft-linux:
     needs: stage-draft
@@ -264,7 +275,9 @@ jobs:
       - name: Download and verify the staged release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
         run: |
+          test "$(gh release view "$TAG" --json databaseId --jq .databaseId)" = "$RELEASE_ID"
           gh release download "$TAG" --dir "$RUNNER_TEMP/draft-assets"
           python scripts/release-artifacts.py verify \
             --artifacts "$RUNNER_TEMP/draft-assets" \
@@ -295,7 +308,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
         run: |
+          if ((gh release view "$env:TAG" --json databaseId --jq .databaseId) -ne $env:RELEASE_ID) { throw "Draft release ID mismatch" }
           gh release download "$env:TAG" --dir "$env:RUNNER_TEMP/draft-assets"
           python scripts/release-artifacts.py verify `
             --artifacts "$env:RUNNER_TEMP/draft-assets" `
@@ -308,7 +323,7 @@ jobs:
           if ($value.executable_modes_verified -ne $false -or $value.writes -ne $false) { throw "Staged Windows asset verification mismatch" }
 
   publish:
-    needs: [verify-draft-linux, verify-draft-windows]
+    needs: [stage-draft, verify-draft-linux, verify-draft-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -325,6 +340,7 @@ jobs:
       - name: Re-download and verify the exact draft immediately before publication
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
         run: |
           test "$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git refs/heads/main | cut -f1)" = "$RELEASE_COMMIT"
           test "$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git refs/tags/$TAG | cut -f1)" = "$RELEASE_COMMIT"
@@ -333,6 +349,7 @@ jobs:
             "repos/$GITHUB_REPOSITORY/immutable-releases" \
             --jq '.enabled' | grep -Fx true
           gh release verify --help >/dev/null
+          test "$(gh release view "$TAG" --json databaseId --jq .databaseId)" = "$RELEASE_ID"
           gh release download "$TAG" --dir "$RUNNER_TEMP/final-assets"
           python scripts/release-artifacts.py verify \
             --artifacts "$RUNNER_TEMP/final-assets" \
@@ -342,7 +359,7 @@ jobs:
             --commit "$RELEASE_COMMIT" \
             > "$RUNNER_TEMP/final-verification.json"
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             --jq '{draft, prerelease, assets: [.assets[] | {name, size, digest}]}' \
             > "$RUNNER_TEMP/release-state.json"
           python -c 'import hashlib, json, os, pathlib; root=pathlib.Path(os.environ["RUNNER_TEMP"] + "/final-assets"); value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); remote={item["name"]: item for item in value["assets"]}; local={path.name: path for path in root.iterdir() if path.is_file()}; assert value["draft"] is True and value["prerelease"] is False and set(remote) == set(local); assert all(item["size"] == local[name].stat().st_size and item["digest"] == "sha256:" + hashlib.sha256(local[name].read_bytes()).hexdigest() for name, item in remote.items())'
@@ -350,11 +367,15 @@ jobs:
       - name: Publish the verified draft and require immutability
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
         run: |
-          gh release edit "$TAG" --draft=false --latest
+          gh api --method PATCH -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F draft=false \
+            -f make_latest=true >/dev/null
           for attempt in 1 2 3 4 5 6; do
             IMMUTABLE=$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .immutable 2>/dev/null || true)
+              "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --jq .immutable 2>/dev/null || true)
             if [[ "$IMMUTABLE" == "true" ]] && gh release verify "$TAG"; then
               exit 0
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,299 @@
+name: Release v0.12.0
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: Exact reviewed 40-hex commit on main to release
+        required: true
+        type: string
+
+concurrency:
+  group: release-v0.12.0
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  VERSION: 0.12.0
+  TAG: v0.12.0
+  RELEASE_COMMIT: ${{ inputs.commit }}
+  ASSET_STEM: agent-context-os-template-v0.12.0
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Require the exact reviewed commit on main and immutable releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          test "$(git rev-parse origin/main)" = "$RELEASE_COMMIT"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            --jq '.enabled' | grep -Fx true
+
+      - name: Run the canonical validator on the release source
+        run: |
+          chmod +x scripts/*.sh tests/*.sh
+          bash scripts/validate-all.sh
+
+      - name: Build the candidate twice and compare every byte
+        run: |
+          python scripts/release-artifacts.py build \
+            --source . \
+            --output-dir "$RUNNER_TEMP/release-one" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT"
+          python scripts/release-artifacts.py build \
+            --source . \
+            --output-dir "$RUNNER_TEMP/release-two" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT"
+          diff --recursive --brief "$RUNNER_TEMP/release-one" "$RUNNER_TEMP/release-two"
+
+      - name: Verify the candidate archive in a fresh Linux directory
+        run: |
+          python scripts/release-artifacts.py verify \
+            --artifacts "$RUNNER_TEMP/release-one" \
+            --extract-to "$RUNNER_TEMP/extracted-build" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT" \
+            > "$RUNNER_TEMP/build-verification.json"
+          python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/build-verification.json").read_text()); assert value["executable_modes_verified"] is True; assert value["writes"] is False'
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: v0.12.0-candidate-${{ inputs.commit }}
+          path: ${{ runner.temp }}/release-one/*
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+
+  verify-candidate-linux:
+    needs: build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.12.0-candidate-${{ inputs.commit }}
+          path: ${{ runner.temp }}/assets
+
+      - name: Verify the candidate and execute its extracted verifier
+        run: |
+          python scripts/release-artifacts.py verify \
+            --artifacts "$RUNNER_TEMP/assets" \
+            --extract-to "$RUNNER_TEMP/extracted-linux" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT" \
+            > "$RUNNER_TEMP/candidate-linux.json"
+          BUNDLE_SHA=$(python -c 'import json, os, pathlib; print(json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/assets/agent-context-os-template-v0.12.0.provenance.json").read_text())["bundle_lock"]["bundle_sha256"])')
+          cd "$RUNNER_TEMP/extracted-linux/$ASSET_STEM"
+          python -m contextos bundle check \
+            --lock "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
+            --source . \
+            --source-mode directory \
+            --expect-sha256 "$BUNDLE_SHA" \
+            > "$RUNNER_TEMP/extracted-linux-check.json"
+          python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/extracted-linux-check.json").read_text()); assert value["source_mode"] == "directory"; assert value["executable_modes_verified"] is True; assert value["unlocked_files_ignored"] is True; assert value["writes"] is False'
+
+  verify-candidate-windows:
+    needs: build-linux
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.12.0-candidate-${{ inputs.commit }}
+          path: ${{ runner.temp }}/assets
+
+      - name: Verify the candidate and execute its extracted verifier
+        shell: pwsh
+        run: |
+          python scripts/release-artifacts.py verify `
+            --artifacts "$env:RUNNER_TEMP/assets" `
+            --extract-to "$env:RUNNER_TEMP/extracted-windows" `
+            --version "$env:VERSION" `
+            --tag "$env:TAG" `
+            --commit "$env:RELEASE_COMMIT" `
+            | Set-Content -Encoding utf8 "$env:RUNNER_TEMP/candidate-windows.json"
+          $candidate = Get-Content -Raw "$env:RUNNER_TEMP/candidate-windows.json" | ConvertFrom-Json
+          if ($candidate.executable_modes_verified -ne $false -or $candidate.writes -ne $false) { throw "Windows verification contract mismatch" }
+          $provenance = Get-Content -Raw "$env:RUNNER_TEMP/assets/$env:ASSET_STEM.provenance.json" | ConvertFrom-Json
+          Push-Location "$env:RUNNER_TEMP/extracted-windows/$env:ASSET_STEM"
+          python -m contextos bundle check `
+            --lock "$env:RUNNER_TEMP/assets/$env:ASSET_STEM.bundle.lock.json" `
+            --source . `
+            --source-mode directory `
+            --expect-sha256 $provenance.bundle_lock.bundle_sha256 `
+            | Set-Content -Encoding utf8 "$env:RUNNER_TEMP/extracted-windows-check.json"
+          Pop-Location
+          $check = Get-Content -Raw "$env:RUNNER_TEMP/extracted-windows-check.json" | ConvertFrom-Json
+          if ($check.source_mode -ne "directory" -or $check.executable_modes_verified -ne $false -or $check.unlocked_files_ignored -ne $true -or $check.writes -ne $false) { throw "Extracted Windows bundle report mismatch" }
+
+  stage-draft:
+    needs: [verify-candidate-linux, verify-candidate-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.12.0-candidate-${{ inputs.commit }}
+          path: ${{ runner.temp }}/assets
+
+      - name: Recheck main and stage the exact assets as a draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$RELEASE_COMMIT"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "tag already exists: $TAG" >&2
+            exit 1
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release already exists: $TAG" >&2
+            exit 1
+          fi
+          gh release create "$TAG" \
+            "$RUNNER_TEMP/assets/$ASSET_STEM.tar" \
+            "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
+            "$RUNNER_TEMP/assets/$ASSET_STEM.provenance.json" \
+            "$RUNNER_TEMP/assets/$ASSET_STEM.OFFLINE-VERIFY.md" \
+            "$RUNNER_TEMP/assets/SHA256SUMS" \
+            --draft \
+            --target "$RELEASE_COMMIT" \
+            --title "Context OS v0.12.0" \
+            --notes-file docs/releases/v0.12.0.md
+          test "$(git ls-remote origin refs/tags/$TAG | cut -f1)" = "$RELEASE_COMMIT"
+
+  verify-draft-linux:
+    needs: stage-draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Download and verify the staged release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "$TAG" --dir "$RUNNER_TEMP/draft-assets"
+          python scripts/release-artifacts.py verify \
+            --artifacts "$RUNNER_TEMP/draft-assets" \
+            --extract-to "$RUNNER_TEMP/draft-linux" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT" \
+            > "$RUNNER_TEMP/draft-linux.json"
+          python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/draft-linux.json").read_text()); assert value["executable_modes_verified"] is True; assert value["writes"] is False'
+
+  verify-draft-windows:
+    needs: stage-draft
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Download and verify the staged release assets
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "$env:TAG" --dir "$env:RUNNER_TEMP/draft-assets"
+          python scripts/release-artifacts.py verify `
+            --artifacts "$env:RUNNER_TEMP/draft-assets" `
+            --extract-to "$env:RUNNER_TEMP/draft-windows" `
+            --version "$env:VERSION" `
+            --tag "$env:TAG" `
+            --commit "$env:RELEASE_COMMIT" `
+            | Set-Content -Encoding utf8 "$env:RUNNER_TEMP/draft-windows.json"
+          $value = Get-Content -Raw "$env:RUNNER_TEMP/draft-windows.json" | ConvertFrom-Json
+          if ($value.executable_modes_verified -ne $false -or $value.writes -ne $false) { throw "Staged Windows asset verification mismatch" }
+
+  publish:
+    needs: [verify-draft-linux, verify-draft-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Recheck the exact draft, tag, assets, and immutable-release policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test "$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git refs/heads/main | cut -f1)" = "$RELEASE_COMMIT"
+          test "$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git refs/tags/$TAG | cut -f1)" = "$RELEASE_COMMIT"
+          gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            --jq '.enabled' | grep -Fx true
+          gh api "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '.[] | select(.tag_name == env.TAG) | [.draft, .prerelease, (.assets | map(.name) | sort)]' \
+            > "$RUNNER_TEMP/release-state.json"
+          python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); expected=sorted([os.environ["ASSET_STEM"] + suffix for suffix in [".tar", ".bundle.lock.json", ".provenance.json", ".OFFLINE-VERIFY.md"]] + ["SHA256SUMS"]); assert value == [True, False, expected]'
+
+      - name: Publish the verified draft and require immutability
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "$TAG" --draft=false --latest
+          test "$(gh release view "$TAG" --json isImmutable --jq .isImmutable)" = true
+          gh release verify "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,24 +179,55 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: v0.12.0-candidate-${{ inputs.commit }}
           path: ${{ runner.temp }}/assets
 
-      - name: Recheck main and stage the exact assets as a draft
+      - name: Recheck and verify the candidate before staging
+        run: |
+          test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$RELEASE_COMMIT"
+          python scripts/release-artifacts.py verify \
+            --artifacts "$RUNNER_TEMP/assets" \
+            --extract-to "$RUNNER_TEMP/stage-candidate" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT" \
+            > "$RUNNER_TEMP/stage-candidate.json"
+
+      - name: Create or confirm the exact tag, then stage the draft
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$RELEASE_COMMIT"
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "tag already exists: $TAG" >&2
+          REMOTE_TAG=$(git ls-remote origin "refs/tags/$TAG" | cut -f1)
+          if [[ -z "$REMOTE_TAG" ]]; then
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f "ref=refs/tags/$TAG" \
+              -f "sha=$RELEASE_COMMIT" >/dev/null
+          elif [[ "$REMOTE_TAG" != "$RELEASE_COMMIT" ]]; then
+            echo "tag $TAG points to $REMOTE_TAG, expected $RELEASE_COMMIT" >&2
             exit 1
           fi
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release already exists: $TAG" >&2
-            exit 1
+          test "$(git ls-remote origin "refs/tags/$TAG" | cut -f1)" = "$RELEASE_COMMIT"
+
+          if gh release view "$TAG" --json isDraft,isPrerelease > "$RUNNER_TEMP/existing-release.json" 2>/dev/null; then
+            python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/existing-release.json").read_text()); assert value == {"isDraft": True, "isPrerelease": False}'
+            gh release download "$TAG" --dir "$RUNNER_TEMP/existing-assets"
+            python scripts/release-artifacts.py verify \
+              --artifacts "$RUNNER_TEMP/existing-assets" \
+              --extract-to "$RUNNER_TEMP/existing-extracted" \
+              --version "$VERSION" \
+              --tag "$TAG" \
+              --commit "$RELEASE_COMMIT" \
+              > "$RUNNER_TEMP/existing-verification.json"
+            diff --recursive --brief "$RUNNER_TEMP/assets" "$RUNNER_TEMP/existing-assets"
+            exit 0
           fi
+
           gh release create "$TAG" \
             "$RUNNER_TEMP/assets/$ASSET_STEM.tar" \
             "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
@@ -204,16 +235,22 @@ jobs:
             "$RUNNER_TEMP/assets/$ASSET_STEM.OFFLINE-VERIFY.md" \
             "$RUNNER_TEMP/assets/SHA256SUMS" \
             --draft \
-            --target "$RELEASE_COMMIT" \
+            --verify-tag \
             --title "Context OS v0.12.0" \
             --notes-file docs/releases/v0.12.0.md
-          test "$(git ls-remote origin refs/tags/$TAG | cut -f1)" = "$RELEASE_COMMIT"
+          for attempt in 1 2 3 4 5; do
+            gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null | grep -Fx true && exit 0
+            sleep 2
+          done
+          echo "draft release did not become readable" >&2
+          exit 1
 
   verify-draft-linux:
     needs: stage-draft
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # GitHub exposes draft releases only to tokens with push access.
+      contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -242,7 +279,8 @@ jobs:
     needs: stage-draft
     runs-on: windows-latest
     permissions:
-      contents: read
+      # GitHub exposes draft releases only to tokens with push access.
+      contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -275,7 +313,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Recheck the exact draft, tag, assets, and immutable-release policy
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Re-download and verify the exact draft immediately before publication
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -285,15 +332,33 @@ jobs:
             -H 'X-GitHub-Api-Version: 2026-03-10' \
             "repos/$GITHUB_REPOSITORY/immutable-releases" \
             --jq '.enabled' | grep -Fx true
-          gh api "repos/$GITHUB_REPOSITORY/releases" \
-            --jq '.[] | select(.tag_name == env.TAG) | [.draft, .prerelease, (.assets | map(.name) | sort)]' \
+          gh release verify --help >/dev/null
+          gh release download "$TAG" --dir "$RUNNER_TEMP/final-assets"
+          python scripts/release-artifacts.py verify \
+            --artifacts "$RUNNER_TEMP/final-assets" \
+            --extract-to "$RUNNER_TEMP/final-extracted" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT" \
+            > "$RUNNER_TEMP/final-verification.json"
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" \
+            --jq '{draft, prerelease, assets: [.assets[] | {name, size, digest}]}' \
             > "$RUNNER_TEMP/release-state.json"
-          python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); expected=sorted([os.environ["ASSET_STEM"] + suffix for suffix in [".tar", ".bundle.lock.json", ".provenance.json", ".OFFLINE-VERIFY.md"]] + ["SHA256SUMS"]); assert value == [True, False, expected]'
+          python -c 'import hashlib, json, os, pathlib; root=pathlib.Path(os.environ["RUNNER_TEMP"] + "/final-assets"); value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); remote={item["name"]: item for item in value["assets"]}; local={path.name: path for path in root.iterdir() if path.is_file()}; assert value["draft"] is True and value["prerelease"] is False and set(remote) == set(local); assert all(item["size"] == local[name].stat().st_size and item["digest"] == "sha256:" + hashlib.sha256(local[name].read_bytes()).hexdigest() for name, item in remote.items())'
 
       - name: Publish the verified draft and require immutability
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release edit "$TAG" --draft=false --latest
-          test "$(gh release view "$TAG" --json isImmutable --jq .isImmutable)" = true
-          gh release verify "$TAG"
+          for attempt in 1 2 3 4 5 6; do
+            IMMUTABLE=$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .immutable 2>/dev/null || true)
+            if [[ "$IMMUTABLE" == "true" ]] && gh release verify "$TAG"; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "published release did not expose a valid immutable attestation" >&2
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## [Unreleased]
 
-### Changed
+---
+
+## [0.12.0] — 2026-08-29 — Immutable full-template release
+
+v0.12.0 publishes the colocated full-template, full-component-closure contract.
+It does not claim external repository attachment or a durable slim workspace
+profile; those require later binding and workspace-schema revisions.
+
+### Release contract
+- Release qualification now distinguishes deterministic adapter/kernel
+  conformance from installed-client execution. Hermes 0.20.5 was installed and
+  its deterministic lifecycle passed, but its retained live run did not complete
+  model inference; Hermes is experimental and that attempt is not counted as
+  successful installed-client conformance.
 - Git-index bundle verification now streams locked blobs through one bounded
   `git cat-file --batch` process per pass, retains only requested candidate
   write payloads, discards current-bundle payloads after validation, and removes
@@ -34,6 +47,11 @@
   README support claims, plus strict maintainer and conformance checks.
 
 ### Added
+- Deterministic v0.12 release tooling and a gated manual workflow build the exact
+  full component closure twice from a clean Linux Git index, bind archive, lock,
+  version, tag, commit, provenance, and offline instructions, verify candidate
+  bytes on Linux and Windows before creating a tag or draft, then verify the
+  exact staged assets on both platforms before immutable publication.
 - Digest-bound bundle composition and upgrade proposals that materialize binary
   and text component files through the existing journal, receipt, recovery, and
   rollback engine. Clean composition writes workspace configuration in the same
@@ -188,7 +206,7 @@
 
 ### Changed
 - **Repository renamed `claude-context-os` → `agent-context-os`.** Self-references updated across the README (badges, clone commands, UTM), docs, setup remote check, test fixtures, and the og-image SVG; old GitHub URLs redirect automatically. Re-render and re-upload `docs/assets/og-image.png` via Settings → Social preview.
-- Added first-class Hermes Agent support: an AGENTS.md Hermes section (Hermes loads `AGENTS.md` as project rules), a memory-mapping guide (`docs/memory-across-agents.md`) covering native Hermes memory and its Curator versus repository state and `/dream`, a hooks-equivalents note, and a new [memory across agents](docs/memory-across-agents.md) README row in host support.
+- Added an experimental Hermes Agent adapter: an AGENTS.md Hermes section (Hermes loads `AGENTS.md` as project rules), a memory-mapping guide (`docs/memory-across-agents.md`) covering native Hermes memory and its Curator versus repository state and `/dream`, a hooks-equivalents note, and a new [memory across agents](docs/memory-across-agents.md) README row in host support.
 - `scripts/setup.sh` now detects and offers to launch Claude Code, Codex, Hermes, Cursor CLI, or OpenClaw (`--agent auto|claude|codex|hermes|cursor|openclaw|none`), with per-host next steps.
 - The public product name and repository slug are now `agent-context-os`; historical `claude-context-os` URLs continue to redirect.
 - The README now follows the complete user journey: privacy-aware setup, selective import, honest host support, opt-in integrations, maintenance, and a task-based documentation map.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,11 @@ Update `CHANGELOG.md` whenever you add, remove, or significantly change a file.
 Use each applicable `Added`, `Changed`, `Fixed`, or `Removed` heading at most
 once per release block, and list each public behavior change once.
 
+Release maintainers must follow [`docs/release-process.md`](docs/release-process.md).
+The tag and staged assets are created only after the Linux and Windows candidate
+gates pass; the draft is published only after both platforms verify the exact
+downloaded release assets.
+
 ## Pull requests
 
 - Branch from `main`. Keep one concern per pull request.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A portable Git-backed context and workflow layer for agents like Claude Code, Co
 
 Chat history, project instructions, and copied prompts drift apart. Context OS puts the durable parts in plain Markdown: who you are, what you are working on, decisions already made, and the workflows you want an agent to follow.
 
-Claude Code, Codex, Hermes, and OpenClaw, plus the experimental Cursor and Devin adapters,
-read the same repository state. A deterministic
+Claude Code, Codex, and OpenClaw, plus the experimental Hermes, Cursor, and
+Devin adapters, read the same repository state. A deterministic
 lifecycle kernel turns reviewed setup, checkpoint, and close requests into
 hash-checked proposals and receipts, without treating native memory as the
 source of truth.
@@ -77,7 +77,7 @@ the [root contract](docs/root-contract.md).
 |---|---|
 | New workspace in Claude Code | Run `/setup` |
 | New workspace in Codex | Run `$setup` |
-| New workspace in Hermes | Run `/setup` after exposing the repository skills |
+| New workspace in experimental Hermes support | Read the [evidence limit](adapters/hermes/README.md), then run `/setup` after exposing the repository skills |
 | New workspace in OpenClaw | Follow the [OpenClaw adapter](adapters/openclaw/README.md), then run `/contextos <alias> setup` through an authorized operator surface |
 | New workspace in Cursor | Follow the separate [experimental IDE and CLI paths](adapters/cursor/README.md), then run `/context-setup` |
 | New cloud session in Devin | Complete the [managed-account checks](adapters/devin/README.md), then run `@skills:context-setup` |
@@ -103,7 +103,7 @@ At the end, `/end` or `$end` proposes a handoff for review before it updates `se
 
 Start small. Use the core loop for a week, add one active project, then turn a repeated task into a skill when the repetition is clear.
 
-| Moment | Claude Code | Codex | Hermes | OpenClaw | Cursor IDE/CLI (experimental) | Devin session (experimental) | Shared result |
+| Moment | Claude Code | Codex | Hermes (experimental) | OpenClaw | Cursor IDE/CLI (experimental) | Devin session (experimental) | Shared result |
 |---|---|---|---|---|---|---|---|
 | First run or major refresh | `/setup` | `$setup` | `/setup` | `/contextos <alias> setup` | `/context-setup` | `@skills:context-setup` | Reviewed context proposal |
 | Start work | `/start` | `$start` | `/start` | `/contextos <alias> start` | `/context-start` | `@skills:context-start` | Read-only continuity inventory and briefing |
@@ -141,7 +141,7 @@ The guide covers ChatGPT, Claude, Gemini Apps, Gemini CLI, and a generic path fo
 | Codex | first-class | Shared lifecycle, native skills, project instructions, hooks, and reviewed proposal/apply writes |
 | Cursor | experimental | Separate IDE and CLI onboarding through root AGENTS.md and project Agent Skills, without hook, memory, or rule-conflict claims |
 | Devin | experimental | Experimental cloud-session lifecycle through repository AGENTS.md and Agent Skills, with Devin Review and all account-managed state kept separate |
-| Hermes Agent | first-class | Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory |
+| Hermes Agent | experimental | Deterministic adapter and kernel conformance; installed-client model inference remains unverified, with advisory hooks and separate native memory |
 | OpenClaw | first-class | External-plugin multi-turn lifecycle with alias-bound lightweight subagents, copied portable skills, separate private memory, and trusted-shell kernel apply |
 <!-- runtime-support:end -->
 
@@ -155,7 +155,7 @@ Compatibility paths that are not registered runtime adapters:
 
 ## One source, explicit host adapters
 
-| Capability | Shared | Claude Code | Codex | Hermes | OpenClaw | Cursor IDE/CLI (experimental) | Devin session (experimental) |
+| Capability | Shared | Claude Code | Codex | Hermes (experimental) | OpenClaw | Cursor IDE/CLI (experimental) | Devin session (experimental) |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Identity, project, state, and session files | Yes | Reads | Reads | Reads | Reads | Reads | Reads |
 | Deterministic proposal/apply and receipts | Yes | Adapter | Native skill calls | Installed skill calls | Copied skill calls | Native skill calls | Native skill calls |
@@ -262,8 +262,9 @@ behavior of an installed agent version or an external service.
 | Use the repository in Cursor | [Experimental Cursor IDE and CLI adapter](adapters/cursor/README.md) |
 | Keep claude.ai projects aligned | [Claude projects sync](docs/claude-projects-sync.md) |
 | See every command and portable skill | [Commands and skills](docs/commands-and-skills.md) |
-| Understand component ownership and future clean composition | [Component model](docs/component-model.md) |
+| Understand component ownership and the composition/materialization substrate | [Component model](docs/component-model.md) |
 | Verify an offline bundle or inspect a structural plan | [Bundle locks and plans](docs/bundle-locks.md) |
+| Read the v0.12 release scope and evidence limits | [v0.12.0 release notes](docs/releases/v0.12.0.md) |
 | Understand KernelRoot, ContextRoot, WorkingRoot, and the v0.12 compatibility boundary | [Root contract](docs/root-contract.md) |
 | Choose an optional add-on | [Integration chooser](docs/integrations-guide.md) and [catalog](references/integrations.md) |
 | Understand product language and boundaries | [Positioning](docs/positioning.md) |

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -1,5 +1,10 @@
 # Hermes adapter
 
+This adapter is experimental in v0.12. Deterministic repository, kernel, skill,
+and hook conformance passes, but the installed Hermes 0.20.5 client did not
+complete model inference during the retained live run. That attempt is not
+counted as installed-client conformance.
+
 Run `bash scripts/contextos.sh install --runtime hermes` from the repository root.
 Expose `.agents/skills/` as an external Hermes skill directory, or install the
 four short aliases together with their four `context-*` cores. Hermes copies

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -52,6 +52,10 @@
                     "policy": "development"
                 },
                 {
+                    "path": ".github/workflows/release.yml",
+                    "policy": "development"
+                },
+                {
                     "path": ".gitignore",
                     "policy": "managed"
                 },
@@ -196,6 +200,14 @@
                     "policy": "managed"
                 },
                 {
+                    "path": "docs/release-process.md",
+                    "policy": "managed"
+                },
+                {
+                    "path": "docs/releases/v0.12.0.md",
+                    "policy": "development"
+                },
+                {
                     "path": "docs/root-contract.md",
                     "policy": "managed"
                 },
@@ -328,6 +340,10 @@
                     "policy": "development"
                 },
                 {
+                    "path": "scripts/release-artifacts.py",
+                    "policy": "development"
+                },
+                {
                     "path": "scripts/pre-commit-hook.sh",
                     "policy": "managed"
                 },
@@ -409,6 +425,10 @@
                 },
                 {
                     "path": "tests/test_materializer.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_release_artifacts.py",
                     "policy": "development"
                 },
                 {

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -205,7 +205,7 @@
                 },
                 {
                     "path": "docs/releases/v0.12.0.md",
-                    "policy": "development"
+                    "policy": "managed"
                 },
                 {
                     "path": "docs/root-contract.md",

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -36,6 +36,33 @@ Generation prints JSON and does not write a lock. It rejects unclassified or
 owned-but-untracked index paths. Release automation can publish the printed lock
 beside an archive of the recorded commit.
 
+## v0.12 release artifact contract
+
+The supported v0.12 distribution is the full-template, full-component closure.
+Although the low-level planner accepts explicit component closures for
+conformance and future composition work, workspace schema v1 cannot persist a
+desired slim closure. Guided slim installation and reconciliation wait for
+workspace schema v2.
+
+The maintainer procedure is [`release-process.md`](release-process.md). Its
+canonical Linux build reads exact bytes from a clean Git index at the reviewed
+commit and emits a deterministic uncompressed USTAR archive containing only the
+lock's non-development paths. The detached lock and provenance bind template
+name and version, anticipated tag, exact commit, archive digest, whole lock-file
+digest, and the lock's internal `bundle_sha256`.
+
+These three digests have different scopes:
+
+- the archive SHA-256 identifies the canonical tar container;
+- the whole lock-file SHA-256 identifies the detached JSON file; and
+- `bundle_sha256` identifies the lock's canonical bundle payload and is the
+  independent value passed to offline directory verification.
+
+Release automation builds twice on Linux, verifies the same candidate artifact
+on Linux and Windows before creating its tag or draft, then downloads and
+verifies the exact staged release assets on both platforms before publication.
+No failed or skipped installed-client check is represented as green evidence.
+
 ## Offline verification
 
 Verification requires both a local source and the independently obtained exact
@@ -147,7 +174,11 @@ both platforms, but records time and memory without platform-sensitive
 thresholds because shared-runner measurements are not stable correctness
 signals. Exact subset-retention tests enforce the payload policy separately.
 
-## Materializing a clean workspace
+## Developer substrate: materializing a clean workspace
+
+The following component-subset interfaces exercise the materializer and future
+composition boundary. They do not create a supported v0.12 slim-workspace
+profile; release-grade v0.12 installs use the full component closure.
 
 Prepare a canonical workspace JSON file whose template name and version match
 the pinned candidate. The target directory must already exist, but its tracked
@@ -175,7 +206,7 @@ The explicit `bundle apply --target` route exists because a clean destination
 has no tracked marker for ordinary root discovery until the approved transaction
 publishes it.
 
-## Materializing a marker-only root
+## Developer substrate: materializing a marker-only root
 
 A marker-only root already has `contextos.workspace.json`, so it is not a clean
 target and `bundle compose` must not be used. The marker's `template.source`
@@ -202,7 +233,7 @@ bash scripts/contextos.sh bundle apply \
 The pinned candidate bundle supplies product authority for this installation
 boundary. The already-loaded executable package and writable marker do not.
 
-## Materializing an upgrade
+## Developer substrate: materializing an upgrade
 
 `bundle propose` consumes the exact current configuration and, when applicable,
 a verified current bundle plus the component closure actually installed. It can

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -5,11 +5,10 @@ make up Context OS. Runtime descriptors name component IDs; the component graph
 resolves those IDs to one deterministic dependency closure and one owner for
 every checked-in path.
 
-This inventory is metadata, not a materializer. It does not copy, delete,
-upgrade, or rewrite a workspace. Those operations require the later
-configuration and transaction layers described in the multi-agent design epic.
-Detached immutable source identity and read-only composition planning are
-defined in [`bundle-locks.md`](bundle-locks.md).
+The inventory remains metadata rather than executable authority. Materialization
+is implemented by the detached-bundle planner/materializer and the shared
+transaction engine; see [`bundle-locks.md`](bundle-locks.md) and
+[`workspace-configuration.md`](workspace-configuration.md).
 
 ## Path policies
 
@@ -86,9 +85,9 @@ untracked owned files, duplicate owners, and any unclassified tracked source
 file. `components/schema.json` is generated from the Python contract and must
 stay current.
 
-## Clean-composition prerequisites
+## Materialization guarantees
 
-Before a later command may materialize a selected component set, it must also:
+The shipped low-level materializer:
 
 1. record the selected runtimes and components in workspace-local
    configuration;
@@ -97,12 +96,12 @@ Before a later command may materialize a selected component set, it must also:
 4. produce an exact add/change/remove plan with immutable source hashes;
 5. require digest-bound approval and use the transaction lock and receipts;
 6. preserve existing `seed` paths and arbitrary files below extensible roots;
-7. define how generated whole-file artifacts and maintainer-only conformance
-   evidence behave in a slim workspace; and
-8. validate the resulting selected runtime closure without assuming every
-   adapter or the development test tree is present;
-9. make shared instruction and documentation links closure-aware so a slim
-    workspace neither points at omitted adapter docs nor describes hooks that
-    were not selected.
+7. keeps generated whole-file artifacts and maintainer-only conformance evidence
+   outside the released component closure; and
+8. validates the selected runtime closure without treating the development test
+   tree as a workspace output.
 
-Until those guarantees ship, the catalog is intentionally read-only inventory.
+The v0.12 release supports the full-template, full-component closure. Durable
+slim-profile intent, reconciliation, and closure-aware documentation require
+workspace schema v2; the lower-level component-selection interfaces are shipped
+substrate, not a v0.12 slim-workspace support claim.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,14 +2,15 @@
 
 Context OS can begin with a blank interview or selected context from another
 assistant. The result is a small, reviewable repository that Claude Code,
-Codex, Hermes, and OpenClaw, plus the experimental Cursor adapter, can use as
-shared state.
+Codex, and OpenClaw, plus the experimental Hermes, Cursor, and Devin adapters,
+can use as shared state.
 
 ## Before you clone
 
 You need Git, Bash, and Python 3.10 or newer. Local hosts include Claude Code,
-Codex, Hermes, OpenClaw, and Cursor; verify Devin's managed cloud path separately
-in its account UI. claude.ai cannot maintain a local checkout directly.
+Codex, OpenClaw, and the experimental Hermes and Cursor adapters; verify Devin's
+managed cloud path separately in its account UI. claude.ai cannot maintain a
+local checkout directly.
 
 Python may be installed as either `python3` or `python`; the repository resolves
 whichever works. To pin a specific interpreter — a virtualenv, or one of several

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -6,7 +6,8 @@ The product name and the repository slug are both **Context OS** (`agent-context
 
 ## One-line description
 
-Context OS is a Git-backed context and workflow layer shared across Claude Code and Codex.
+Context OS is a Git-backed context and workflow layer shared across Claude Code,
+Codex, and OpenClaw, with experimental Hermes Agent, Cursor, and Devin adapters.
 
 ## The problem
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -53,8 +53,8 @@ The workflow then fails closed through these gates:
 4. verify the same Actions candidate in separate Linux and Windows extraction
    jobs, including execution of `python -m contextos bundle check` from the
    extracted archive;
-5. only after both candidate jobs pass, create the exact tag and stage all five
-   assets in an unpublished draft;
+5. only after both candidate jobs pass, create or confirm the exact lightweight
+   tag through the GitHub API and stage all five assets in an unpublished draft;
 6. download those staged release assets—not the Actions copies—and verify them
    again in separate Linux and Windows directories; and
 7. only after both staged-asset jobs pass, recheck `main`, tag, draft state,
@@ -70,8 +70,9 @@ executable bits. That is an explicit limitation, not a skipped success.
 - Before the tag exists, publish nothing; retain bounded Actions diagnostics and
   rerun only against the same commit.
 - After the tag exists, never move or force-replace it. A failed staged release
-  remains a draft for inspection. Do not automatically overwrite assets or
-  delete forensic evidence.
+  remains a draft for inspection. A rerun may resume only when both the tag and
+  every downloaded draft asset are byte-identical to the same candidate; do not
+  overwrite assets or delete forensic evidence automatically.
 - If deterministic source or artifact verification fails after the tag exists,
   retire that version and fix the problem in a patch release.
 - After publication, tags and assets are immutable. Correct errors with a notice

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,83 @@
+# Release process
+
+Context OS releases one canonical full-template artifact: a deterministic tar of
+the complete non-development component closure. GitHub's automatically generated
+source archives are convenient repository snapshots, but they are not the
+canonical template artifact.
+
+## Assets and identity
+
+For version `X.Y.Z`, the immutable release contains exactly:
+
+- `agent-context-os-template-vX.Y.Z.tar` — deterministic uncompressed USTAR;
+- `agent-context-os-template-vX.Y.Z.bundle.lock.json` — detached bundle lock;
+- `agent-context-os-template-vX.Y.Z.provenance.json` — outer identity and digest
+  binding;
+- `agent-context-os-template-vX.Y.Z.OFFLINE-VERIFY.md` — version-specific offline
+  verification instructions; and
+- `SHA256SUMS` — SHA-256 values for the other four assets.
+
+The archive contains exactly the paths recorded by the lock, beneath one
+`agent-context-os-template-vX.Y.Z/` root. Development files, including CI,
+tests, release tooling, the changelog, and contributor-only documentation, are
+excluded. File order is the lock's portable path order. UIDs and GIDs are zero,
+owner and group names are empty, modes are `0755` only for locked executable
+files and `0644` otherwise, and every mtime is the source commit epoch.
+
+The provenance binds the repository, anticipated tag, exact commit, template
+identity, archive identity, whole lock-file digest, internal `bundle_sha256`,
+instructions digest, generator version, source mode, and fixed epoch. It is
+deterministic and deliberately excludes runner names, workflow IDs, temporary
+paths, and wall-clock generation times.
+
+## Qualification and publication
+
+Only dispatch `.github/workflows/release.yml` from `main`, with the exact
+reviewed 40-hex commit. Before dispatch:
+
+1. merge the release-preparation PR after canonical validation, hosted Linux and
+   Windows validation, and exact-SHA Claude plus free-Hermes reviews;
+2. confirm the version constants, example workspace, and dated changelog agree;
+3. enable GitHub immutable releases for the repository; and
+4. confirm the release tag and release do not already exist.
+
+The workflow uses the checked-in [v0.12.0 release notes](releases/v0.12.0.md) as
+the immutable published description.
+
+The workflow then fails closed through these gates:
+
+1. require the input commit to equal both checked-out `HEAD` and `origin/main`,
+   require a completely clean source, and require immutable releases enabled;
+2. run the canonical validator on that exact source;
+3. build twice from its Linux Git index and compare every artifact byte;
+4. verify the same Actions candidate in separate Linux and Windows extraction
+   jobs, including execution of `python -m contextos bundle check` from the
+   extracted archive;
+5. only after both candidate jobs pass, create the exact tag and stage all five
+   assets in an unpublished draft;
+6. download those staged release assets—not the Actions copies—and verify them
+   again in separate Linux and Windows directories; and
+7. only after both staged-asset jobs pass, recheck `main`, tag, draft state,
+   exact asset names, and immutability policy, publish the draft, and require
+   GitHub's immutable release attestation to verify.
+
+Linux must report executable-mode verification as `true`. Windows must report
+it as `false`, because directory sources there do not expose portable POSIX
+executable bits. That is an explicit limitation, not a skipped success.
+
+## Failure policy
+
+- Before the tag exists, publish nothing; retain bounded Actions diagnostics and
+  rerun only against the same commit.
+- After the tag exists, never move or force-replace it. A failed staged release
+  remains a draft for inspection. Do not automatically overwrite assets or
+  delete forensic evidence.
+- If deterministic source or artifact verification fails after the tag exists,
+  retire that version and fix the problem in a patch release.
+- After publication, tags and assets are immutable. Correct errors with a notice
+  and a new patch release, never by replacing bytes.
+
+Consumers should follow the version-specific offline instructions and obtain
+the expected digest through a channel they trust. Co-located checksums prove
+consistency; GitHub's immutable-release attestation and independently observed
+release identity provide publisher provenance.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -78,7 +78,9 @@ executable bits. That is an explicit limitation, not a skipped success.
 - If deterministic source or artifact verification fails after the tag exists,
   retire that version and fix the problem in a patch release.
 - After publication, tags and assets are immutable. Correct errors with a notice
-  and a new patch release, never by replacing bytes.
+  and a new patch release, never by replacing bytes. If only the final
+  attestation poll times out, a rerun verifies the already-published immutable
+  release by its numeric ID without attempting to publish it again.
 
 Consumers should follow the version-specific offline instructions and obtain
 the expected digest through a channel they trust. Co-located checksums prove

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -54,12 +54,14 @@ The workflow then fails closed through these gates:
    jobs, including execution of `python -m contextos bundle check` from the
    extracted archive;
 5. only after both candidate jobs pass, create or confirm the exact lightweight
-   tag through the GitHub API and stage all five assets in an unpublished draft;
+   tag through the GitHub API, stage all five assets in an unpublished draft,
+   and carry that draft's immutable numeric release ID through every later job;
 6. download those staged release assets—not the Actions copies—and verify them
    again in separate Linux and Windows directories; and
 7. only after both staged-asset jobs pass, recheck `main`, tag, draft state,
-   exact asset names, and immutability policy, publish the draft, and require
-   GitHub's immutable release attestation to verify.
+   exact asset names and server-reported digests, and immutability policy,
+   publish that exact numeric release ID, and require GitHub's immutable release
+   attestation to verify.
 
 Linux must report executable-mode verification as `true`. Windows must report
 it as `false`, because directory sources there do not expose portable POSIX

--- a/docs/releases/v0.12.0.md
+++ b/docs/releases/v0.12.0.md
@@ -1,0 +1,17 @@
+# Context OS v0.12.0
+
+This is the first release-grade, full-template Context OS artifact: a
+deterministic archive, detached content-addressed lock, checksums, provenance,
+and offline verification instructions bound to one reviewed commit.
+
+The supported v0.12 path is colocated and full-closure. External project
+attachment and durable slim workspace profiles remain later schema work.
+
+Hermes is experimental in this release. Its deterministic adapter and kernel
+conformance passes, but the retained installed Hermes 0.20.5 live run did not
+complete model inference and is not counted as installed-client conformance.
+
+Download all five attached assets. Start with
+`agent-context-os-template-v0.12.0.OFFLINE-VERIFY.md`; the canonical artifact is
+`agent-context-os-template-v0.12.0.tar`, not GitHub's automatically generated
+source archives.

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -44,8 +44,10 @@ means core-only. The CLI token `none` maps to that empty set but is never stored
 intent. `generic` is reserved for operation receipts and is not a runtime ID.
 
 Version 1 intentionally uses only `full-template`. Selecting agents records
-intent and controls bare `doctor` validation scope. Removal of unselected
-adapters remains later transaction-backed work.
+intent and controls bare `doctor` validation scope. Activation and disable never
+remove adapter files. A low-level detached-bundle materializer exists, but a
+durable desired slim closure and supported slim reconciliation require workspace
+schema v2.
 
 The public template ships `workspace/example.json` with `agents: []`, but no
 live root configuration. This avoids overriding an existing clone's legacy YAML

--- a/runtimes/hermes.json
+++ b/runtimes/hermes.json
@@ -2,8 +2,8 @@
   "schema_version": 2,
   "runtime": "hermes",
   "display_name": "Hermes Agent",
-  "support_tier": "first-class",
-  "support_summary": "Shared lifecycle through portable skills, advisory hooks, MCP, and separate Hermes-native memory",
+  "support_tier": "experimental",
+  "support_summary": "Deterministic adapter and kernel conformance; installed-client model inference remains unverified, with advisory hooks and separate native memory",
   "components": ["core", "portable-skills", "agents-instructions", "hermes-adapter"],
   "install": {
     "mode": "skill-copy-or-external-directory",
@@ -17,7 +17,7 @@
   "surfaces": {
     "cli": {
       "kind": "cli",
-      "support_tier": "first-class",
+      "support_tier": "experimental",
       "instruction_sources": [
         {"scope": "repository", "role": "canonical", "path": "AGENTS.md", "precedence": 100}
       ],
@@ -55,7 +55,7 @@
   },
   "evidence": {
     "checked_on": "2026-08-24",
-    "tested_versions": [{"surface": "cli", "version": "0.20.5"}],
+    "tested_versions": [],
     "sources": [
       {
         "id": "hermes-overview",

--- a/scripts/release-artifacts.py
+++ b/scripts/release-artifacts.py
@@ -163,13 +163,17 @@ source archives are not the release artifact.
 
 Publisher identity: tag `{tag}`, commit `{commit}`.
 
-1. Obtain all five release assets through an authenticated or otherwise trusted
-   GitHub channel. The co-located files prove consistency, not publisher identity.
+1. Create one empty verification directory, obtain all five release assets in
+   that directory through an authenticated or otherwise trusted GitHub channel,
+   and make it the current directory. Keep the assets together throughout these
+   steps. The co-located files prove consistency, not publisher identity.
 2. Check the four payload digests listed in `{names['checksums']}` using
    `sha256sum -c {names['checksums']}` (or an equivalent SHA-256 tool).
-3. Extract `{names['archive']}` into a new directory. It has one root named
-   `{TEMPLATE_NAME}-v{version}`.
-4. From that extracted root, verify the detached lock without network access:
+3. Extract `{names['archive']}` directly in the current verification directory;
+   do not select a separate extraction destination. The archive creates one root
+   named `{TEMPLATE_NAME}-v{version}` beside the five assets.
+4. Change into that extracted root and verify the detached lock without network
+   access:
 
 ```bash
 python -m contextos bundle check \\

--- a/scripts/release-artifacts.py
+++ b/scripts/release-artifacts.py
@@ -214,6 +214,22 @@ def build_artifacts(source: Path, output_dir: Path, *, version: str, tag: str, c
         instructions = _offline_instructions(version, tag, commit, names, lock["bundle_sha256"])
         instructions_path = staging / names["instructions"]
         instructions_path.write_bytes(instructions)
+        runtime_evidence = []
+        records = {record["path"]: record for record in lock["bundle"]["files"]}
+        for path in sorted(
+            (path for path in verified.verified_bytes if path.startswith("runtimes/")
+             and path.endswith(".json") and path != "runtimes/schema.json"),
+            key=portable_path_identity,
+        ):
+            descriptor = json.loads(verified.verified_bytes[path].decode("utf-8"))
+            runtime_evidence.append({
+                "path": path,
+                "sha256_raw": records[path]["sha256_raw"],
+                "runtime": descriptor["runtime"],
+                "support_tier": descriptor["support_tier"],
+                "support_summary": descriptor["support_summary"],
+                "tested_versions": descriptor["evidence"]["tested_versions"],
+            })
         provenance = {
             "schema_version": 1,
             "release": {
@@ -245,9 +261,7 @@ def build_artifacts(source: Path, output_dir: Path, *, version: str, tag: str, c
                 "filename": names["instructions"],
                 "sha256": _sha256_bytes(instructions),
             },
-            "runtime_evidence": {
-                "hermes": "experimental: deterministic adapter/kernel conformance; installed-client model inference not verified"
-            },
+            "runtime_evidence": runtime_evidence,
         }
         provenance_bytes = _json_bytes(provenance)
         (staging / names["provenance"]).write_bytes(provenance_bytes)
@@ -333,11 +347,8 @@ def verify_artifacts(artifacts: Path, extract_to: Path, *, version: str, tag: st
         raise ReleaseArtifactError("provenance generator identity does not match")
     if type(source.get("commit_epoch")) is not int or source["commit_epoch"] < 0:
         raise ReleaseArtifactError("provenance commit epoch is invalid")
-    expected_runtime_evidence = {
-        "hermes": "experimental: deterministic adapter/kernel conformance; installed-client model inference not verified"
-    }
-    if provenance.get("runtime_evidence") != expected_runtime_evidence:
-        raise ReleaseArtifactError("provenance runtime-evidence qualification does not match")
+    if not isinstance(provenance.get("runtime_evidence"), list):
+        raise ReleaseArtifactError("provenance runtime evidence must be an array")
     lock_path = artifacts / names["lock"]
     lock = load_bundle_lock(lock_path)
     if lock["bundle"]["name"] != TEMPLATE_NAME or lock["bundle"]["version"] != version or lock["bundle"]["source_git_commit"] != commit:
@@ -373,6 +384,7 @@ def verify_artifacts(artifacts: Path, extract_to: Path, *, version: str, tag: st
     expected_members = [f"{prefix}/{item['path']}" for item in lock["bundle"]["files"]]
     extract_root = extract_to / prefix
     extract_to.mkdir(parents=True)
+    runtime_evidence: list[dict[str, Any]] = []
     try:
         with tarfile.open(artifacts / names["archive"], mode="r:") as archive:
             members = archive.getmembers()
@@ -395,9 +407,21 @@ def verify_artifacts(artifacts: Path, extract_to: Path, *, version: str, tag: st
                 data = payload.read()
                 if _sha256_bytes(data) != record["sha256_raw"]:
                     raise ReleaseArtifactError(f"archive payload mismatch: {member.name}")
+                if record["path"].startswith("runtimes/") and record["path"].endswith(".json") and record["path"] != "runtimes/schema.json":
+                    descriptor = json.loads(data.decode("utf-8"))
+                    runtime_evidence.append({
+                        "path": record["path"],
+                        "sha256_raw": record["sha256_raw"],
+                        "runtime": descriptor["runtime"],
+                        "support_tier": descriptor["support_tier"],
+                        "support_summary": descriptor["support_summary"],
+                        "tested_versions": descriptor["evidence"]["tested_versions"],
+                    })
                 destination.write_bytes(data)
                 if os.name != "nt":
                     destination.chmod(expected_mode)
+        if provenance["runtime_evidence"] != runtime_evidence:
+            raise ReleaseArtifactError("provenance runtime evidence does not match locked descriptors")
         verified = verify_bundle(
             lock_path, extract_root, expected_sha256=lock["bundle_sha256"],
             source_mode="directory", retain_paths=(),

--- a/scripts/release-artifacts.py
+++ b/scripts/release-artifacts.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Build and verify deterministic, full-closure Context OS release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from contextos.bundle_schema import (  # noqa: E402
+    BundleError,
+    create_bundle_lock,
+    load_bundle_lock,
+    verify_bundle,
+)
+from contextos.component_schema import portable_path_identity  # noqa: E402
+from contextos.primitives import git_environment  # noqa: E402
+
+
+GENERATOR_VERSION = 1
+TEMPLATE_NAME = "agent-context-os-template"
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+CHECKSUM_RE = re.compile(r"^([0-9a-f]{64})  ([A-Za-z0-9._-]+)$")
+
+
+class ReleaseArtifactError(ValueError):
+    """Raised when release identity or artifact bytes fail closed."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _git(root: Path, *arguments: str) -> bytes:
+    try:
+        return subprocess.run(
+            ["git", *arguments], cwd=root, check=True, capture_output=True,
+            env=git_environment(),
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", b"")
+        if isinstance(detail, bytes):
+            detail = detail.decode("utf-8", errors="replace").strip()
+        raise ReleaseArtifactError(
+            "git " + " ".join(arguments) + " failed" + (f": {detail}" if detail else "")
+        ) from exc
+
+
+def _require_clean_repository(root: Path, expected_commit: str) -> int:
+    if not COMMIT_RE.fullmatch(expected_commit):
+        raise ReleaseArtifactError("commit must be one exact lowercase 40-hex Git commit")
+    actual = _git(root, "rev-parse", "HEAD").decode("ascii").strip()
+    if actual != expected_commit:
+        raise ReleaseArtifactError(f"HEAD is {actual}, expected {expected_commit}")
+    status = _git(root, "status", "--porcelain=v1", "--untracked-files=all")
+    if status:
+        raise ReleaseArtifactError("release source must have a completely clean worktree and index")
+    if _git(root, "ls-files", "--stage").count(b"\n") == 0:
+        raise ReleaseArtifactError("release source Git index is empty")
+    submodules = _git(root, "ls-files", "--stage").splitlines()
+    if any(line.startswith(b"160000 ") for line in submodules):
+        raise ReleaseArtifactError("release source must not contain Git submodules")
+    epoch_text = _git(root, "show", "-s", "--format=%ct", "HEAD").decode("ascii").strip()
+    try:
+        epoch = int(epoch_text)
+    except ValueError as exc:
+        raise ReleaseArtifactError("source commit timestamp is not an integer") from exc
+    if epoch < 0:
+        raise ReleaseArtifactError("source commit timestamp must not be negative")
+    return epoch
+
+
+def _require_release_identity(root: Path, version: str, tag: str) -> None:
+    if not VERSION_RE.fullmatch(version):
+        raise ReleaseArtifactError("version must be an exact X.Y.Z release version")
+    if tag != f"v{version}":
+        raise ReleaseArtifactError(f"tag must equal v{version}")
+    init_text = (root / "contextos/__init__.py").read_text(encoding="utf-8")
+    schema_text = (root / "contextos/workspace_schema.py").read_text(encoding="utf-8")
+    init_match = re.search(r'^__version__\s*=\s*"([^"]+)"\s*$', init_text, re.MULTILINE)
+    schema_match = re.search(
+        r'^DEFAULT_TEMPLATE_VERSION\s*=\s*"([^"]+)"\s*$', schema_text, re.MULTILINE
+    )
+    source_match = re.search(
+        r'^DEFAULT_TEMPLATE_SOURCE\s*=\s*"([^"]+)"\s*$', schema_text, re.MULTILINE
+    )
+    if init_match is None or init_match.group(1) != version:
+        raise ReleaseArtifactError("contextos.__version__ does not match the release version")
+    if schema_match is None or schema_match.group(1) != version:
+        raise ReleaseArtifactError("DEFAULT_TEMPLATE_VERSION does not match the release version")
+    if source_match is None or source_match.group(1) != TEMPLATE_NAME:
+        raise ReleaseArtifactError("DEFAULT_TEMPLATE_SOURCE does not match the release template")
+    workspace = json.loads((root / "workspace/example.json").read_text(encoding="utf-8"))
+    if workspace.get("template") != {"version": version, "source": TEMPLATE_NAME}:
+        raise ReleaseArtifactError("workspace/example.json template identity does not match")
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    if not re.search(rf"^## \[{re.escape(version)}\] [—-] \d{{4}}-\d{{2}}-\d{{2}}\b", changelog, re.MULTILINE):
+        raise ReleaseArtifactError("CHANGELOG.md lacks a dated release block for the version")
+
+
+def artifact_names(version: str) -> dict[str, str]:
+    stem = f"{TEMPLATE_NAME}-v{version}"
+    return {
+        "archive": f"{stem}.tar",
+        "lock": f"{stem}.bundle.lock.json",
+        "provenance": f"{stem}.provenance.json",
+        "instructions": f"{stem}.OFFLINE-VERIFY.md",
+        "checksums": "SHA256SUMS",
+    }
+
+
+def _archive_bytes(prefix: str, source_epoch: int, files: Sequence[dict[str, Any]], payloads: dict[str, bytes]) -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for record in files:
+            relative = record["path"]
+            info = tarfile.TarInfo(f"{prefix}/{relative}")
+            info.size = len(payloads[relative])
+            info.mode = 0o755 if record["executable"] else 0o644
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            info.mtime = source_epoch
+            info.type = tarfile.REGTYPE
+            archive.addfile(info, io.BytesIO(payloads[relative]))
+    return stream.getvalue()
+
+
+def _offline_instructions(version: str, tag: str, commit: str, names: dict[str, str], bundle_digest: str) -> bytes:
+    return f"""# Offline verification for Context OS v{version}
+
+Canonical artifact: `{names['archive']}`. GitHub's automatically generated
+source archives are not the release artifact.
+
+Publisher identity: tag `{tag}`, commit `{commit}`.
+
+1. Obtain all five release assets through an authenticated or otherwise trusted
+   GitHub channel. The co-located files prove consistency, not publisher identity.
+2. Check the four payload digests listed in `{names['checksums']}` using
+   `sha256sum -c {names['checksums']}` (or an equivalent SHA-256 tool).
+3. Extract `{names['archive']}` into a new directory. It has one root named
+   `{TEMPLATE_NAME}-v{version}`.
+4. From that extracted root, verify the detached lock without network access:
+
+```bash
+python -m contextos bundle check \\
+  --lock ../{names['lock']} \\
+  --source . \\
+  --source-mode directory \\
+  --expect-sha256 {bundle_digest}
+```
+
+The report must name version `{version}`, commit `{commit}`, directory source
+mode, `unlocked_files_ignored: true`, and `writes: false`. Linux must report
+`executable_modes_verified: true`. Windows reports `false` because Windows
+directory sources do not expose portable POSIX executable bits; this is an
+explicit platform limitation, not a skipped check.
+""".encode("utf-8")
+
+
+def build_artifacts(source: Path, output_dir: Path, *, version: str, tag: str, commit: str) -> dict[str, Any]:
+    source = source.absolute().resolve()
+    output_dir = output_dir.absolute()
+    if output_dir.exists():
+        raise ReleaseArtifactError(f"output directory already exists: {output_dir}")
+    source_epoch = _require_clean_repository(source, commit)
+    _require_release_identity(source, version, tag)
+    names = artifact_names(version)
+    staging = Path(tempfile.mkdtemp(prefix="contextos-release-", dir=output_dir.parent))
+    try:
+        lock = create_bundle_lock(source, name=TEMPLATE_NAME, version=version, source_mode="git-index")
+        if lock["bundle"]["source_git_commit"] != commit:
+            raise ReleaseArtifactError("bundle lock source commit does not match")
+        lock_bytes = _json_bytes(lock)
+        lock_path = staging / names["lock"]
+        lock_path.write_bytes(lock_bytes)
+        verified = verify_bundle(
+            lock_path, source, expected_sha256=lock["bundle_sha256"],
+            source_mode="git-index", retain_paths=None,
+        )
+        prefix = f"{TEMPLATE_NAME}-v{version}"
+        archive_bytes = _archive_bytes(prefix, source_epoch, lock["bundle"]["files"], verified.verified_bytes)
+        archive_path = staging / names["archive"]
+        archive_path.write_bytes(archive_bytes)
+        instructions = _offline_instructions(version, tag, commit, names, lock["bundle_sha256"])
+        instructions_path = staging / names["instructions"]
+        instructions_path.write_bytes(instructions)
+        provenance = {
+            "schema_version": 1,
+            "release": {
+                "repository": "https://github.com/conorbronsdon/agent-context-os",
+                "tag": tag,
+                "commit": commit,
+            },
+            "template": {"name": TEMPLATE_NAME, "version": version},
+            "source": {
+                "mode": "git-index",
+                "commit_epoch": source_epoch,
+                "generator": "scripts/release-artifacts.py",
+                "generator_version": GENERATOR_VERSION,
+                "generation_platform": "linux",
+            },
+            "archive": {
+                "filename": names["archive"],
+                "media_type": "application/x-tar",
+                "root": prefix,
+                "file_count": len(lock["bundle"]["files"]),
+                "sha256": _sha256_bytes(archive_bytes),
+            },
+            "bundle_lock": {
+                "filename": names["lock"],
+                "sha256": _sha256_bytes(lock_bytes),
+                "bundle_sha256": lock["bundle_sha256"],
+            },
+            "verification_instructions": {
+                "filename": names["instructions"],
+                "sha256": _sha256_bytes(instructions),
+            },
+            "runtime_evidence": {
+                "hermes": "experimental: deterministic adapter/kernel conformance; installed-client model inference not verified"
+            },
+        }
+        provenance_bytes = _json_bytes(provenance)
+        (staging / names["provenance"]).write_bytes(provenance_bytes)
+        checksummed = [names[key] for key in ("archive", "lock", "provenance", "instructions")]
+        checksum_text = "".join(
+            f"{_sha256_file(staging / filename)}  {filename}\n" for filename in checksummed
+        )
+        (staging / names["checksums"]).write_text(checksum_text, encoding="ascii", newline="\n")
+        staging.replace(output_dir)
+        return provenance
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ReleaseArtifactError(f"invalid JSON in {path.name}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ReleaseArtifactError(f"{path.name} must contain a JSON object")
+    return value
+
+
+def _parse_checksums(path: Path, expected_names: Sequence[str]) -> dict[str, str]:
+    try:
+        lines = path.read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise ReleaseArtifactError(f"cannot read {path.name}: {exc}") from exc
+    if len(lines) != len(expected_names):
+        raise ReleaseArtifactError("SHA256SUMS has an unexpected number of entries")
+    result: dict[str, str] = {}
+    for line in lines:
+        match = CHECKSUM_RE.fullmatch(line)
+        if match is None or match.group(2) in result:
+            raise ReleaseArtifactError("SHA256SUMS is malformed or contains duplicates")
+        result[match.group(2)] = match.group(1)
+    if list(result) != list(expected_names):
+        raise ReleaseArtifactError("SHA256SUMS filenames or order do not match the release contract")
+    return result
+
+
+def verify_artifacts(artifacts: Path, extract_to: Path, *, version: str, tag: str, commit: str) -> dict[str, Any]:
+    artifacts = artifacts.absolute().resolve()
+    extract_to = extract_to.absolute()
+    if not artifacts.is_dir():
+        raise ReleaseArtifactError("artifacts must be an existing directory")
+    if extract_to.exists():
+        raise ReleaseArtifactError("extract destination must not already exist")
+    if not VERSION_RE.fullmatch(version) or not COMMIT_RE.fullmatch(commit) or tag != f"v{version}":
+        raise ReleaseArtifactError("expected release identity is malformed")
+    names = artifact_names(version)
+    expected_set = set(names.values())
+    actual_set = {item.name for item in artifacts.iterdir() if item.is_file()}
+    if actual_set != expected_set or any(not item.is_file() for item in artifacts.iterdir()):
+        raise ReleaseArtifactError("release artifact set does not exactly match the contract")
+    checksummed = [names[key] for key in ("archive", "lock", "provenance", "instructions")]
+    checksums = _parse_checksums(artifacts / names["checksums"], checksummed)
+    for filename, expected_digest in checksums.items():
+        if _sha256_file(artifacts / filename) != expected_digest:
+            raise ReleaseArtifactError(f"SHA-256 mismatch for {filename}")
+    provenance = _load_json(artifacts / names["provenance"])
+    if set(provenance) != {
+        "schema_version", "release", "template", "source", "archive",
+        "bundle_lock", "verification_instructions", "runtime_evidence",
+    } or provenance.get("schema_version") != 1:
+        raise ReleaseArtifactError("provenance schema or top-level fields do not match")
+    if provenance.get("release") != {
+        "repository": "https://github.com/conorbronsdon/agent-context-os",
+        "tag": tag,
+        "commit": commit,
+    }:
+        raise ReleaseArtifactError("provenance release identity does not match")
+    if provenance.get("template") != {"name": TEMPLATE_NAME, "version": version}:
+        raise ReleaseArtifactError("provenance template identity does not match")
+    source = provenance.get("source")
+    if not isinstance(source, dict) or set(source) != {
+        "mode", "commit_epoch", "generator", "generator_version", "generation_platform"
+    } or source.get("mode") != "git-index" or source.get("generation_platform") != "linux":
+        raise ReleaseArtifactError("provenance source contract does not match")
+    if source.get("generator") != "scripts/release-artifacts.py" or source.get("generator_version") != GENERATOR_VERSION:
+        raise ReleaseArtifactError("provenance generator identity does not match")
+    if type(source.get("commit_epoch")) is not int or source["commit_epoch"] < 0:
+        raise ReleaseArtifactError("provenance commit epoch is invalid")
+    expected_runtime_evidence = {
+        "hermes": "experimental: deterministic adapter/kernel conformance; installed-client model inference not verified"
+    }
+    if provenance.get("runtime_evidence") != expected_runtime_evidence:
+        raise ReleaseArtifactError("provenance runtime-evidence qualification does not match")
+    lock_path = artifacts / names["lock"]
+    lock = load_bundle_lock(lock_path)
+    if lock["bundle"]["name"] != TEMPLATE_NAME or lock["bundle"]["version"] != version or lock["bundle"]["source_git_commit"] != commit:
+        raise ReleaseArtifactError("bundle lock identity does not match")
+    lock_provenance = provenance.get("bundle_lock")
+    if lock_provenance != {
+        "filename": names["lock"],
+        "sha256": checksums[names["lock"]],
+        "bundle_sha256": lock["bundle_sha256"],
+    }:
+        raise ReleaseArtifactError("provenance bundle-lock binding does not match")
+    instructions_provenance = provenance.get("verification_instructions")
+    if instructions_provenance != {
+        "filename": names["instructions"],
+        "sha256": checksums[names["instructions"]],
+    }:
+        raise ReleaseArtifactError("provenance instructions binding does not match")
+    expected_instructions = _offline_instructions(
+        version, tag, commit, names, lock["bundle_sha256"]
+    )
+    if (artifacts / names["instructions"]).read_bytes() != expected_instructions:
+        raise ReleaseArtifactError("offline verification instructions do not match the release identity")
+    prefix = f"{TEMPLATE_NAME}-v{version}"
+    archive_provenance = provenance.get("archive")
+    if archive_provenance != {
+        "filename": names["archive"],
+        "media_type": "application/x-tar",
+        "root": prefix,
+        "file_count": len(lock["bundle"]["files"]),
+        "sha256": checksums[names["archive"]],
+    }:
+        raise ReleaseArtifactError("provenance archive binding does not match")
+    expected_members = [f"{prefix}/{item['path']}" for item in lock["bundle"]["files"]]
+    extract_root = extract_to / prefix
+    extract_to.mkdir(parents=True)
+    try:
+        with tarfile.open(artifacts / names["archive"], mode="r:") as archive:
+            members = archive.getmembers()
+            if [member.name for member in members] != expected_members:
+                raise ReleaseArtifactError("archive members or portable order do not match the lock")
+            for member, record in zip(members, lock["bundle"]["files"]):
+                if not member.isfile() or member.linkname or member.uid != 0 or member.gid != 0:
+                    raise ReleaseArtifactError(f"unsafe archive member metadata: {member.name}")
+                if member.uname or member.gname or member.mtime != source["commit_epoch"]:
+                    raise ReleaseArtifactError(f"non-deterministic archive metadata: {member.name}")
+                expected_mode = 0o755 if record["executable"] else 0o644
+                if member.mode != expected_mode or member.size != record["size"]:
+                    raise ReleaseArtifactError(f"archive mode or size mismatch: {member.name}")
+                relative = PurePosixPath(record["path"])
+                destination = extract_root.joinpath(*relative.parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                payload = archive.extractfile(member)
+                if payload is None:
+                    raise ReleaseArtifactError(f"archive payload unavailable: {member.name}")
+                data = payload.read()
+                if _sha256_bytes(data) != record["sha256_raw"]:
+                    raise ReleaseArtifactError(f"archive payload mismatch: {member.name}")
+                destination.write_bytes(data)
+                if os.name != "nt":
+                    destination.chmod(expected_mode)
+        verified = verify_bundle(
+            lock_path, extract_root, expected_sha256=lock["bundle_sha256"],
+            source_mode="directory", retain_paths=(),
+        )
+        return {
+            "schema_version": 1,
+            "tag": tag,
+            "commit": commit,
+            "version": version,
+            "bundle_sha256": verified.digest,
+            "archive_sha256": checksums[names["archive"]],
+            "files": len(verified.records),
+            "source_mode": verified.source_mode,
+            "executable_modes_verified": verified.mode_verified,
+            "unlocked_files_ignored": True,
+            "writes": False,
+        }
+    except Exception:
+        shutil.rmtree(extract_to, ignore_errors=True)
+        raise
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    build = commands.add_parser("build")
+    build.add_argument("--source", type=Path, required=True)
+    build.add_argument("--output-dir", type=Path, required=True)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--artifacts", type=Path, required=True)
+    verify.add_argument("--extract-to", type=Path, required=True)
+    for command in (build, verify):
+        command.add_argument("--version", required=True)
+        command.add_argument("--tag", required=True)
+        command.add_argument("--commit", required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "build":
+            if not sys.platform.startswith("linux"):
+                raise ReleaseArtifactError("canonical release generation is Linux-only")
+            result = build_artifacts(
+                args.source, args.output_dir, version=args.version,
+                tag=args.tag, commit=args.commit,
+            )
+        else:
+            result = verify_artifacts(
+                args.artifacts, args.extract_to, version=args.version,
+                tag=args.tag, commit=args.commit,
+            )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+    except (ReleaseArtifactError, BundleError, OSError, UnicodeError, json.JSONDecodeError, tarfile.TarError) as exc:
+        print(f"release artifacts: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -215,6 +215,10 @@ class ReleaseArtifactTest(unittest.TestCase):
         self.assertIn('-f "ref=refs/tags/$TAG"', workflow)
         self.assertIn("--verify-tag", workflow)
         self.assertNotIn('--target "$RELEASE_COMMIT"', workflow)
+        build = workflow.split("  build-linux:", 1)[1].split(
+            "  verify-candidate-linux:", 1
+        )[0]
+        self.assertNotIn("chmod +x", build)
         publish = workflow.split("  publish:", 1)[1]
         self.assertLess(
             publish.index('gh release download "$TAG"'),
@@ -231,6 +235,7 @@ class ReleaseArtifactTest(unittest.TestCase):
         self.assertIn("release_id: ${{ steps.stage.outputs.release_id }}", workflow)
         self.assertIn('"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"', publish)
         self.assertNotIn('releases/tags/$TAG', publish)
+        self.assertIn("already_published=true", publish)
         action_references = [
             line.strip().split("uses: ", 1)[1].split(" #", 1)[0]
             for line in workflow.splitlines() if "uses: actions/" in line

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -207,7 +207,7 @@ class ReleaseArtifactTest(unittest.TestCase):
             "needs: [verify-candidate-linux, verify-candidate-windows]", workflow
         )
         self.assertIn(
-            "needs: [verify-draft-linux, verify-draft-windows]", workflow
+            "needs: [stage-draft, verify-draft-linux, verify-draft-windows]", workflow
         )
         self.assertLess(workflow.index("stage-draft:"), workflow.index("publish:"))
         self.assertNotIn("always()", workflow)
@@ -218,16 +218,19 @@ class ReleaseArtifactTest(unittest.TestCase):
         publish = workflow.split("  publish:", 1)[1]
         self.assertLess(
             publish.index('gh release download "$TAG"'),
-            publish.index('gh release edit "$TAG" --draft=false'),
+            publish.index('gh api --method PATCH'),
         )
         self.assertLess(
             publish.index("scripts/release-artifacts.py verify"),
-            publish.index('gh release edit "$TAG" --draft=false'),
+            publish.index('gh api --method PATCH'),
         )
         self.assertLess(
             publish.index('item["digest"] == "sha256:"'),
-            publish.index('gh release edit "$TAG" --draft=false'),
+            publish.index('gh api --method PATCH'),
         )
+        self.assertIn("release_id: ${{ steps.stage.outputs.release_id }}", workflow)
+        self.assertIn('"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"', publish)
+        self.assertNotIn('releases/tags/$TAG', publish)
         action_references = [
             line.strip().split("uses: ", 1)[1].split(" #", 1)[0]
             for line in workflow.splitlines() if "uses: actions/" in line

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -211,7 +211,23 @@ class ReleaseArtifactTest(unittest.TestCase):
         )
         self.assertLess(workflow.index("stage-draft:"), workflow.index("publish:"))
         self.assertNotIn("always()", workflow)
-        self.assertEqual(workflow.count("contents: write"), 2)
+        self.assertEqual(workflow.count("contents: write"), 4)
+        self.assertIn('-f "ref=refs/tags/$TAG"', workflow)
+        self.assertIn("--verify-tag", workflow)
+        self.assertNotIn('--target "$RELEASE_COMMIT"', workflow)
+        publish = workflow.split("  publish:", 1)[1]
+        self.assertLess(
+            publish.index('gh release download "$TAG"'),
+            publish.index('gh release edit "$TAG" --draft=false'),
+        )
+        self.assertLess(
+            publish.index("scripts/release-artifacts.py verify"),
+            publish.index('gh release edit "$TAG" --draft=false'),
+        )
+        self.assertLess(
+            publish.index('item["digest"] == "sha256:"'),
+            publish.index('gh release edit "$TAG" --draft=false'),
+        )
         action_references = [
             line.strip().split("uses: ", 1)[1].split(" #", 1)[0]
             for line in workflow.splitlines() if "uses: actions/" in line

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import shutil
 import subprocess
+import sys
+import tarfile
 import tempfile
 import unittest
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from contextos.primitives import git_environment
 
@@ -28,14 +31,10 @@ class ReleaseFixture:
         self.root = root
         for directory in ("components", "contextos", "workspace", "runtimes", "dev"):
             (root / directory).mkdir(parents=True)
-        (root / "contextos/__init__.py").write_text(
-            '__version__ = "0.12.0"\n', encoding="utf-8"
-        )
-        (root / "contextos/workspace_schema.py").write_text(
-            'DEFAULT_TEMPLATE_VERSION = "0.12.0"\n'
-            'DEFAULT_TEMPLATE_SOURCE = "agent-context-os-template"\n',
-            encoding="utf-8",
-        )
+        contextos_paths = []
+        for source in sorted((ROOT / "contextos").glob("*.py")):
+            shutil.copyfile(source, root / "contextos" / source.name)
+            contextos_paths.append((f"contextos/{source.name}", "managed"))
         workspace = {
             "schema_version": 1,
             "mode": "full-template",
@@ -67,8 +66,7 @@ class ReleaseFixture:
         )
         paths = [
             ("components/manifest.json", "managed"),
-            ("contextos/__init__.py", "managed"),
-            ("contextos/workspace_schema.py", "managed"),
+            *contextos_paths,
             ("workspace/example.json", "managed"),
             ("runtimes/codex.json", "managed"),
             ("managed.txt", "managed"),
@@ -149,6 +147,61 @@ class ReleaseArtifactTest(unittest.TestCase):
         self.assertTrue((extracted / "seed.txt").is_file())
         self.assertFalse((extracted / "dev/test.txt").exists())
         self.assertFalse((extracted / "CHANGELOG.md").exists())
+
+    def test_generated_offline_command_works_in_documented_colocated_layout(self) -> None:
+        output = self.root / "offline-verification"
+        provenance = self.fixture.build(output)
+        names = release_artifacts.artifact_names("0.12.0")
+        instructions = (output / names["instructions"]).read_text(encoding="utf-8")
+        self.assertIn("obtain all five release assets in\n   that directory", instructions)
+        self.assertIn("do not select a separate extraction destination", instructions)
+        self.assertIn("beside the five assets", instructions)
+
+        with tarfile.open(output / names["archive"], mode="r:") as archive:
+            for member in archive.getmembers():
+                self.assertTrue(member.isfile())
+                destination = output.joinpath(*PurePosixPath(member.name).parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                payload = archive.extractfile(member)
+                self.assertIsNotNone(payload)
+                assert payload is not None
+                destination.write_bytes(payload.read())
+                if os.name != "nt":
+                    destination.chmod(member.mode)
+
+        extracted = output / "agent-context-os-template-v0.12.0"
+        environment = git_environment()
+        environment.pop("PYTHONPATH", None)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "contextos",
+                "bundle",
+                "check",
+                "--lock",
+                f"../{names['lock']}",
+                "--source",
+                ".",
+                "--source-mode",
+                "directory",
+                "--expect-sha256",
+                provenance["bundle_lock"]["bundle_sha256"],
+            ],
+            cwd=extracted,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        report = json.loads(completed.stdout)
+        self.assertEqual(report["bundle_sha256"], provenance["bundle_lock"]["bundle_sha256"])
+        self.assertEqual(report["files"], provenance["archive"]["file_count"])
+        self.assertEqual(report["source_mode"], "directory")
+        self.assertTrue(report["unlocked_files_ignored"])
+        self.assertFalse(report["writes"])
+        self.assertEqual(report["executable_modes_verified"], os.name != "nt")
 
     def test_tampered_archive_and_unexpected_asset_fail(self) -> None:
         output = self.root / "release"

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from contextos.primitives import git_environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "release_artifacts", ROOT / "scripts/release-artifacts.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+release_artifacts = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_artifacts)
+
+
+class ReleaseFixture:
+    version = "0.12.0"
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        for directory in ("components", "contextos", "workspace", "runtimes", "dev"):
+            (root / directory).mkdir(parents=True)
+        (root / "contextos/__init__.py").write_text(
+            '__version__ = "0.12.0"\n', encoding="utf-8"
+        )
+        (root / "contextos/workspace_schema.py").write_text(
+            'DEFAULT_TEMPLATE_VERSION = "0.12.0"\n'
+            'DEFAULT_TEMPLATE_SOURCE = "agent-context-os-template"\n',
+            encoding="utf-8",
+        )
+        workspace = {
+            "schema_version": 1,
+            "mode": "full-template",
+            "agents": ["codex"],
+            "paths": {
+                "state_dir": "state",
+                "sessions_dir": "sessions",
+                "task_file": "TODO.md",
+            },
+            "template": {
+                "version": self.version,
+                "source": "agent-context-os-template",
+            },
+        }
+        (root / "workspace/example.json").write_text(
+            json.dumps(workspace, indent=2) + "\n", encoding="utf-8"
+        )
+        runtime = json.loads((ROOT / "runtimes/codex.json").read_text(encoding="utf-8"))
+        runtime["components"] = ["core"]
+        (root / "runtimes/codex.json").write_text(
+            json.dumps(runtime, indent=2) + "\n", encoding="utf-8"
+        )
+        (root / "managed.txt").write_bytes(b"managed\x00bytes\n")
+        (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+        (root / "dev/test.txt").write_text("never release\n", encoding="utf-8")
+        (root / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [Unreleased]\n\n## [0.12.0] — 2026-08-29\n",
+            encoding="utf-8",
+        )
+        paths = [
+            ("components/manifest.json", "managed"),
+            ("contextos/__init__.py", "managed"),
+            ("contextos/workspace_schema.py", "managed"),
+            ("workspace/example.json", "managed"),
+            ("runtimes/codex.json", "managed"),
+            ("managed.txt", "managed"),
+            ("seed.txt", "seed"),
+            ("dev/test.txt", "development"),
+            ("CHANGELOG.md", "development"),
+        ]
+        manifest = {
+            "schema_version": 1,
+            "extensible_paths": ["contextos.workspace.json"],
+            "extensible_roots": ["state"],
+            "components": [{
+                "id": "core",
+                "description": "Release artifact fixture.",
+                "depends_on": [],
+                "paths": [{"path": path, "policy": policy} for path, policy in paths],
+            }],
+        }
+        (root / "components/manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+        self.git("init", "--quiet")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "user.name", "Release Fixture")
+        self.git("config", "core.autocrlf", "false")
+        self.git("config", "core.excludesFile", str(root / ".git/info/exclude"))
+        self.git("add", "--all")
+        self.git("commit", "--quiet", "-m", "release fixture")
+        self.commit = self.git("rev-parse", "HEAD").stdout.decode("ascii").strip()
+
+    def git(self, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.run(
+            ["git", *arguments], cwd=self.root, check=True, capture_output=True,
+            env=git_environment(),
+        )
+
+    def build(self, output: Path) -> dict:
+        return release_artifacts.build_artifacts(
+            self.root,
+            output,
+            version=self.version,
+            tag="v0.12.0",
+            commit=self.commit,
+        )
+
+
+class ReleaseArtifactTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.fixture = ReleaseFixture(self.source)
+
+    def test_build_is_reproducible_full_closure_and_directory_verifiable(self) -> None:
+        first = self.root / "first"
+        second = self.root / "second"
+        provenance = self.fixture.build(first)
+        self.fixture.build(second)
+        self.assertEqual(
+            {path.name: path.read_bytes() for path in first.iterdir()},
+            {path.name: path.read_bytes() for path in second.iterdir()},
+        )
+        report = release_artifacts.verify_artifacts(
+            first,
+            self.root / "extracted",
+            version="0.12.0",
+            tag="v0.12.0",
+            commit=self.fixture.commit,
+        )
+        self.assertEqual(report["bundle_sha256"], provenance["bundle_lock"]["bundle_sha256"])
+        self.assertEqual(report["source_mode"], "directory")
+        self.assertTrue(report["unlocked_files_ignored"])
+        self.assertFalse(report["writes"])
+        extracted = self.root / "extracted/agent-context-os-template-v0.12.0"
+        self.assertTrue((extracted / "managed.txt").is_file())
+        self.assertTrue((extracted / "seed.txt").is_file())
+        self.assertFalse((extracted / "dev/test.txt").exists())
+        self.assertFalse((extracted / "CHANGELOG.md").exists())
+
+    def test_tampered_archive_and_unexpected_asset_fail(self) -> None:
+        output = self.root / "release"
+        self.fixture.build(output)
+        archive = output / "agent-context-os-template-v0.12.0.tar"
+        archive.write_bytes(archive.read_bytes() + b"tamper")
+        with self.assertRaisesRegex(release_artifacts.ReleaseArtifactError, "SHA-256 mismatch"):
+            release_artifacts.verify_artifacts(
+                output, self.root / "extract-one", version="0.12.0",
+                tag="v0.12.0", commit=self.fixture.commit,
+            )
+        shutil.rmtree(output)
+        self.fixture.build(output)
+        (output / "unexpected.txt").write_text("extra\n", encoding="utf-8")
+        with self.assertRaisesRegex(release_artifacts.ReleaseArtifactError, "artifact set"):
+            release_artifacts.verify_artifacts(
+                output, self.root / "extract-two", version="0.12.0",
+                tag="v0.12.0", commit=self.fixture.commit,
+            )
+
+    def test_provenance_mismatch_fails_even_with_updated_checksum(self) -> None:
+        output = self.root / "release"
+        self.fixture.build(output)
+        name = "agent-context-os-template-v0.12.0.provenance.json"
+        path = output / name
+        provenance = json.loads(path.read_text(encoding="utf-8"))
+        provenance["release"]["commit"] = "0" * 40
+        path.write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
+        checksums = output / "SHA256SUMS"
+        lines = checksums.read_text(encoding="ascii").splitlines()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        checksums.write_text(
+            "\n".join(digest + "  " + name if line.endswith("  " + name) else line for line in lines) + "\n",
+            encoding="ascii",
+        )
+        with self.assertRaisesRegex(release_artifacts.ReleaseArtifactError, "release identity"):
+            release_artifacts.verify_artifacts(
+                output, self.root / "extract", version="0.12.0",
+                tag="v0.12.0", commit=self.fixture.commit,
+            )
+
+    def test_dirty_source_and_wrong_identity_fail_before_artifacts_exist(self) -> None:
+        (self.source / "managed.txt").write_text("dirty\n", encoding="utf-8")
+        with self.assertRaisesRegex(release_artifacts.ReleaseArtifactError, "clean worktree"):
+            self.fixture.build(self.root / "dirty-output")
+        self.fixture.git("restore", "managed.txt")
+        with self.assertRaisesRegex(release_artifacts.ReleaseArtifactError, "tag must equal"):
+            release_artifacts.build_artifacts(
+                self.source, self.root / "wrong-output", version="0.12.0",
+                tag="v0.12.1", commit=self.fixture.commit,
+            )
+
+    def test_workflow_requires_both_platforms_before_tag_and_publication(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        self.assertIn(
+            "needs: [verify-candidate-linux, verify-candidate-windows]", workflow
+        )
+        self.assertIn(
+            "needs: [verify-draft-linux, verify-draft-windows]", workflow
+        )
+        self.assertLess(workflow.index("stage-draft:"), workflow.index("publish:"))
+        self.assertNotIn("always()", workflow)
+        self.assertEqual(workflow.count("contents: write"), 2)
+        action_references = [
+            line.strip().split("uses: ", 1)[1].split(" #", 1)[0]
+            for line in workflow.splitlines() if "uses: actions/" in line
+        ]
+        self.assertGreater(len(action_references), 0)
+        for reference in action_references:
+            self.assertRegex(reference, r"^actions/[a-z-]+@[0-9a-f]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the gated v0.12.0 release workflow and deterministic full-closure release artifact builder/verifier
- publish release process and v0.12.0 release notes, with the notes included in the managed artifact closure
- qualify Hermes as experimental until installed-client inference completes successfully
- require exact-commit Linux and Windows verification before tag/draft creation, then re-verify staged assets on both platforms before immutable publication

The user-authorized exceptional fourth repair cycle resolves #131 by making the
five-asset extraction layout explicit and executing the documented offline command in
a regression test. No tag or release has been created.

## Verification at `5b63b90c5bdcd31cd9e1880d8a5745b4b581904b`

- canonical validator: 558 tests passed, 43 expected skips
- `actionlint .github/workflows/release.yml`: passed
- release-artifact tests: 6/6 passed on Windows, including the extracted artifact's own CLI with no `PYTHONPATH`
- two fresh WSL/Linux builds: byte-identical
- Linux verification: 162 files, executable modes verified, no writes
- Windows verification of the same Linux-built bytes: passed
- corrected offline guide executed literally against the real Linux candidate: passed
- archive SHA-256: `c1961e83a37111cb2e58aa6d52a34694dfcd33a9f0317852c306ab3ce6797030`
- bundle closure SHA-256: `770eaa0757a6aa4c9559e4b22705b8c514461d2bf415adfbd20e2d9cb5ed9f81`

## Independent exact-SHA reviews

- Claude Opus 5 (`claude-opus-5`, high effort): **PASS**, no blocking findings
- Hermes Inkling (`thinkingmachines/inkling:free`): **PASS**, no blocking findings
- three focused Codex subagent audits: **PASS**, no blocking findings

Three bounded repair cycles resolved findings around tag creation, draft visibility/API
addressing, final byte verification, clean-source preservation, release-note closure,
and resumable immutable attestation. A user-authorized exceptional fourth cycle fixed
the reproduced offline-instruction layout defect in #131 and added executable coverage.

The workflow remains manually dispatched and fail-closed. It creates no tag or draft until both candidate platform jobs pass, and it publishes no release until both staged-asset platform jobs pass.

Closes #119.
Closes #131.
