### PR TITLE
feat(integrations): add Trello MCP catalog entry and render reference (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- `trello-mcp` integration catalog entry for Atlassian's official remote MCP
+  server with workspace-scoped OAuth and non-destructive operations (#46).
+
 ---
 
 ## [0.12.0] — 2026-08-29 — Immutable full-template release

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -23,6 +23,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Read or update a mounted Markdown vault | [Tolaria MCP](../references/integrations.md#tolaria-mcp) | Sensitive vault reads and full-note overwrite |
 | Convert an explicitly selected document or URI to Markdown | [MarkItDown MCP](../references/integrations.md#markitdown-mcp) | Local-file and network reads through an unauthenticated server process |
 | Export reviewed Markdown to DOCX, PDF, EPUB, or HTML | [Pandoc](../references/integrations.md#pandoc) | Sensitive local or network reads, output overwrite, and PDF-engine execution |
+| Read or update Trello boards, cards, and checklists | [Trello MCP](../references/integrations.md#trello-mcp) | Workspace-scoped OAuth, sensitive board reads, and overwrite-capable card updates |
 
 The obsolete checked-in `gws mcp` configuration was removed. The current Google Workspace path uses the reviewed CLI setup in [`references/google-workspace-cli-setup.md`](../references/google-workspace-cli-setup.md); it is still opt-in and is not pre-approved by the command adapters.
 

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -660,6 +660,50 @@
         "instructions": "Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them; review any separately installed PDF engine independently.",
         "removes_user_data": false
       }
+    },
+    {
+      "id": "trello-mcp",
+      "name": "Trello MCP",
+      "summary": "Atlassian's official hosted MCP server for Trello boards, lists, cards, and checklists with workspace-scoped OAuth and non-destructive operations.",
+      "source_url": "https://github.com/atlassian/trello-mcp-server",
+      "kind": "mcp_server",
+      "supported_agents": ["claude_code", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["A Trello or Atlassian account", "An MCP client supporting remote Streamable HTTP and browser OAuth, or a compatible remote-server bridge", "An authorized Trello workspace"]
+      },
+      "data_boundary": {
+        "credentials": ["OAuth 2.0 token managed by the MCP client for the authorized Trello workspace"],
+        "reads": ["Sensitive Trello workspace identity, boards, lists, cards, custom fields, comments, checklists, and search results available to the connected account"],
+        "writes": ["Remote creation and updates of Trello cards, descriptions, checklist items, and comments in the authorized workspace", "Overwrite-capable updates to existing card descriptions, due dates, checklists, or list placements"]
+      },
+      "capabilities": {
+        "read": true,
+        "sensitive_read": true,
+        "write": true,
+        "remote_write": true,
+        "publish": false,
+        "overwrite": true,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": true,
+        "destructive": true,
+        "details": ["Start with read-only board and search queries; card creation, updates, and checklist modifications require separate confirmation", "Atlassian documents that the server exposes no destructive card operations; cards and lists can be moved or archived"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "overwrite", "oauth", "destructive"],
+        "notes": "Confirm the exact Trello workspace and board before reading sensitive board state; show card title, destination list, and proposed content before every remote card or checklist creation or overwrite-capable update."
+      },
+      "risk_tags": ["credentials", "hosted", "project-management", "sensitive-read", "remote-write", "overwrite-capable", "oauth", "destructive-capable", "prompt-injection"],
+      "maturity": "verified",
+      "last_verified": "2026-08-30",
+      "evidence": ["https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/", "https://github.com/atlassian/trello-mcp-server"],
+      "health_check": "Connect to https://mcp.trello.com/v1, verify the authorized workspace and user identity, then fetch one explicitly named board or list without creating or updating cards.",
+      "uninstall": {
+        "instructions": "Remove the Trello MCP entry from the client and revoke the authorized application connection in Trello account settings; preserve all boards, lists, cards, and workspace data.",
+        "removes_user_data": false
+      }
     }
   ]
 }

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -20,6 +20,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
+| [Trello MCP](https://github.com/atlassian/trello-mcp-server) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
 
 ## Agent Skills
 
@@ -390,3 +391,26 @@ Capabilities and limits:
 - Prefer get\_note, diff review, and expectedMtime before update\_note
 - The MCP content-mutation surface is limited to create, append, update, attach, and local clone operations; open, highlight, and refresh also change transient UI state
 - Review embedded agents, direct provider models, stored provider keys, and AutoGit as separate trust boundaries before enabling them
+
+## Trello MCP
+
+Atlassian's official hosted MCP server for Trello boards, lists, cards, and checklists with workspace-scoped OAuth and non-destructive operations.
+
+- **Supported agents:** `claude_code`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** A Trello or Atlassian account; An MCP client supporting remote Streamable HTTP and browser OAuth, or a compatible remote-server bridge; An authorized Trello workspace
+- **Credentials:** OAuth 2.0 token managed by the MCP client for the authorized Trello workspace
+- **Reads:** Sensitive Trello workspace identity, boards, lists, cards, custom fields, comments, checklists, and search results available to the connected account
+- **Writes / external effects:** Remote creation and updates of Trello cards, descriptions, checklist items, and comments in the authorized workspace; Overwrite-capable updates to existing card descriptions, due dates, checklists, or list placements
+- **Typed safety signals:** sensitive read, remote write, overwrite, oauth
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `overwrite`, `oauth`, `destructive`
+- **Confirmation:** Confirm the exact Trello workspace and board before reading sensitive board state; show card title, destination list, and proposed content before every remote card or checklist creation or overwrite-capable update.
+- **Risk tags:** `credentials`, `hosted`, `project-management`, `sensitive-read`, `remote-write`, `overwrite-capable`, `oauth`, `destructive-capable`, `prompt-injection`
+- **Evidence:** [1](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/); [2](https://github.com/atlassian/trello-mcp-server)
+- **Health check:** Connect to https://mcp.trello.com/v1, verify the authorized workspace and user identity, then fetch one explicitly named board or list without creating or updating cards.
+- **Uninstall:** Remove the Trello MCP entry from the client and revoke the authorized application connection in Trello account settings; preserve all boards, lists, cards, and workspace data. (removes user data: No)
+
+Capabilities and limits:
+
+- Start with read-only board and search queries; card creation, updates, and checklist modifications require separate confirmation
+- Atlassian documents that the server exposes no destructive card operations; cards and lists can be moved or archived

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -27,7 +27,7 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
         self.assertEqual(self.catalog["schema_version"], 2)
-        self.assertEqual(len(self.catalog["integrations"]), 15)
+        self.assertEqual(len(self.catalog["integrations"]), 16)
         self.assertTrue(
             {
                 "github-mcp",


### PR DESCRIPTION
﻿## Summary

Adds the official Atlassian Trello remote MCP server to the integration catalog as requested in #46.

### Details

- **Catalog entry (`integrations/catalog.json`)**:
  - `id`: `trello-mcp`
  - `kind`: `mcp_server`
  - `supported_agents`: `["claude_code", "generic"]`
  - `data_boundary`: Workspace-scoped OAuth 2.0 credentials; reads boards, lists, cards, custom fields, comments, checklists, and search; writes cards, descriptions, checklist items, and comments.
  - `capabilities`: Explicit typed boundaries for `read`, `sensitive_read`, `write`, `remote_write`, `overwrite`, `oauth`, and `destructive` (due to overwrite capability per catalog rules), with `delete: false` reflecting Atlassian's non-destructive design.
  - `confirmation`: Required for `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `overwrite`, `oauth`, and `destructive`.
  - `evidence`: First-party documentation links to Atlassian Support and official repository.
  - `last_verified`: `2026-08-30`
- **Rendered Reference (`references/integrations.md`)**: Regenerated via `scripts/integrations.py render`.
- **Changelog (`CHANGELOG.md`)**: Documented under `Added`.
- **Verification**: `python scripts/integrations.py validate` and `check` both pass.

Closes #46.
