### PR TITLE
feat(integrations): add Shortcut MCP catalog entry and render reference (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- `shortcut-mcp` integration catalog entry for Shortcut's hosted MCP server with
+  granular OAuth scopes and dedicated read-only mode (#49).
+
 ---
 
 ## [0.12.0] — 2026-08-29 — Immutable full-template release

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -23,6 +23,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Read or update a mounted Markdown vault | [Tolaria MCP](../references/integrations.md#tolaria-mcp) | Sensitive vault reads and full-note overwrite |
 | Convert an explicitly selected document or URI to Markdown | [MarkItDown MCP](../references/integrations.md#markitdown-mcp) | Local-file and network reads through an unauthenticated server process |
 | Export reviewed Markdown to DOCX, PDF, EPUB, or HTML | [Pandoc](../references/integrations.md#pandoc) | Sensitive local or network reads, output overwrite, and PDF-engine execution |
+| Plan or update Shortcut stories, epics, and iterations | [Shortcut MCP](../references/integrations.md#shortcut-mcp) | Workspace-wide sensitive reads and overwrite-capable story or doc updates |
 
 The obsolete checked-in `gws mcp` configuration was removed. The current Google Workspace path uses the reviewed CLI setup in [`references/google-workspace-cli-setup.md`](../references/google-workspace-cli-setup.md); it is still opt-in and is not pre-approved by the command adapters.
 

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -660,6 +660,50 @@
         "instructions": "Uninstall Pandoc using the platform package manager and keep generated documents unless the user explicitly asks to remove them; review any separately installed PDF engine independently.",
         "removes_user_data": false
       }
+    },
+    {
+      "id": "shortcut-mcp",
+      "name": "Shortcut MCP",
+      "summary": "Shortcut's hosted MCP server for stories, epics, iterations, objectives, and docs with granular OAuth scopes including a dedicated read-only scope.",
+      "source_url": "https://www.shortcut.com/help/integrations/mcp-server/",
+      "kind": "mcp_server",
+      "supported_agents": ["claude_code", "cursor", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["A Shortcut account and workspace", "An MCP client supporting remote Streamable HTTP and browser OAuth", "An authorized Shortcut workspace"]
+      },
+      "data_boundary": {
+        "credentials": ["OAuth 2.0 token managed by the MCP client for the authorized Shortcut workspace"],
+        "reads": ["Sensitive Shortcut stories, epics, iterations, objectives, teams, members, workflows, and docs across the authorized workspace"],
+        "writes": ["Remote creation of stories, epics, iterations, and docs in the authorized workspace", "Overwrite-capable updates to existing story descriptions, assignees, estimates, workflows, or doc contents"]
+      },
+      "capabilities": {
+        "read": true,
+        "sensitive_read": true,
+        "write": true,
+        "remote_write": true,
+        "publish": false,
+        "overwrite": true,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": true,
+        "destructive": true,
+        "details": ["Start with the dedicated read OAuth scope for read-only story and epic search", "The hosted service supports granular write, story-write, and comment-write OAuth scopes for explicit creation and update workflows", "The open-source repository is archived but the hosted https://mcp.shortcut.com/mcp service remains actively documented", "The server exposes no destructive card operations; archiving remains within standard Shortcut workflows"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "overwrite", "oauth", "destructive"],
+        "notes": "Confirm the target Shortcut workspace before reading sensitive project state; show proposed story, epic, or doc changes before executing writes, and prefer the dedicated read OAuth scope for session briefings."
+      },
+      "risk_tags": ["credentials", "hosted", "project-management", "sensitive-read", "remote-write", "overwrite-capable", "oauth", "destructive-capable", "prompt-injection"],
+      "maturity": "verified",
+      "last_verified": "2026-08-30",
+      "evidence": ["https://www.shortcut.com/help/integrations/mcp-server/"],
+      "health_check": "Connect to https://mcp.shortcut.com/mcp using the read scope, verify authorized workspace and user identity, then fetch one explicitly named story or epic without modifying content.",
+      "uninstall": {
+        "instructions": "Remove the Shortcut MCP entry from the client and revoke the authorized application connection in Shortcut account settings; preserve all workspace, story, epic, and doc data.",
+        "removes_user_data": false
+      }
     }
   ]
 }

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -18,6 +18,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Obsidian CLI](https://obsidian.md/help/cli) | `editor_guide` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-15 |
 | [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | Yes | Yes | 2026-08-25 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
+| [Shortcut MCP](https://www.shortcut.com/help/integrations/mcp-server/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
 
@@ -342,6 +343,31 @@ Capabilities and limits:
 - Use the current https://mcp2.readwise.io/mcp endpoint; the older Readwise-only MCP is deprecated
 - The server indexes both Readwise highlights and Reader documents, so connecting it exposes a broader personal knowledge boundary than a single selected document
 - No separate read-only endpoint is documented; treat organizing, bulk editing, updating, and deleting tools as disabled by policy until the user requests a specific change
+
+## Shortcut MCP
+
+Shortcut's hosted MCP server for stories, epics, iterations, objectives, and docs with granular OAuth scopes including a dedicated read-only scope.
+
+- **Supported agents:** `claude_code`, `cursor`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** A Shortcut account and workspace; An MCP client supporting remote Streamable HTTP and browser OAuth; An authorized Shortcut workspace
+- **Credentials:** OAuth 2.0 token managed by the MCP client for the authorized Shortcut workspace
+- **Reads:** Sensitive Shortcut stories, epics, iterations, objectives, teams, members, workflows, and docs across the authorized workspace
+- **Writes / external effects:** Remote creation of stories, epics, iterations, and docs in the authorized workspace; Overwrite-capable updates to existing story descriptions, assignees, estimates, workflows, or doc contents
+- **Typed safety signals:** sensitive read, remote write, overwrite, oauth
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `overwrite`, `oauth`, `destructive`
+- **Confirmation:** Confirm the target Shortcut workspace before reading sensitive project state; show proposed story, epic, or doc changes before executing writes, and prefer the dedicated read OAuth scope for session briefings.
+- **Risk tags:** `credentials`, `hosted`, `project-management`, `sensitive-read`, `remote-write`, `overwrite-capable`, `oauth`, `destructive-capable`, `prompt-injection`
+- **Evidence:** [1](https://www.shortcut.com/help/integrations/mcp-server/)
+- **Health check:** Connect to https://mcp.shortcut.com/mcp using the read scope, verify authorized workspace and user identity, then fetch one explicitly named story or epic without modifying content.
+- **Uninstall:** Remove the Shortcut MCP entry from the client and revoke the authorized application connection in Shortcut account settings; preserve all workspace, story, epic, and doc data. (removes user data: No)
+
+Capabilities and limits:
+
+- Start with the dedicated read OAuth scope for read-only story and epic search
+- The hosted service supports granular write, story-write, and comment-write OAuth scopes for explicit creation and update workflows
+- The open-source repository is archived but the hosted https://mcp.shortcut.com/mcp service remains actively documented
+- The server exposes no destructive card operations; archiving remains within standard Shortcut workflows
 
 ## Substack MCP
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -27,7 +27,7 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
         self.assertEqual(self.catalog["schema_version"], 2)
-        self.assertEqual(len(self.catalog["integrations"]), 15)
+        self.assertEqual(len(self.catalog["integrations"]), 16)
         self.assertTrue(
             {
                 "github-mcp",


### PR DESCRIPTION
﻿## Summary

Adds Shortcut's official hosted MCP server to the integration catalog as requested in #49.

### Details

- **Catalog entry (`integrations/catalog.json`)**:
  - `id`: `shortcut-mcp`
  - `kind`: `mcp_server`
  - `supported_agents`: `["claude_code", "cursor", "generic"]` (mapping Shortcut's documented client support)
  - `data_boundary`: OAuth 2.0 credentials; reads stories, epics, iterations, objectives, teams, members, workflows, and docs; writes creating stories/epics/iterations/docs and updating existing stories/docs.
  - `capabilities`: Explicit typed boundaries for `read`, `sensitive_read`, `write`, `remote_write`, `overwrite`, `oauth`, and `destructive` (due to overwrite capability per catalog rules), with `delete: false`.
  - `confirmation`: Required for all sensitive read, write, overwrite, and credential boundaries.
  - `details`: Notes the availability of a dedicated `read` OAuth scope for read-only workflows, documents the archived open-source repository while confirming active hosted service documentation at `mcp.shortcut.com`, and records that no hard deletion tools are exposed.
  - `evidence`: First-party documentation links to Shortcut Help Center.
  - `last_verified`: `2026-08-30`
- **Rendered Reference (`references/integrations.md`)**: Regenerated via `scripts/integrations.py render`.
- **Changelog (`CHANGELOG.md`)**: Documented under `Added`.
- **Verification**: `python scripts/integrations.py validate` and `check` both pass.

Closes #49.
