### PR TITLE
feat(integrations): add Slack MCP catalog entry and render reference (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Fixed
 - The enabled Claude worktree guard now counts exact Claude executable names and identifies linked worktrees from Git's common-directory structure, with must-fire and must-not-fire controls for primary, linked, guarded, unguarded, and single-session paths.
 
+### Added
+- `shortcut-mcp` integration catalog entry for Shortcut's hosted MCP server with
+  granular OAuth scopes and dedicated read-only mode (#49).
+- `slack-mcp` integration catalog entry for Slack's official first-party MCP server
+  with channel history, canvas, and granular message confirmation boundaries (#52).
+
 ---
 
 ## [0.12.0] — 2026-08-31 — Immutable full-template release

--- a/docs/integrations-guide.md
+++ b/docs/integrations-guide.md
@@ -25,6 +25,7 @@ Nothing in this guide installs, activates, authenticates, or grants permissions 
 | Convert an explicitly selected document or URI to Markdown | [MarkItDown MCP](../references/integrations.md#markitdown-mcp) | Local-file and network reads through an unauthenticated server process |
 | Export reviewed Markdown to DOCX, PDF, EPUB, or HTML | [Pandoc](../references/integrations.md#pandoc) | Sensitive local or network reads, output overwrite, and PDF-engine execution |
 | Plan or update Shortcut stories, epics, and iterations | [Shortcut MCP](../references/integrations.md#shortcut-mcp) | Workspace-wide sensitive reads and overwrite-capable story or doc updates |
+| Search Slack conversations or post messages | [Slack MCP](../references/integrations.md#slack-mcp) | Sensitive conversation reads and publicly visible message sends |
 
 The obsolete checked-in `gws mcp` configuration was removed. The current Google Workspace path uses the reviewed CLI setup in [`references/google-workspace-cli-setup.md`](../references/google-workspace-cli-setup.md); it is still opt-in and is not pre-approved by the command adapters.
 

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -835,7 +835,7 @@
       },
       "risk_tags": ["credentials", "hosted", "team-chat", "sensitive-read", "remote-write", "publish-capable", "public-publish", "overwrite-capable", "oauth", "destructive-capable", "prompt-injection"],
       "maturity": "verified",
-      "last_verified": "2026-09-03",
+      "last_verified": "2026-09-02",
       "evidence": ["https://docs.slack.dev/ai/slack-mcp-server/", "https://docs.slack.dev/ai/slack-mcp-server/connect-to-claude"],
       "health_check": "Connect to the Slack MCP endpoint, verify authorized workspace and user identity, then read history from one explicitly named test channel without posting messages.",
       "uninstall": {

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -798,6 +798,50 @@
         "instructions": "Remove the Shortcut MCP entry from the client and revoke the authorized application connection in Shortcut account settings; preserve all workspace, story, epic, and doc data.",
         "removes_user_data": false
       }
+    },
+    {
+      "id": "slack-mcp",
+      "name": "Slack MCP",
+      "summary": "Slack's official first-party MCP server for searching conversations, channels, canvases, and posting messages with OAuth 2.0 and workspace admin approval.",
+      "source_url": "https://docs.slack.dev/ai/slack-mcp-server/",
+      "kind": "mcp_server",
+      "supported_agents": ["claude_code", "generic"],
+      "installation": {
+        "automatic": false,
+        "scope": "project_or_user",
+        "prerequisites": ["A Slack workspace account", "Workspace admin approval or eligible app install permissions", "An MCP client supporting remote Streamable HTTP and browser OAuth"]
+      },
+      "data_boundary": {
+        "credentials": ["OAuth 2.0 token managed by the MCP client for the authorized Slack workspace"],
+        "reads": ["Sensitive public or private channel conversations, threads, DMs, canvases, files, user profiles, and emails depending on granted scopes"],
+        "writes": ["Remote creation and updates of Slack channel messages, thread replies, reactions, canvases, and conversations", "Publicly visible message sends in shared channels and overwrite-capable updates to canvas content"]
+      },
+      "capabilities": {
+        "read": true,
+        "sensitive_read": true,
+        "write": true,
+        "remote_write": true,
+        "publish": true,
+        "overwrite": true,
+        "delete": false,
+        "arbitrary_execution": false,
+        "oauth": true,
+        "destructive": true,
+        "details": ["Start with read-only search and history tools for explicitly named public channels", "Exclude DMs, user email addresses, files, canvas mutations, and write scopes by default", "Posting messages or updating canvases creates immediate visible team communication and requires separate approval", "The server focuses on messaging, search, and canvas updates; message retraction remains within Slack UI"]
+      },
+      "confirmation": {
+        "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "publish", "overwrite", "oauth", "destructive"],
+        "notes": "Confirm the target Slack workspace, channels, and granted OAuth scopes before reading conversations; show exact message text, target channel, and thread before posting messages, and keep DM and canvas access disabled by default."
+      },
+      "risk_tags": ["credentials", "hosted", "team-chat", "sensitive-read", "remote-write", "publish-capable", "public-publish", "overwrite-capable", "oauth", "destructive-capable", "prompt-injection"],
+      "maturity": "verified",
+      "last_verified": "2026-08-30",
+      "evidence": ["https://docs.slack.dev/ai/slack-mcp-server/", "https://docs.slack.dev/ai/slack-mcp-server/connect-to-claude"],
+      "health_check": "Connect to the Slack MCP endpoint, verify authorized workspace and user identity, then read history from one explicitly named test channel without posting messages.",
+      "uninstall": {
+        "instructions": "Remove the Slack MCP entry from the client and revoke the authorized application connection in Slack workspace settings; preserve all messages and conversation history.",
+        "removes_user_data": false
+      }
     }
   ]
 }

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -802,19 +802,19 @@
     {
       "id": "slack-mcp",
       "name": "Slack MCP",
-      "summary": "Slack's official first-party MCP server for searching conversations, channels, canvases, and posting messages with OAuth 2.0 and workspace admin approval.",
+      "summary": "Slack's official first-party MCP server for searching conversations, channels, canvases, files, and lists, and for posting messages, restricted to Marketplace-published or internal Slack apps using confidential OAuth 2.0 with workspace admin approval.",
       "source_url": "https://docs.slack.dev/ai/slack-mcp-server/",
       "kind": "mcp_server",
-      "supported_agents": ["claude_code", "generic"],
+      "supported_agents": ["claude_code", "cursor", "generic"],
       "installation": {
         "automatic": false,
         "scope": "project_or_user",
-        "prerequisites": ["A Slack workspace account", "Workspace admin approval or eligible app install permissions", "An MCP client supporting remote Streamable HTTP and browser OAuth"]
+        "prerequisites": ["A Slack workspace account", "An MCP client backed by a registered Slack app with a fixed, hardcoded app ID", "An app published in the Slack Marketplace or an internal app; unlisted apps are prohibited from using MCP", "Workspace admin approval through the standard Slack app approval process", "The app's client_id and client_secret for confidential OAuth; Dynamic Client Registration is not supported", "An MCP client supporting JSON-RPC 2.0 over Streamable HTTP at https://mcp.slack.com/mcp; SSE-based connections are not supported"]
       },
       "data_boundary": {
-        "credentials": ["OAuth 2.0 token managed by the MCP client for the authorized Slack workspace"],
-        "reads": ["Sensitive public or private channel conversations, threads, DMs, canvases, files, user profiles, and emails depending on granted scopes"],
-        "writes": ["Remote creation and updates of Slack channel messages, thread replies, reactions, canvases, and conversations", "Publicly visible message sends in shared channels and overwrite-capable updates to canvas content"]
+        "credentials": ["Confidential OAuth 2.0 client credentials, the registered Slack app's client_id and client_secret, kept outside repository files", "Per-user OAuth 2.0 access token managed by the MCP client for the authorized Slack workspace"],
+        "reads": ["Sensitive public or private channel conversations, threads, DMs, canvases, files, user profiles, and emails depending on granted scopes", "Slack list contents and schemas"],
+        "writes": ["Remote creation and updates of Slack channel messages, thread replies, reactions, drafts, canvases, and conversations", "File uploads through the two-step flow of slack_get_file_upload_url then slack_complete_file_upload, optionally sharing the uploaded file to a channel with a message", "Slack Lists writes including creating lists with custom schemas, updating list metadata and columns, and adding or updating individual records", "Publicly visible message sends in shared channels and overwrite-capable updates to canvas, list, and record content"]
       },
       "capabilities": {
         "read": true,
@@ -827,15 +827,15 @@
         "arbitrary_execution": false,
         "oauth": true,
         "destructive": true,
-        "details": ["Start with read-only search and history tools for explicitly named public channels", "Exclude DMs, user email addresses, files, canvas mutations, and write scopes by default", "Posting messages or updating canvases creates immediate visible team communication and requires separate approval", "The server focuses on messaging, search, and canvas updates; message retraction remains within Slack UI"]
+        "details": ["Start with read-only search and history tools for explicitly named public channels", "Exclude DMs, user email addresses, files, canvas mutations, list writes, and write scopes by default", "Posting messages, uploading files, or updating canvases and lists creates immediate visible team communication and requires separate approval", "The server focuses on messaging, search, files, canvases, and lists; the documented tool surface is create-and-update only, and message retraction remains within the Slack UI"]
       },
       "confirmation": {
         "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "publish", "overwrite", "oauth", "destructive"],
-        "notes": "Confirm the target Slack workspace, channels, and granted OAuth scopes before reading conversations; show exact message text, target channel, and thread before posting messages, and keep DM and canvas access disabled by default."
+        "notes": "Confirm the target Slack workspace, channels, and granted OAuth scopes before reading conversations; show exact message text, target channel, and thread before posting messages, show the exact file and destination before completing an upload, and keep DM, canvas, and list writes disabled by default."
       },
       "risk_tags": ["credentials", "hosted", "team-chat", "sensitive-read", "remote-write", "publish-capable", "public-publish", "overwrite-capable", "oauth", "destructive-capable", "prompt-injection"],
       "maturity": "verified",
-      "last_verified": "2026-08-30",
+      "last_verified": "2026-09-03",
       "evidence": ["https://docs.slack.dev/ai/slack-mcp-server/", "https://docs.slack.dev/ai/slack-mcp-server/connect-to-claude"],
       "health_check": "Connect to the Slack MCP endpoint, verify authorized workspace and user identity, then read history from one explicitly named test channel without posting messages.",
       "uninstall": {

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -19,7 +19,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | Yes | Yes | 2026-08-25 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Shortcut MCP](https://www.shortcut.com/help/integrations/mcp-server/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
-| [Slack MCP](https://docs.slack.dev/ai/slack-mcp-server/) | `mcp_server` | verified | Yes | Yes | Yes | Yes | Yes | 2026-09-03 |
+| [Slack MCP](https://docs.slack.dev/ai/slack-mcp-server/) | `mcp_server` | verified | Yes | Yes | Yes | Yes | Yes | 2026-09-02 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
 | [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -19,7 +19,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | Yes | Yes | 2026-08-25 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Shortcut MCP](https://www.shortcut.com/help/integrations/mcp-server/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
-| [Slack MCP](https://docs.slack.dev/ai/slack-mcp-server/) | `mcp_server` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-30 |
+| [Slack MCP](https://docs.slack.dev/ai/slack-mcp-server/) | `mcp_server` | verified | Yes | Yes | Yes | Yes | Yes | 2026-09-03 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
 | [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
@@ -373,17 +373,17 @@ Capabilities and limits:
 
 ## Slack MCP
 
-Slack's official first-party MCP server for searching conversations, channels, canvases, and posting messages with OAuth 2.0 and workspace admin approval.
+Slack's official first-party MCP server for searching conversations, channels, canvases, files, and lists, and for posting messages, restricted to Marketplace-published or internal Slack apps using confidential OAuth 2.0 with workspace admin approval.
 
-- **Supported agents:** `claude_code`, `generic`
+- **Supported agents:** `claude_code`, `cursor`, `generic`
 - **Install scope:** `project_or_user`; never automatic
-- **Prerequisites:** A Slack workspace account; Workspace admin approval or eligible app install permissions; An MCP client supporting remote Streamable HTTP and browser OAuth
-- **Credentials:** OAuth 2.0 token managed by the MCP client for the authorized Slack workspace
-- **Reads:** Sensitive public or private channel conversations, threads, DMs, canvases, files, user profiles, and emails depending on granted scopes
-- **Writes / external effects:** Remote creation and updates of Slack channel messages, thread replies, reactions, canvases, and conversations; Publicly visible message sends in shared channels and overwrite-capable updates to canvas content
+- **Prerequisites:** A Slack workspace account; An MCP client backed by a registered Slack app with a fixed, hardcoded app ID; An app published in the Slack Marketplace or an internal app; unlisted apps are prohibited from using MCP; Workspace admin approval through the standard Slack app approval process; The app's client\_id and client\_secret for confidential OAuth; Dynamic Client Registration is not supported; An MCP client supporting JSON-RPC 2.0 over Streamable HTTP at https://mcp.slack.com/mcp; SSE-based connections are not supported
+- **Credentials:** Confidential OAuth 2.0 client credentials, the registered Slack app's client\_id and client\_secret, kept outside repository files; Per-user OAuth 2.0 access token managed by the MCP client for the authorized Slack workspace
+- **Reads:** Sensitive public or private channel conversations, threads, DMs, canvases, files, user profiles, and emails depending on granted scopes; Slack list contents and schemas
+- **Writes / external effects:** Remote creation and updates of Slack channel messages, thread replies, reactions, drafts, canvases, and conversations; File uploads through the two-step flow of slack\_get\_file\_upload\_url then slack\_complete\_file\_upload, optionally sharing the uploaded file to a channel with a message; Slack Lists writes including creating lists with custom schemas, updating list metadata and columns, and adding or updating individual records; Publicly visible message sends in shared channels and overwrite-capable updates to canvas, list, and record content
 - **Typed safety signals:** sensitive read, remote write, overwrite, oauth
 - **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `publish`, `overwrite`, `oauth`, `destructive`
-- **Confirmation:** Confirm the target Slack workspace, channels, and granted OAuth scopes before reading conversations; show exact message text, target channel, and thread before posting messages, and keep DM and canvas access disabled by default.
+- **Confirmation:** Confirm the target Slack workspace, channels, and granted OAuth scopes before reading conversations; show exact message text, target channel, and thread before posting messages, show the exact file and destination before completing an upload, and keep DM, canvas, and list writes disabled by default.
 - **Risk tags:** `credentials`, `hosted`, `team-chat`, `sensitive-read`, `remote-write`, `publish-capable`, `public-publish`, `overwrite-capable`, `oauth`, `destructive-capable`, `prompt-injection`
 - **Evidence:** [1](https://docs.slack.dev/ai/slack-mcp-server/); [2](https://docs.slack.dev/ai/slack-mcp-server/connect-to-claude)
 - **Health check:** Connect to the Slack MCP endpoint, verify authorized workspace and user identity, then read history from one explicitly named test channel without posting messages.
@@ -392,9 +392,9 @@ Slack's official first-party MCP server for searching conversations, channels, c
 Capabilities and limits:
 
 - Start with read-only search and history tools for explicitly named public channels
-- Exclude DMs, user email addresses, files, canvas mutations, and write scopes by default
-- Posting messages or updating canvases creates immediate visible team communication and requires separate approval
-- The server focuses on messaging, search, and canvas updates; message retraction remains within Slack UI
+- Exclude DMs, user email addresses, files, canvas mutations, list writes, and write scopes by default
+- Posting messages, uploading files, or updating canvases and lists creates immediate visible team communication and requires separate approval
+- The server focuses on messaging, search, files, canvases, and lists; the documented tool surface is create-and-update only, and message retraction remains within the Slack UI
 
 ## Substack MCP
 

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -19,6 +19,7 @@ These add-ons are **references, not bundled dependencies**. Setup does not insta
 | [Pandoc](https://github.com/jgm/pandoc) | `connector` | verified | Yes | No | No | Yes | Yes | 2026-08-25 |
 | [Readwise MCP](https://docs.readwise.io/tools/mcp) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-18 |
 | [Shortcut MCP](https://www.shortcut.com/help/integrations/mcp-server/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
+| [Slack MCP](https://docs.slack.dev/ai/slack-mcp-server/) | `mcp_server` | verified | Yes | Yes | Yes | Yes | Yes | 2026-08-30 |
 | [Substack MCP](https://github.com/conorbronsdon/substack-mcp) | `mcp_server` | verified | Yes | Yes | Yes | Yes | No | 2026-08-15 |
 | [Tolaria MCP](https://github.com/refactoringhq/tolaria) | `local_workspace` | verified | Yes | No | No | Yes | Yes | 2026-08-15 |
 | [Trello MCP](https://support.atlassian.com/trello/docs/connect-trello-to-ai-assistants-with-trello-mcp/) | `mcp_server` | verified | Yes | Yes | No | Yes | Yes | 2026-08-30 |
@@ -369,6 +370,31 @@ Capabilities and limits:
 - The hosted service supports granular write, story-write, and comment-write OAuth scopes for explicit creation and update workflows
 - The open-source repository is archived but the hosted https://mcp.shortcut.com/mcp service remains actively documented
 - The documented surface is overwrite-capable but includes no permanently destructive operations; archiving remains within standard Shortcut workflows
+
+## Slack MCP
+
+Slack's official first-party MCP server for searching conversations, channels, canvases, and posting messages with OAuth 2.0 and workspace admin approval.
+
+- **Supported agents:** `claude_code`, `generic`
+- **Install scope:** `project_or_user`; never automatic
+- **Prerequisites:** A Slack workspace account; Workspace admin approval or eligible app install permissions; An MCP client supporting remote Streamable HTTP and browser OAuth
+- **Credentials:** OAuth 2.0 token managed by the MCP client for the authorized Slack workspace
+- **Reads:** Sensitive public or private channel conversations, threads, DMs, canvases, files, user profiles, and emails depending on granted scopes
+- **Writes / external effects:** Remote creation and updates of Slack channel messages, thread replies, reactions, canvases, and conversations; Publicly visible message sends in shared channels and overwrite-capable updates to canvas content
+- **Typed safety signals:** sensitive read, remote write, overwrite, oauth
+- **Required confirmation gates:** `credential_setup`, `external_install`, `read_sensitive`, `write`, `write_remote`, `publish`, `overwrite`, `oauth`, `destructive`
+- **Confirmation:** Confirm the target Slack workspace, channels, and granted OAuth scopes before reading conversations; show exact message text, target channel, and thread before posting messages, and keep DM and canvas access disabled by default.
+- **Risk tags:** `credentials`, `hosted`, `team-chat`, `sensitive-read`, `remote-write`, `publish-capable`, `public-publish`, `overwrite-capable`, `oauth`, `destructive-capable`, `prompt-injection`
+- **Evidence:** [1](https://docs.slack.dev/ai/slack-mcp-server/); [2](https://docs.slack.dev/ai/slack-mcp-server/connect-to-claude)
+- **Health check:** Connect to the Slack MCP endpoint, verify authorized workspace and user identity, then read history from one explicitly named test channel without posting messages.
+- **Uninstall:** Remove the Slack MCP entry from the client and revoke the authorized application connection in Slack workspace settings; preserve all messages and conversation history. (removes user data: No)
+
+Capabilities and limits:
+
+- Start with read-only search and history tools for explicitly named public channels
+- Exclude DMs, user email addresses, files, canvas mutations, and write scopes by default
+- Posting messages or updating canvases creates immediate visible team communication and requires separate approval
+- The server focuses on messaging, search, and canvas updates; message retraction remains within Slack UI
 
 ## Substack MCP
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -27,7 +27,7 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_catalog_has_expected_entries_and_visible_safety_columns(self) -> None:
         rendered = MODULE.render_reference(self.catalog)
         self.assertEqual(self.catalog["schema_version"], 2)
-        self.assertEqual(len(self.catalog["integrations"]), 17)
+        self.assertEqual(len(self.catalog["integrations"]), 18)
         self.assertTrue(
             {
                 "github-mcp",


### PR DESCRIPTION
﻿## Summary

Adds Slack's official first-party hosted MCP server to the integration catalog as requested in #52.

### Details

- **Catalog entry (`integrations/catalog.json`)**:
  - `id`: `slack-mcp`
  - `kind`: `mcp_server`
  - `supported_agents`: `["claude_code", "generic"]` (aligned with official Slack Claude connector documentation)
  - `installation`: Documents workspace admin approval / eligible app installation requirements as an explicit prerequisite.
  - `data_boundary`: OAuth 2.0 credentials; reads channel history, threads, DMs, canvases, files, and user profiles; writes messages, thread replies, reactions, and canvas updates.
  - `capabilities`: Explicit typed boundaries for `read`, `sensitive_read`, `write`, `remote_write`, `publish`, `overwrite`, `oauth`, and `destructive` (due to overwrite capability per catalog rules), with `delete: false`.
  - `confirmation`: Required for all sensitive read, write, publication, overwrite, OAuth, and destructive boundaries.
  - `details`: Recommends starting with read-only search and history on explicitly named public channels, explicitly excluding DMs, user email addresses, files, and canvas mutations by default, with strict pre-send confirmation for message posts.
  - `evidence`: First-party documentation links to Slack Developer docs.
  - `last_verified`: `2026-08-30`
- **Rendered Reference (`references/integrations.md`)**: Regenerated via `scripts/integrations.py render`.
- **Changelog (`CHANGELOG.md`)**: Documented under `Added`.
- **Verification**: `python scripts/integrations.py validate` and `check` both pass.

Closes #52.
