### PR TITLE
fix: stage verified release before local publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release v0.12.0
+name: Qualify and stage v0.12.0
 
 on:
   workflow_dispatch:
@@ -35,18 +35,14 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Require the exact reviewed commit on main and immutable releases
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Require the exact reviewed commit on main
         run: |
           [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          test "$GITHUB_REF" = refs/heads/main
+          test "$GITHUB_SHA" = "$RELEASE_COMMIT"
           test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
           test "$(git rev-parse origin/main)" = "$RELEASE_COMMIT"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
-          gh api \
-            -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/immutable-releases" \
-            --jq '.enabled' | grep -Fx true
 
       - name: Run the canonical validator on the release source
         run: |
@@ -81,12 +77,11 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: v0.12.0-candidate-${{ inputs.commit }}
+          name: v0.12.0-candidate-${{ inputs.commit }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/release-one/*
           compression-level: 0
           if-no-files-found: error
-          overwrite: true
-          retention-days: 1
+          retention-days: 7
 
   verify-candidate-linux:
     needs: build-linux
@@ -103,7 +98,7 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: v0.12.0-candidate-${{ inputs.commit }}
+          name: v0.12.0-candidate-${{ inputs.commit }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/assets
 
       - name: Verify the candidate and execute its extracted verifier
@@ -140,7 +135,7 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: v0.12.0-candidate-${{ inputs.commit }}
+          name: v0.12.0-candidate-${{ inputs.commit }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/assets
 
       - name: Verify the candidate and execute its extracted verifier
@@ -187,7 +182,7 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: v0.12.0-candidate-${{ inputs.commit }}
+          name: v0.12.0-candidate-${{ inputs.commit }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/assets
 
       - name: Recheck and verify the candidate before staging
@@ -217,8 +212,8 @@ jobs:
           fi
           test "$(git ls-remote origin "refs/tags/$TAG" | cut -f1)" = "$RELEASE_COMMIT"
 
-          if gh release view "$TAG" --json isDraft,isImmutable,isPrerelease > "$RUNNER_TEMP/existing-release.json" 2>/dev/null; then
-            python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/existing-release.json").read_text()); assert value["isPrerelease"] is False and (value["isDraft"] is True or value["isImmutable"] is True)'
+          if gh release view "$TAG" --json isDraft,isPrerelease > "$RUNNER_TEMP/existing-release.json" 2>/dev/null; then
+            python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/existing-release.json").read_text()); assert value == {"isDraft": True, "isPrerelease": False}'
             gh release download "$TAG" --dir "$RUNNER_TEMP/existing-assets"
             python scripts/release-artifacts.py verify \
               --artifacts "$RUNNER_TEMP/existing-assets" \
@@ -322,10 +317,11 @@ jobs:
           $value = Get-Content -Raw "$env:RUNNER_TEMP/draft-windows.json" | ConvertFrom-Json
           if ($value.executable_modes_verified -ne $false -or $value.writes -ne $false) { throw "Staged Windows asset verification mismatch" }
 
-  publish:
+  ready-to-publish:
     needs: [stage-draft, verify-draft-linux, verify-draft-windows]
     runs-on: ubuntu-latest
     permissions:
+      # GitHub exposes draft releases only to tokens with push access.
       contents: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -337,64 +333,39 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Re-download and verify the exact release immediately before publication
-        id: final
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: v0.12.0-candidate-${{ inputs.commit }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/candidate-assets
+
+      - name: Re-download and bind the verified draft to the exact-run candidate
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
         run: |
           test "$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git refs/heads/main | cut -f1)" = "$RELEASE_COMMIT"
           test "$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git refs/tags/$TAG | cut -f1)" = "$RELEASE_COMMIT"
-          gh api \
-            -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/immutable-releases" \
-            --jq '.enabled' | grep -Fx true
-          gh release verify --help >/dev/null
           test "$(gh release view "$TAG" --json databaseId --jq .databaseId)" = "$RELEASE_ID"
-          gh release download "$TAG" --dir "$RUNNER_TEMP/final-assets"
+          gh release download "$TAG" --dir "$RUNNER_TEMP/draft-assets"
           python scripts/release-artifacts.py verify \
-            --artifacts "$RUNNER_TEMP/final-assets" \
-            --extract-to "$RUNNER_TEMP/final-extracted" \
+            --artifacts "$RUNNER_TEMP/draft-assets" \
+            --extract-to "$RUNNER_TEMP/draft-final-extracted" \
             --version "$VERSION" \
             --tag "$TAG" \
             --commit "$RELEASE_COMMIT" \
-            > "$RUNNER_TEMP/final-verification.json"
+            > "$RUNNER_TEMP/draft-final-verification.json"
+          diff --recursive --brief "$RUNNER_TEMP/candidate-assets" "$RUNNER_TEMP/draft-assets"
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
             "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            --jq '{draft, prerelease, assets: [.assets[] | {name, size, digest}]}' \
-            > "$RUNNER_TEMP/release-state.json"
-          python -c 'import hashlib, json, os, pathlib; root=pathlib.Path(os.environ["RUNNER_TEMP"] + "/final-assets"); value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text()); remote={item["name"]: item for item in value["assets"]}; local={path.name: path for path in root.iterdir() if path.is_file()}; assert type(value["draft"]) is bool and value["prerelease"] is False and set(remote) == set(local); assert all(item["size"] == local[name].stat().st_size and item["digest"] == "sha256:" + hashlib.sha256(local[name].read_bytes()).hexdigest() for name, item in remote.items())'
-          DRAFT=$(python -c 'import json, os, pathlib; print(str(json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/release-state.json").read_text())["draft"]).lower())')
-          if [[ "$DRAFT" == "false" ]]; then
-            test "$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --jq .immutable)" = true
-            echo "already_published=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "already_published=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish the verified draft
-        if: steps.final.outputs.already_published != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
-        run: |
-          gh api --method PATCH -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            -F draft=false \
-            -f make_latest=true >/dev/null
-
-      - name: Require immutability and verify the release attestation
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_ID: ${{ needs.stage-draft.outputs.release_id }}
-        run: |
-          for attempt in 1 2 3 4 5 6; do
-            IMMUTABLE=$(gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --jq .immutable 2>/dev/null || true)
-            if [[ "$IMMUTABLE" == "true" ]] && gh release verify "$TAG"; then
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "published release did not expose a valid immutable attestation" >&2
-          exit 1
+            --jq '{id, tag_name, name, body, draft, prerelease, assets: [.assets[] | {id, name, size, digest}]}' \
+            > "$RUNNER_TEMP/draft-state.json"
+          python -c 'import hashlib, json, os, pathlib; temp=pathlib.Path(os.environ["RUNNER_TEMP"]); root=temp / "draft-assets"; value=json.loads((temp / "draft-state.json").read_text()); expected_body=(pathlib.Path("docs/releases/v0.12.0.md").read_text()).replace("\r\n", "\n").rstrip("\n"); remote={item["name"]: item for item in value["assets"]}; local={path.name: path for path in root.iterdir() if path.is_file()}; assert value["id"] == int(os.environ["RELEASE_ID"]) and value["tag_name"] == os.environ["TAG"] and value["name"] == "Context OS v0.12.0" and (value["body"] or "").replace("\r\n", "\n").rstrip("\n") == expected_body and value["draft"] is True and value["prerelease"] is False and set(remote) == set(local); assert all(type(item["id"]) is int and item["id"] > 0 and item["size"] == local[name].stat().st_size and item["digest"] == "sha256:" + hashlib.sha256(local[name].read_bytes()).hexdigest() for name, item in remote.items())'
+          {
+            echo "## Verified draft ready for local admin publication"
+            echo "- Commit: \`$RELEASE_COMMIT\`"
+            echo "- Tag: \`$TAG\`"
+            echo "- Numeric release ID: \`$RELEASE_ID\`"
+            echo "- Workflow run: \`$GITHUB_RUN_ID\` attempt \`$GITHUB_RUN_ATTEMPT\`"
+            echo "- Candidate and draft bytes: identical"
+            echo "- Draft assets: independently verified on Linux and Windows"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -340,6 +340,10 @@
                     "policy": "development"
                 },
                 {
+                    "path": "scripts/publish-release.py",
+                    "policy": "development"
+                },
+                {
                     "path": "scripts/release-artifacts.py",
                     "policy": "development"
                 },
@@ -425,6 +429,10 @@
                 },
                 {
                     "path": "tests/test_materializer.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_publish_release.py",
                     "policy": "development"
                 },
                 {

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -30,7 +30,7 @@ instructions digest, generator version, source mode, and fixed epoch. It is
 deterministic and deliberately excludes runner names, workflow IDs, temporary
 paths, and wall-clock generation times.
 
-## Qualification and publication
+## Automated qualification and draft staging
 
 Only dispatch `.github/workflows/release.yml` from `main`, with the exact
 reviewed 40-hex commit. Before dispatch:
@@ -38,16 +38,23 @@ reviewed 40-hex commit. Before dispatch:
 1. merge the release-preparation PR after canonical validation, hosted Linux and
    Windows validation, and exact-SHA Claude plus free-Hermes reviews;
 2. confirm the version constants, example workspace, and dated changelog agree;
-3. enable GitHub immutable releases for the repository; and
+3. from a locally authenticated GitHub CLI session whose token can read
+   repository administration settings, require
+   `GET /repos/conorbronsdon/agent-context-os/immutable-releases` to report
+   `enabled: true`; and
 4. confirm the release tag and release do not already exist.
 
-The workflow uses the checked-in [v0.12.0 release notes](releases/v0.12.0.md) as
-the immutable published description.
+The administration-read policy endpoint is intentionally not called with an
+Actions `GITHUB_TOKEN`: GitHub does not grant that token repository
+administration permission. Do not put a personal admin token in workflow inputs,
+logs, repository secrets, or artifacts. The workflow uses the checked-in
+[v0.12.0 release notes](releases/v0.12.0.md) as the draft description.
 
 The workflow then fails closed through these gates:
 
-1. require the input commit to equal both checked-out `HEAD` and `origin/main`,
-   require a completely clean source, and require immutable releases enabled;
+1. require the dispatch ref, workflow SHA, input commit, checked-out `HEAD`, and
+   `origin/main` to identify the same commit, and require a completely clean
+   source;
 2. run the canonical validator on that exact source;
 3. build twice from its Linux Git index and compare every artifact byte;
 4. verify the same Actions candidate in separate Linux and Windows extraction
@@ -58,14 +65,62 @@ The workflow then fails closed through these gates:
    and carry that draft's immutable numeric release ID through every later job;
 6. download those staged release assets—not the Actions copies—and verify them
    again in separate Linux and Windows directories; and
-7. only after both staged-asset jobs pass, recheck `main`, tag, draft state,
-   exact asset names and server-reported digests, and immutability policy,
-   publish that exact numeric release ID, and require GitHub's immutable release
-   attestation to verify.
+7. only after both staged-asset jobs pass, re-download the exact-run Actions
+   candidate and draft assets, require them to be byte-identical, and recheck
+   `main`, tag, numeric release ID, draft and non-prerelease state, checked-in
+   title/body, exact asset names, IDs, sizes, and server-reported digests.
+
+The workflow stops successfully with the release still an unpublished draft. A
+green workflow is qualification evidence for that exact draft; it is not
+publication and does not complete the release by itself.
 
 Linux must report executable-mode verification as `true`. Windows must report
 it as `false`, because directory sources there do not expose portable POSIX
 executable bits. That is an explicit limitation, not a skipped success.
+
+## Local admin publication
+
+Publish only from a clean checkout of the exact commit named by the successful
+workflow. Use the checked-in publisher with the exact workflow run ID:
+
+```bash
+python scripts/publish-release.py \
+  --repository conorbronsdon/agent-context-os \
+  --run-id RUN_ID \
+  --commit REVIEWED_40_HEX_COMMIT \
+  --version 0.12.0 \
+  --tag v0.12.0
+```
+
+The publisher uses the existing locally authenticated `gh` session. Before the
+irreversible numeric-release-ID PATCH, it requires all of the following:
+
+- the exact workflow run and attempt are complete and successful on `main` for
+  the reviewed commit, including every candidate, draft, and terminal readiness
+  job;
+- the exact attempt-qualified Actions candidate is selected, downloaded by its
+  numeric artifact ID, checked against its server-reported ZIP size and digest,
+  and re-read by ID before publication;
+- local `HEAD` and the target repository's GitHub API `main` and
+  `refs/tags/v0.12.0` equal the reviewed commit (the local `origin` is not an
+  independent authority);
+- the numeric release is still a draft, is not a prerelease, and has the exact
+  tag, title, checked-in body, and five asset IDs/names/sizes/digests;
+- independently verified candidate and draft downloads are byte-identical, with
+  the release state unchanged across repeated numeric-ID reads;
+- no other release workflow has any nonterminal status; and
+- the admin-only immutable-release policy endpoint reports `enabled: true`
+  immediately before publication.
+
+The GitHub API has no atomic compare-and-publish operation, so a small residual
+time-of-check/time-of-use window remains. Coordinate one release operator and do
+not mutate the tag or draft while publication runs. The publisher minimizes the
+window, PATCHes only the verified numeric release ID, then repeats the tag,
+metadata, asset, and byte checks. It requires `.immutable: true`, verifies the
+release attestation, and verifies the attestation for each of the five freshly
+downloaded published assets. Its JSON result records operator, timestamp, run
+and attempt, Actions artifact ID, release ID, commit, policy result, immutable
+state, asset metadata, and attestation results.
 
 ## Failure policy
 
@@ -75,12 +130,31 @@ executable bits. That is an explicit limitation, not a skipped success.
   remains a draft for inspection. A rerun may resume only when both the tag and
   every downloaded draft asset are byte-identical to the same candidate; do not
   overwrite assets or delete forensic evidence automatically.
+- If the candidate Actions artifact expires before local publication, rerun the
+  complete qualification workflow against the same commit. Never publish a
+  draft that can no longer be byte-compared to its exact-run candidate.
 - If deterministic source or artifact verification fails after the tag exists,
   retire that version and fix the problem in a patch release.
 - After publication, tags and assets are immutable. Correct errors with a notice
-  and a new patch release, never by replacing bytes. If only the final
-  attestation poll times out, a rerun verifies the already-published immutable
-  release by its numeric ID without attempting to publish it again.
+  and a new patch release, never by replacing bytes. If publication succeeds but
+  the final immutable or attestation poll times out, do not PATCH or publish
+  again; retry only the read-only numeric-ID, byte, immutable, and attestation
+  checks with the same exact bindings:
+
+```bash
+python scripts/publish-release.py \
+  --repository conorbronsdon/agent-context-os \
+  --run-id RUN_ID \
+  --commit REVIEWED_40_HEX_COMMIT \
+  --version 0.12.0 \
+  --tag v0.12.0 \
+  --verify-published
+```
+
+This mode requires the numeric release to be published and immutable, repeats
+the run, attempt, artifact, repository-ref, metadata, byte, and attestation
+checks, and never issues a publication PATCH. Any post-publication integrity
+mismatch retires v0.12.0 rather than authorizing mutation.
 
 Consumers should follow the version-specific offline instructions and obtain
 the expected digest through a channel they trust. Co-located checksums prove

--- a/docs/releases/v0.12.0.md
+++ b/docs/releases/v0.12.0.md
@@ -11,7 +11,7 @@ Hermes is experimental in this release. Its deterministic adapter and kernel
 conformance passes, but the retained installed Hermes 0.20.5 live run did not
 complete model inference and is not counted as installed-client conformance.
 
-Download all five attached assets. Start with
+From the published immutable release, download all five attached assets. Start with
 `agent-context-os-template-v0.12.0.OFFLINE-VERIFY.md`; the canonical artifact is
 `agent-context-os-template-v0.12.0.tar`, not GitHub's automatically generated
 source archives.

--- a/scripts/publish-release.py
+++ b/scripts/publish-release.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""Publish one fully qualified draft with a local admin-authenticated GitHub CLI."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_JOBS = (
+    "build-linux",
+    "verify-candidate-linux",
+    "verify-candidate-windows",
+    "stage-draft",
+    "verify-draft-linux",
+    "verify-draft-windows",
+    "ready-to-publish",
+)
+
+
+class PublishError(RuntimeError):
+    """Raised before or after publication when a release invariant fails."""
+
+
+class CommandRunner:
+    """Small subprocess boundary so the irreversible sequence can be tested."""
+
+    def run(
+        self, arguments: Sequence[str], *, cwd: Path | None = None, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                list(arguments), cwd=cwd, check=check, capture_output=True,
+                text=True, encoding="utf-8",
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            stderr = getattr(exc, "stderr", "") or ""
+            detail = stderr.strip()
+            raise PublishError(
+                "command failed: " + " ".join(arguments) + (f": {detail}" if detail else "")
+            ) from exc
+
+    def json(self, arguments: Sequence[str], *, cwd: Path | None = None) -> Any:
+        completed = self.run(arguments, cwd=cwd)
+        try:
+            return json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise PublishError("command did not return valid JSON: " + " ".join(arguments)) from exc
+
+    def download_artifact(
+        self, repository: str, artifact: dict[str, Any], destination: Path,
+        expected_names: set[str],
+    ) -> None:
+        """Download one exact Actions artifact ID and safely extract its zip."""
+        artifact_id = artifact["id"]
+        archive = destination.parent / f"artifact-{artifact_id}.zip"
+        arguments = [
+            "gh", "api", "-H", "X-GitHub-Api-Version: 2026-03-10",
+            f"repos/{repository}/actions/artifacts/{artifact_id}/zip",
+        ]
+        try:
+            with archive.open("wb") as output:
+                completed = subprocess.run(
+                    arguments, check=False, stdout=output, stderr=subprocess.PIPE,
+                    cwd=ROOT, text=False,
+                )
+        except OSError as exc:
+            raise PublishError("artifact download failed") from exc
+        if completed.returncode != 0:
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            raise PublishError(f"artifact download failed: {detail}")
+        _require(archive.stat().st_size == artifact["size_in_bytes"],
+                 "Actions artifact zip size changed during download")
+        _require("sha256:" + _sha256_file(archive) == artifact["digest"],
+                 "Actions artifact zip digest changed during download")
+        try:
+            with zipfile.ZipFile(archive) as bundle:
+                seen: set[str] = set()
+                for member in bundle.infolist():
+                    parts = Path(member.filename).parts
+                    _require(
+                        not member.is_dir() and not Path(member.filename).is_absolute()
+                        and ".." not in parts and len(parts) == 1,
+                        "Actions artifact zip contains an unsafe path",
+                    )
+                    _require(member.filename not in seen, "Actions artifact zip has duplicate names")
+                    seen.add(member.filename)
+                    mode = member.external_attr >> 16
+                    _require((mode & 0o170000) != 0o120000,
+                             "Actions artifact zip contains a symbolic link")
+                _require(seen == expected_names,
+                         "Actions artifact zip names do not match the five-file contract")
+                bundle.extractall(destination)
+        except (OSError, zipfile.BadZipFile) as exc:
+            raise PublishError("Actions artifact is not a valid zip") from exc
+
+
+def _load_release_artifacts() -> Any:
+    path = ROOT / "scripts/release-artifacts.py"
+    spec = importlib.util.spec_from_file_location("release_artifacts", path)
+    if spec is None or spec.loader is None:
+        raise PublishError("cannot load scripts/release-artifacts.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalized_body(value: str) -> str:
+    return value.replace("\r\n", "\n").rstrip("\n")
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PublishError(message)
+
+
+def _git_text(runner: CommandRunner, root: Path, *arguments: str) -> str:
+    return runner.run(["git", *arguments], cwd=root).stdout.strip()
+
+
+def _github_ref(runner: CommandRunner, repository: str, ref: str) -> str:
+    value = runner.json([
+        "gh", "api", "-H", "X-GitHub-Api-Version: 2026-03-10",
+        f"repos/{repository}/git/ref/{ref}",
+    ])
+    _require(isinstance(value, dict) and isinstance(value.get("object"), dict),
+             f"target repository ref is absent or malformed: {ref}")
+    target = value["object"]
+    _require(target.get("type") == "commit" and COMMIT_RE.fullmatch(target.get("sha") or ""),
+             f"target repository ref is not a commit: {ref}")
+    return target["sha"]
+
+
+def _validate_run(value: Any, *, commit: str) -> int:
+    _require(isinstance(value, dict), "workflow run response must be an object")
+    expected = {
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": commit,
+        "path": ".github/workflows/release.yml",
+        "status": "completed",
+        "conclusion": "success",
+    }
+    for key, wanted in expected.items():
+        _require(value.get(key) == wanted, f"workflow run {key} does not match: {value.get(key)!r}")
+    attempt = value.get("run_attempt")
+    _require(type(attempt) is int and attempt > 0, "workflow run attempt must be a positive integer")
+    return attempt
+
+
+def _validate_jobs(value: Any, *, attempt: int) -> None:
+    _require(isinstance(value, dict) and isinstance(value.get("jobs"), list), "jobs response is invalid")
+    current = [job for job in value["jobs"] if job.get("run_attempt", attempt) == attempt]
+    by_name = {job.get("name"): job for job in current}
+    for name in REQUIRED_JOBS:
+        job = by_name.get(name)
+        _require(job is not None, f"required workflow job is absent: {name}")
+        _require(job.get("status") == "completed" and job.get("conclusion") == "success",
+                 f"required workflow job did not succeed: {name}")
+
+
+def _candidate_artifact(value: Any, *, expected_name: str) -> dict[str, Any]:
+    _require(isinstance(value, dict) and isinstance(value.get("artifacts"), list),
+             "workflow artifacts response is invalid")
+    matches = [
+        artifact for artifact in value["artifacts"]
+        if artifact.get("name") == expected_name and artifact.get("expired") is False
+    ]
+    _require(len(matches) == 1, "exactly one unexpired candidate Actions artifact is required")
+    artifact_id = matches[0].get("id")
+    _require(type(artifact_id) is int and artifact_id > 0, "candidate artifact ID is invalid")
+    return matches[0]
+
+
+def _validate_artifact_record(
+    artifact: Any, *, expected_id: int | None, expected_name: str,
+    run_id: int, commit: str,
+) -> dict[str, Any]:
+    _require(isinstance(artifact, dict), "candidate artifact response must be an object")
+    if expected_id is not None:
+        _require(artifact.get("id") == expected_id, "candidate artifact ID changed")
+    _require(artifact.get("name") == expected_name, "candidate artifact name changed")
+    _require(artifact.get("expired") is False, "candidate artifact expired")
+    size = artifact.get("size_in_bytes")
+    digest = artifact.get("digest")
+    _require(type(size) is int and size > 0, "candidate artifact zip size is invalid")
+    _require(isinstance(digest, str) and digest.startswith("sha256:")
+             and SHA256_RE.fullmatch(digest.removeprefix("sha256:")) is not None,
+             "candidate artifact zip digest is invalid")
+    workflow_run = artifact.get("workflow_run")
+    _require(isinstance(workflow_run, dict), "candidate artifact workflow identity is absent")
+    _require(workflow_run.get("id") == run_id, "candidate artifact belongs to another run")
+    _require(workflow_run.get("head_sha") == commit, "candidate artifact commit does not match")
+    _require(workflow_run.get("head_branch") == "main", "candidate artifact branch does not match")
+    return artifact
+
+
+def _asset_snapshot(
+    release: Any, *, expected_names: set[str], expected_tag: str,
+    expected_title: str, expected_body: str, draft: bool,
+) -> tuple[tuple[int, str, int, str], ...]:
+    _require(isinstance(release, dict), "release response must be an object")
+    _require(release.get("tag_name") == expected_tag, "release tag does not match")
+    _require(release.get("name") == expected_title, "release title does not match")
+    _require(_normalized_body(release.get("body") or "") == _normalized_body(expected_body),
+             "release body does not match the checked-in notes")
+    _require(release.get("draft") is draft, "release draft state does not match")
+    _require(release.get("prerelease") is False, "release must not be a prerelease")
+    assets = release.get("assets")
+    _require(isinstance(assets, list), "release assets response is invalid")
+    _require({asset.get("name") for asset in assets} == expected_names,
+             "release asset names do not match the five-file contract")
+    snapshot: list[tuple[int, str, int, str]] = []
+    for asset in assets:
+        asset_id = asset.get("id")
+        name = asset.get("name")
+        size = asset.get("size")
+        digest = asset.get("digest")
+        _require(type(asset_id) is int and asset_id > 0, f"release asset ID is invalid: {name}")
+        _require(isinstance(name, str) and name in expected_names, "release asset name is invalid")
+        _require(type(size) is int and size >= 0, f"release asset size is invalid: {name}")
+        _require(
+            isinstance(digest, str) and digest.startswith("sha256:")
+            and SHA256_RE.fullmatch(digest.removeprefix("sha256:")) is not None,
+            f"release asset digest is invalid: {name}",
+        )
+        snapshot.append((asset_id, name, size, digest))
+    return tuple(sorted(snapshot, key=lambda item: item[1]))
+
+
+def _require_server_bytes(snapshot: Sequence[tuple[int, str, int, str]], root: Path) -> None:
+    local = {path.name: path for path in root.iterdir() if path.is_file()}
+    _require({item[1] for item in snapshot} == set(local), "downloaded asset names do not match server state")
+    for _, name, size, digest in snapshot:
+        path = local[name]
+        _require(path.stat().st_size == size, f"downloaded asset size does not match server: {name}")
+        _require("sha256:" + _sha256_file(path) == digest,
+                 f"downloaded asset digest does not match server: {name}")
+
+
+def _require_same_files(left: Path, right: Path, expected_names: set[str]) -> None:
+    left_files = {path.name: path for path in left.iterdir() if path.is_file()}
+    right_files = {path.name: path for path in right.iterdir() if path.is_file()}
+    _require(set(left_files) == expected_names and set(right_files) == expected_names,
+             "candidate and release asset sets do not match the contract")
+    for name in sorted(expected_names):
+        _require(left_files[name].read_bytes() == right_files[name].read_bytes(),
+                 f"draft or published asset differs from the exact-run candidate: {name}")
+
+
+def _release_by_id(runner: CommandRunner, repository: str, release_id: int) -> Any:
+    return runner.json([
+        "gh", "api", "-H", "X-GitHub-Api-Version: 2026-03-10",
+        f"repos/{repository}/releases/{release_id}",
+    ])
+
+
+def _require_no_competing_runs(
+    runner: CommandRunner, repository: str, *, selected_run_id: int,
+) -> None:
+    value = runner.json([
+        "gh", "api",
+        f"repos/{repository}/actions/workflows/release.yml/runs?per_page=100",
+    ])
+    _require(isinstance(value, dict) and isinstance(value.get("workflow_runs"), list),
+             "release workflow runs response is invalid")
+    for run in value["workflow_runs"]:
+        run_id = run.get("id")
+        status = run.get("status")
+        if run_id != selected_run_id and status != "completed":
+            raise PublishError(f"another release workflow run is nonterminal: {run_id} ({status})")
+
+
+def _artifact_for_attempt(
+    runner: CommandRunner, repository: str, run_id: int, *,
+    version: str, commit: str, attempt: int,
+) -> dict[str, Any]:
+    expected_name = f"v{version}-candidate-{commit}-{run_id}-{attempt}"
+    value = runner.json([
+        "gh", "api", f"repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100",
+    ])
+    artifact = _candidate_artifact(value, expected_name=expected_name)
+    return _validate_artifact_record(
+        artifact, expected_id=None, expected_name=expected_name,
+        run_id=run_id, commit=commit,
+    )
+
+
+def _recheck_artifact(
+    runner: CommandRunner, repository: str, *, artifact: dict[str, Any],
+    expected_name: str, run_id: int, commit: str,
+) -> dict[str, Any]:
+    current = runner.json([
+        "gh", "api", "-H", "X-GitHub-Api-Version: 2026-03-10",
+        f"repos/{repository}/actions/artifacts/{artifact['id']}",
+    ])
+    current = _validate_artifact_record(
+        current, expected_id=artifact["id"], expected_name=expected_name,
+        run_id=run_id, commit=commit,
+    )
+    _require(current["size_in_bytes"] == artifact["size_in_bytes"],
+             "candidate artifact zip size changed")
+    _require(current["digest"] == artifact["digest"], "candidate artifact zip digest changed")
+    return current
+
+
+def _recheck_run_attempt(
+    runner: CommandRunner, repository: str, *, run_id: int, attempt: int, commit: str,
+) -> None:
+    current = runner.json(["gh", "api", f"repos/{repository}/actions/runs/{run_id}"])
+    _require(_validate_run(current, commit=commit) == attempt,
+             "workflow run advanced to another attempt")
+    selected = runner.json([
+        "gh", "api", f"repos/{repository}/actions/runs/{run_id}/attempts/{attempt}",
+    ])
+    _require(_validate_run(selected, commit=commit) == attempt,
+             "selected workflow run attempt changed")
+
+
+def publish_release(
+    *, root: Path, repository: str, run_id: int, commit: str,
+    version: str, tag: str, wait_attempts: int, wait_seconds: float,
+    verify_published: bool = False,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    runner = runner or CommandRunner()
+    root = root.absolute().resolve()
+    _require(COMMIT_RE.fullmatch(commit) is not None, "commit must be exact lowercase 40-hex")
+    _require(tag == f"v{version}", "tag must equal v<version>")
+    _require(type(run_id) is int and run_id > 0, "run ID must be a positive integer")
+    _require(wait_attempts > 0 and wait_seconds >= 0, "attestation wait settings are invalid")
+
+    _require(_git_text(runner, root, "rev-parse", "HEAD") == commit, "local HEAD is not the release commit")
+    _require(_git_text(runner, root, "status", "--porcelain=v1", "--untracked-files=all") == "",
+             "local release worktree is not clean")
+    _require(_github_ref(runner, repository, "heads/main") == commit,
+             "target repository main moved")
+    _require(_github_ref(runner, repository, f"tags/{tag}") == commit,
+             "target repository release tag is absent or moved")
+
+    run = runner.json(["gh", "api", f"repos/{repository}/actions/runs/{run_id}"])
+    attempt = _validate_run(run, commit=commit)
+    jobs = runner.json([
+        "gh", "api", f"repos/{repository}/actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100",
+    ])
+    _validate_jobs(jobs, attempt=attempt)
+
+    release_artifacts = _load_release_artifacts()
+    names = release_artifacts.artifact_names(version)
+    expected_names = set(names.values())
+    candidate_name = f"v{version}-candidate-{commit}-{run_id}-{attempt}"
+    candidate_record = _artifact_for_attempt(
+        runner, repository, run_id, version=version, commit=commit, attempt=attempt,
+    )
+
+    release_id_text = runner.run([
+        "gh", "release", "view", tag, "--repo", repository,
+        "--json", "databaseId", "--jq", ".databaseId",
+    ]).stdout.strip()
+    _require(release_id_text.isdigit(), "draft release numeric ID is invalid")
+    release_id = int(release_id_text)
+    expected_title = f"Context OS v{version}"
+    expected_body = (root / f"docs/releases/v{version}.md").read_text(encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix=f"contextos-publish-v{version}-") as temporary:
+        workspace = Path(temporary)
+        candidate = workspace / "candidate"
+        release_assets = workspace / "release"
+        published = workspace / "published"
+        candidate.mkdir()
+        release_assets.mkdir()
+        published.mkdir()
+        runner.download_artifact(repository, candidate_record, candidate, expected_names)
+        _recheck_artifact(
+            runner, repository, artifact=candidate_record, expected_name=candidate_name,
+            run_id=run_id, commit=commit,
+        )
+        runner.run([
+            "gh", "release", "download", tag, "--repo", repository,
+            "--dir", str(release_assets),
+        ])
+        release_artifacts.verify_artifacts(
+            candidate, workspace / "candidate-extracted", version=version, tag=tag, commit=commit,
+        )
+        release_artifacts.verify_artifacts(
+            release_assets, workspace / "release-extracted",
+            version=version, tag=tag, commit=commit,
+        )
+        _require_same_files(candidate, release_assets, expected_names)
+
+        expected_draft = not verify_published
+        first_state = _release_by_id(runner, repository, release_id)
+        first_snapshot = _asset_snapshot(
+            first_state, expected_names=expected_names, expected_tag=tag,
+            expected_title=expected_title, expected_body=expected_body, draft=expected_draft,
+        )
+        _require_server_bytes(first_snapshot, release_assets)
+        second_state = _release_by_id(runner, repository, release_id)
+        second_snapshot = _asset_snapshot(
+            second_state, expected_names=expected_names, expected_tag=tag,
+            expected_title=expected_title, expected_body=expected_body, draft=expected_draft,
+        )
+        _require(second_snapshot == first_snapshot, "release assets changed during local verification")
+
+        operator = runner.run(["gh", "api", "user", "--jq", ".login"]).stdout.strip()
+        _require(bool(operator), "authenticated GitHub operator identity is empty")
+        runner.run(["gh", "release", "verify", "--help"])
+        runner.run(["gh", "release", "verify-asset", "--help"])
+
+        if verify_published:
+            _require(first_state.get("immutable") is True and second_state.get("immutable") is True,
+                     "published release is not immutable")
+            _require(_github_ref(runner, repository, "heads/main") == commit,
+                     "target repository main moved during published verification")
+            _require(_github_ref(runner, repository, f"tags/{tag}") == commit,
+                     "target repository release tag moved during published verification")
+            _recheck_run_attempt(
+                runner, repository, run_id=run_id, attempt=attempt, commit=commit,
+            )
+            _recheck_artifact(
+                runner, repository, artifact=candidate_record, expected_name=candidate_name,
+                run_id=run_id, commit=commit,
+            )
+            runner.run(["gh", "release", "verify", tag, "--repo", repository])
+            for name in sorted(expected_names):
+                runner.run([
+                    "gh", "release", "verify-asset", tag, str(release_assets / name),
+                    "--repo", repository,
+                ])
+            return {
+                "schema_version": 1,
+                "mode": "verify-published",
+                "repository": repository,
+                "operator": operator,
+                "verified_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+                "workflow_run_id": run_id,
+                "workflow_run_attempt": attempt,
+                "candidate_artifact_id": candidate_record["id"],
+                "release_id": release_id,
+                "tag": tag,
+                "commit": commit,
+                "immutable": True,
+                "release_attestation_verified": True,
+                "asset_attestations_verified": sorted(expected_names),
+                "assets": [
+                    {"id": asset_id, "name": name, "size": size, "digest": digest}
+                    for asset_id, name, size, digest in second_snapshot
+                ],
+            }
+
+        _require_no_competing_runs(runner, repository, selected_run_id=run_id)
+        _require(_github_ref(runner, repository, "heads/main") == commit,
+                 "target repository main moved before publish")
+        _require(_github_ref(runner, repository, f"tags/{tag}") == commit,
+                 "target repository release tag moved before publish")
+        final_state = _release_by_id(runner, repository, release_id)
+        final_snapshot = _asset_snapshot(
+            final_state, expected_names=expected_names, expected_tag=tag,
+            expected_title=expected_title, expected_body=expected_body, draft=True,
+        )
+        _require(final_snapshot == first_snapshot, "draft state changed before publish")
+        _recheck_run_attempt(
+            runner, repository, run_id=run_id, attempt=attempt, commit=commit,
+        )
+        _recheck_artifact(
+            runner, repository, artifact=candidate_record, expected_name=candidate_name,
+            run_id=run_id, commit=commit,
+        )
+        policy = runner.json([
+            "gh", "api", "-H", "X-GitHub-Api-Version: 2026-03-10",
+            f"repos/{repository}/immutable-releases",
+        ])
+        _require(isinstance(policy, dict) and policy.get("enabled") is True,
+                 "immutable releases are not enabled immediately before publish")
+
+        runner.json([
+            "gh", "api", "--method", "PATCH", "-H", "X-GitHub-Api-Version: 2026-03-10",
+            f"repos/{repository}/releases/{release_id}",
+            "-F", "draft=false", "-f", "make_latest=true",
+        ])
+
+        published_state: Any = None
+        attestation_ok = False
+        for _ in range(wait_attempts):
+            published_state = _release_by_id(runner, repository, release_id)
+            if published_state.get("draft") is False and published_state.get("immutable") is True:
+                verified = runner.run(
+                    ["gh", "release", "verify", tag, "--repo", repository], check=False
+                )
+                if verified.returncode == 0:
+                    attestation_ok = True
+                    break
+            time.sleep(wait_seconds)
+        _require(attestation_ok, "published release did not expose a valid immutable attestation")
+        published_snapshot = _asset_snapshot(
+            published_state, expected_names=expected_names, expected_tag=tag,
+            expected_title=expected_title, expected_body=expected_body, draft=False,
+        )
+        _require(published_state.get("immutable") is True, "published release is not immutable")
+        _require(published_snapshot == first_snapshot, "published asset metadata changed")
+        _require(_github_ref(runner, repository, f"tags/{tag}") == commit,
+                 "release tag changed after publication")
+
+        runner.run([
+            "gh", "release", "download", tag, "--repo", repository, "--dir", str(published),
+        ])
+        release_artifacts.verify_artifacts(
+            published, workspace / "published-extracted", version=version, tag=tag, commit=commit,
+        )
+        _require_same_files(candidate, published, expected_names)
+        _require_server_bytes(published_snapshot, published)
+        for name in sorted(expected_names):
+            runner.run([
+                "gh", "release", "verify-asset", tag, str(published / name),
+                "--repo", repository,
+            ])
+
+        return {
+            "schema_version": 1,
+            "mode": "publish",
+            "repository": repository,
+            "operator": operator,
+            "published_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "workflow_run_id": run_id,
+            "workflow_run_attempt": attempt,
+            "candidate_artifact_id": candidate_record["id"],
+            "release_id": release_id,
+            "tag": tag,
+            "commit": commit,
+            "immutable_policy_enabled": True,
+            "immutable": True,
+            "release_attestation_verified": True,
+            "asset_attestations_verified": sorted(expected_names),
+            "assets": [
+                {"id": asset_id, "name": name, "size": size, "digest": digest}
+                for asset_id, name, size, digest in published_snapshot
+            ],
+        }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--run-id", type=int, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--wait-attempts", type=int, default=18)
+    parser.add_argument("--wait-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--verify-published", action="store_true",
+        help="read-only recovery: verify an already-published immutable release",
+    )
+    args = parser.parse_args(argv)
+    try:
+        result = publish_release(
+            root=ROOT, repository=args.repository, run_id=args.run_id,
+            commit=args.commit, version=args.version, tag=args.tag,
+            wait_attempts=args.wait_attempts, wait_seconds=args.wait_seconds,
+            verify_published=args.verify_published,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+    except (PublishError, OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"publish release: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "publish_release", ROOT / "scripts/publish-release.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+publish_release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(publish_release)
+
+
+REPOSITORY = "conorbronsdon/agent-context-os"
+VERSION = "0.12.0"
+TAG = "v0.12.0"
+COMMIT = "a" * 40
+RUN_ID = 12345
+ATTEMPT = 3
+ARTIFACT_ID = 67890
+RELEASE_ID = 24680
+
+
+class FakeArtifacts:
+    names = {
+        "archive": "agent-context-os-template-v0.12.0.tar",
+        "lock": "agent-context-os-template-v0.12.0.bundle.lock.json",
+        "provenance": "agent-context-os-template-v0.12.0.provenance.json",
+        "instructions": "agent-context-os-template-v0.12.0.OFFLINE-VERIFY.md",
+        "checksums": "SHA256SUMS",
+    }
+
+    @classmethod
+    def artifact_names(cls, version: str) -> dict[str, str]:
+        if version != VERSION:
+            raise AssertionError(version)
+        return cls.names
+
+    @staticmethod
+    def verify_artifacts(root: Path, extracted: Path, **_: object) -> None:
+        if {path.name for path in root.iterdir()} != set(FakeArtifacts.names.values()):
+            raise AssertionError("unexpected test artifact set")
+        extracted.mkdir()
+
+
+class FakeGitHubRunner:
+    def __init__(self, root: Path, *, published: bool = False) -> None:
+        self.root = root
+        self.published = published
+        self.immutable = published
+        self.patch_count = 0
+        self.calls: list[tuple[str, ...]] = []
+        self.other_runs: list[dict[str, object]] = []
+        self.main_sha = COMMIT
+        self.tag_sha = COMMIT
+        self.artifact_replaced = False
+        self.verify_ok = True
+        self.payloads = {
+            name: (name + "\n").encode("utf-8") for name in FakeArtifacts.names.values()
+        }
+        self.body = (root / "docs/releases/v0.12.0.md").read_text(encoding="utf-8")
+
+    def _completed(self, arguments: tuple[str, ...], stdout: str = "", returncode: int = 0):
+        self.calls.append(arguments)
+        return subprocess.CompletedProcess(arguments, returncode, stdout, "")
+
+    def _run_value(self) -> dict[str, object]:
+        return {
+            "event": "workflow_dispatch", "head_branch": "main", "head_sha": COMMIT,
+            "path": ".github/workflows/release.yml", "status": "completed",
+            "conclusion": "success", "run_attempt": ATTEMPT,
+        }
+
+    def _artifact(self) -> dict[str, object]:
+        return {
+            "id": ARTIFACT_ID + int(self.artifact_replaced),
+            "name": f"v{VERSION}-candidate-{COMMIT}-{RUN_ID}-{ATTEMPT}",
+            "expired": False, "size_in_bytes": 111,
+            "digest": "sha256:" + "b" * 64,
+            "workflow_run": {"id": RUN_ID, "head_sha": COMMIT, "head_branch": "main"},
+        }
+
+    def _release(self) -> dict[str, object]:
+        assets = []
+        for index, (name, payload) in enumerate(sorted(self.payloads.items()), start=1):
+            assets.append({
+                "id": index, "name": name, "size": len(payload),
+                "digest": "sha256:" + hashlib.sha256(payload).hexdigest(),
+            })
+        return {
+            "id": RELEASE_ID, "tag_name": TAG, "name": f"Context OS v{VERSION}",
+            "body": self.body, "draft": not self.published, "prerelease": False,
+            "immutable": self.immutable, "assets": assets,
+        }
+
+    def run(self, arguments, *, cwd=None, check=True):
+        args = tuple(str(value) for value in arguments)
+        if args[:2] == ("git", "rev-parse"):
+            return self._completed(args, COMMIT + "\n")
+        if args[:2] == ("git", "status"):
+            return self._completed(args, "")
+        if args[:3] == ("gh", "release", "view"):
+            return self._completed(args, str(RELEASE_ID) + "\n")
+        if args[:3] == ("gh", "release", "download"):
+            destination = Path(args[args.index("--dir") + 1])
+            for name, payload in self.payloads.items():
+                (destination / name).write_bytes(payload)
+            return self._completed(args)
+        if args[:3] in (("gh", "release", "verify"), ("gh", "release", "verify-asset")):
+            if "--help" in args:
+                return self._completed(args)
+            code = 0 if self.verify_ok else 1
+            result = self._completed(args, returncode=code)
+            if check and code:
+                raise publish_release.PublishError("fake attestation failure")
+            return result
+        if args == ("gh", "api", "user", "--jq", ".login"):
+            return self._completed(args, "release-operator\n")
+        raise AssertionError(f"unexpected run command: {args}")
+
+    def json(self, arguments, *, cwd=None):
+        args = tuple(str(value) for value in arguments)
+        self.calls.append(args)
+        endpoint = next((value for value in args if value.startswith("repos/")), "")
+        if endpoint.endswith("/git/ref/heads/main"):
+            return {"object": {"type": "commit", "sha": self.main_sha}}
+        if endpoint.endswith(f"/git/ref/tags/{TAG}"):
+            return {"object": {"type": "commit", "sha": self.tag_sha}}
+        if endpoint.endswith(f"/actions/runs/{RUN_ID}") or endpoint.endswith(
+            f"/actions/runs/{RUN_ID}/attempts/{ATTEMPT}"
+        ):
+            return self._run_value()
+        if endpoint.endswith(f"/attempts/{ATTEMPT}/jobs?per_page=100"):
+            return {"jobs": [
+                {"name": name, "run_attempt": ATTEMPT, "status": "completed", "conclusion": "success"}
+                for name in publish_release.REQUIRED_JOBS
+            ]}
+        if endpoint.endswith(f"/actions/runs/{RUN_ID}/artifacts?per_page=100"):
+            return {"artifacts": [self._artifact()]}
+        if endpoint.endswith(f"/actions/artifacts/{ARTIFACT_ID}"):
+            return self._artifact()
+        if endpoint.endswith(f"/releases/{RELEASE_ID}"):
+            if "PATCH" in args:
+                self.patch_count += 1
+                self.published = True
+                self.immutable = True
+            return self._release()
+        if endpoint.endswith("/actions/workflows/release.yml/runs?per_page=100"):
+            return {"workflow_runs": [{"id": RUN_ID, "status": "completed"}, *self.other_runs]}
+        if endpoint.endswith("/immutable-releases"):
+            return {"enabled": True}
+        raise AssertionError(f"unexpected json command: {args}")
+
+    def download_artifact(self, repository, artifact, destination, expected_names):
+        self.calls.append(("download-artifact-id", str(artifact["id"])))
+        if repository != REPOSITORY or artifact["id"] != ARTIFACT_ID:
+            raise AssertionError("artifact was not downloaded by the selected numeric ID")
+        for name, payload in self.payloads.items():
+            (destination / name).write_bytes(payload)
+        if set(self.payloads) != expected_names:
+            raise AssertionError("unexpected names")
+
+
+class PublishReleaseTest(unittest.TestCase):
+    def _publish(self, fake: FakeGitHubRunner, *, verify_published: bool = False):
+        with mock.patch.object(publish_release, "_load_release_artifacts", return_value=FakeArtifacts):
+            return publish_release.publish_release(
+                root=ROOT, repository=REPOSITORY, run_id=RUN_ID, commit=COMMIT,
+                version=VERSION, tag=TAG, wait_attempts=1, wait_seconds=0,
+                verify_published=verify_published, runner=fake,
+            )
+
+    def test_state_machine_publishes_exact_numeric_release_once(self) -> None:
+        fake = FakeGitHubRunner(ROOT)
+        result = self._publish(fake)
+        self.assertEqual(fake.patch_count, 1)
+        self.assertEqual(result["mode"], "publish")
+        self.assertEqual(result["candidate_artifact_id"], ARTIFACT_ID)
+        self.assertIn(("download-artifact-id", str(ARTIFACT_ID)), fake.calls)
+        patches = [call for call in fake.calls if "PATCH" in call]
+        self.assertEqual(len(patches), 1)
+        self.assertIn(f"repos/{REPOSITORY}/releases/{RELEASE_ID}", patches[0])
+        self.assertFalse(any(call[:3] == ("git", "ls-remote", "origin") for call in fake.calls))
+
+    def test_binary_artifact_download_binds_zip_digest_and_exact_files(self) -> None:
+        payloads = {name: (name + "\n").encode() for name in FakeArtifacts.names.values()}
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            for name, payload in payloads.items():
+                archive.writestr(name, payload)
+        zip_bytes = buffer.getvalue()
+        artifact = {
+            "id": ARTIFACT_ID, "size_in_bytes": len(zip_bytes),
+            "digest": "sha256:" + hashlib.sha256(zip_bytes).hexdigest(),
+        }
+
+        def stream_zip(arguments, **kwargs):
+            kwargs["stdout"].write(zip_bytes)
+            return subprocess.CompletedProcess(arguments, 0, b"", b"")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "assets"
+            destination.mkdir()
+            with mock.patch.object(publish_release.subprocess, "run", side_effect=stream_zip):
+                publish_release.CommandRunner().download_artifact(
+                    REPOSITORY, artifact, destination, set(payloads),
+                )
+            self.assertEqual(
+                {path.name: path.read_bytes() for path in destination.iterdir()}, payloads
+            )
+
+            artifact["digest"] = "sha256:" + "0" * 64
+            with mock.patch.object(publish_release.subprocess, "run", side_effect=stream_zip):
+                with self.assertRaisesRegex(publish_release.PublishError, "digest changed"):
+                    publish_release.CommandRunner().download_artifact(
+                        REPOSITORY, artifact, destination, set(payloads),
+                    )
+
+    def test_target_repository_ref_movement_prevents_patch(self) -> None:
+        for attribute in ("main_sha", "tag_sha"):
+            with self.subTest(attribute=attribute):
+                fake = FakeGitHubRunner(ROOT)
+                setattr(fake, attribute, "c" * 40)
+                with self.assertRaisesRegex(publish_release.PublishError, "target repository"):
+                    self._publish(fake)
+                self.assertEqual(fake.patch_count, 0)
+
+    def test_artifact_replacement_after_exact_id_download_prevents_patch(self) -> None:
+        fake = FakeGitHubRunner(ROOT)
+
+        def replace_after_download(repository, artifact, destination, expected_names):
+            FakeGitHubRunner.download_artifact(
+                fake, repository, artifact, destination, expected_names,
+            )
+            fake.artifact_replaced = True
+
+        fake.download_artifact = replace_after_download
+        with self.assertRaisesRegex(publish_release.PublishError, "artifact ID changed"):
+            self._publish(fake)
+        self.assertEqual(fake.patch_count, 0)
+
+    def test_every_nonterminal_competing_run_prevents_patch(self) -> None:
+        for status in ("queued", "in_progress", "requested", "waiting", "pending"):
+            with self.subTest(status=status):
+                fake = FakeGitHubRunner(ROOT)
+                fake.other_runs = [{"id": 999, "status": status}]
+                with self.assertRaisesRegex(publish_release.PublishError, "nonterminal"):
+                    self._publish(fake)
+                self.assertEqual(fake.patch_count, 0)
+
+    def test_timeout_recovers_with_read_only_published_verification(self) -> None:
+        fake = FakeGitHubRunner(ROOT)
+        fake.verify_ok = False
+        with self.assertRaisesRegex(publish_release.PublishError, "immutable attestation"):
+            self._publish(fake)
+        self.assertEqual(fake.patch_count, 1)
+        fake.verify_ok = True
+        result = self._publish(fake, verify_published=True)
+        self.assertEqual(result["mode"], "verify-published")
+        self.assertEqual(fake.patch_count, 1)
+        self.assertTrue(result["immutable"])
+        self.assertEqual(
+            result["asset_attestations_verified"], sorted(FakeArtifacts.names.values())
+        )
+
+    def test_read_only_mode_rejects_draft_without_patch(self) -> None:
+        fake = FakeGitHubRunner(ROOT)
+        with self.assertRaisesRegex(publish_release.PublishError, "draft state"):
+            self._publish(fake, verify_published=True)
+        self.assertEqual(fake.patch_count, 0)
+
+    def test_exact_run_and_required_jobs_are_fail_closed(self) -> None:
+        commit = "a" * 40
+        run = {
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": commit,
+            "path": ".github/workflows/release.yml",
+            "status": "completed",
+            "conclusion": "success",
+            "run_attempt": 2,
+        }
+        self.assertEqual(publish_release._validate_run(run, commit=commit), 2)
+        jobs = {
+            "jobs": [
+                {"name": name, "run_attempt": 2, "status": "completed", "conclusion": "success"}
+                for name in publish_release.REQUIRED_JOBS
+            ]
+        }
+        publish_release._validate_jobs(jobs, attempt=2)
+
+        stale = dict(run, head_sha="b" * 40)
+        with self.assertRaisesRegex(publish_release.PublishError, "head_sha"):
+            publish_release._validate_run(stale, commit=commit)
+        jobs["jobs"][-1]["conclusion"] = "failure"
+        with self.assertRaisesRegex(publish_release.PublishError, "ready-to-publish"):
+            publish_release._validate_jobs(jobs, attempt=2)
+
+    def test_candidate_artifact_must_be_unique_and_unexpired(self) -> None:
+        value = {"artifacts": [{"id": 41, "name": "candidate", "expired": False}]}
+        self.assertEqual(
+            publish_release._candidate_artifact(value, expected_name="candidate")["id"], 41
+        )
+        value["artifacts"].append({"id": 42, "name": "candidate", "expired": False})
+        with self.assertRaisesRegex(publish_release.PublishError, "exactly one"):
+            publish_release._candidate_artifact(value, expected_name="candidate")
+
+    def test_release_snapshot_binds_metadata_and_downloaded_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            expected_names = {"a.tar", "b.json", "c.json", "d.md", "SHA256SUMS"}
+            assets = []
+            for index, name in enumerate(sorted(expected_names), start=1):
+                path = root / name
+                path.write_bytes((name + "\n").encode("utf-8"))
+                assets.append({
+                    "id": index,
+                    "name": name,
+                    "size": path.stat().st_size,
+                    "digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+                })
+            release = {
+                "tag_name": "v0.12.0",
+                "name": "Context OS v0.12.0",
+                "body": "notes\r\n",
+                "draft": True,
+                "prerelease": False,
+                "assets": assets,
+            }
+            snapshot = publish_release._asset_snapshot(
+                release,
+                expected_names=expected_names,
+                expected_tag="v0.12.0",
+                expected_title="Context OS v0.12.0",
+                expected_body="notes\n",
+                draft=True,
+            )
+            publish_release._require_server_bytes(snapshot, root)
+            (root / "a.tar").write_bytes(b"substituted\n")
+            with self.assertRaisesRegex(publish_release.PublishError, "size|digest"):
+                publish_release._require_server_bytes(snapshot, root)
+
+    def test_candidate_and_release_directories_must_be_byte_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            left = root / "left"
+            right = root / "right"
+            left.mkdir()
+            right.mkdir()
+            names = {"one", "two"}
+            for name in names:
+                (left / name).write_text(name, encoding="utf-8")
+                (right / name).write_text(name, encoding="utf-8")
+            publish_release._require_same_files(left, right, names)
+            (right / "two").write_text("changed", encoding="utf-8")
+            with self.assertRaisesRegex(publish_release.PublishError, "differs"):
+                publish_release._require_same_files(left, right, names)
+
+    def test_admin_policy_check_is_immediately_before_numeric_id_patch(self) -> None:
+        source = (ROOT / "scripts/publish-release.py").read_text(encoding="utf-8")
+        policy = source.index('f"repos/{repository}/immutable-releases"')
+        patch = source.index('"gh", "api", "--method", "PATCH"')
+        self.assertLess(source.rindex("_require_no_competing_runs", 0, policy), policy)
+        self.assertLess(source.rindex("final_snapshot = _asset_snapshot", 0, policy), policy)
+        self.assertLess(policy, patch)
+        between = source[policy:patch]
+        self.assertNotIn("runner.", between.rsplit("runner.json([", 1)[0])
+
+    def test_workflow_artifact_name_binds_run_and_attempt_without_overwrite(self) -> None:
+        source = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        qualified = (
+            "v0.12.0-candidate-${{ inputs.commit }}-"
+            "${{ github.run_id }}-${{ github.run_attempt }}"
+        )
+        self.assertGreaterEqual(source.count(qualified), 5)
+        self.assertNotIn("overwrite: true", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -254,7 +254,7 @@ class ReleaseArtifactTest(unittest.TestCase):
                 tag="v0.12.1", commit=self.fixture.commit,
             )
 
-    def test_workflow_requires_both_platforms_before_tag_and_publication(self) -> None:
+    def test_workflow_requires_both_platforms_before_tag_and_verified_draft(self) -> None:
         workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
         self.assertIn(
             "needs: [verify-candidate-linux, verify-candidate-windows]", workflow
@@ -262,33 +262,42 @@ class ReleaseArtifactTest(unittest.TestCase):
         self.assertIn(
             "needs: [stage-draft, verify-draft-linux, verify-draft-windows]", workflow
         )
-        self.assertLess(workflow.index("stage-draft:"), workflow.index("publish:"))
+        self.assertLess(workflow.index("stage-draft:"), workflow.index("ready-to-publish:"))
         self.assertNotIn("always()", workflow)
         self.assertEqual(workflow.count("contents: write"), 4)
         self.assertIn('-f "ref=refs/tags/$TAG"', workflow)
         self.assertIn("--verify-tag", workflow)
         self.assertNotIn('--target "$RELEASE_COMMIT"', workflow)
+        self.assertIn("retention-days: 7", workflow)
         build = workflow.split("  build-linux:", 1)[1].split(
             "  verify-candidate-linux:", 1
         )[0]
         self.assertNotIn("chmod +x", build)
-        publish = workflow.split("  publish:", 1)[1]
+        self.assertIn('test "$GITHUB_REF" = refs/heads/main', build)
+        self.assertIn('test "$GITHUB_SHA" = "$RELEASE_COMMIT"', build)
+        final = workflow.split("  ready-to-publish:", 1)[1]
         self.assertLess(
-            publish.index('gh release download "$TAG"'),
-            publish.index('gh api --method PATCH'),
+            final.index("actions/download-artifact@"),
+            final.index('gh release download "$TAG"'),
         )
         self.assertLess(
-            publish.index("scripts/release-artifacts.py verify"),
-            publish.index('gh api --method PATCH'),
+            final.index("scripts/release-artifacts.py verify"),
+            final.index('item["digest"] == "sha256:"'),
         )
-        self.assertLess(
-            publish.index('item["digest"] == "sha256:"'),
-            publish.index('gh api --method PATCH'),
-        )
+        self.assertIn('diff --recursive --brief "$RUNNER_TEMP/candidate-assets"', final)
+        self.assertIn('value["draft"] is True', final)
+        self.assertIn('value["prerelease"] is False', final)
         self.assertIn("release_id: ${{ steps.stage.outputs.release_id }}", workflow)
-        self.assertIn('"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"', publish)
-        self.assertNotIn('releases/tags/$TAG', publish)
-        self.assertIn("already_published=true", publish)
+        self.assertIn('"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"', final)
+        self.assertNotIn('releases/tags/$TAG', final)
+        self.assertNotIn("\n  publish:", workflow)
+        self.assertNotIn("immutable-releases", workflow)
+        self.assertNotIn("gh api --method PATCH", workflow)
+        self.assertNotIn("draft=false", workflow)
+        self.assertNotIn("make_latest=true", workflow)
+        self.assertNotIn("gh release verify", workflow)
+        self.assertNotIn("already_published", workflow)
+        self.assertNotIn("secrets.", workflow)
         action_references = [
             line.strip().split("uses: ", 1)[1].split(" #", 1)[0]
             for line in workflow.splitlines() if "uses: actions/" in line


### PR DESCRIPTION
## Summary

- split v0.12 qualification/draft staging from the admin-only publication step
- bind the local publisher to the target repository, exact run attempt, numeric Actions artifact ID and digest, numeric draft release ID, and exact candidate bytes
- add a tested read-only recovery mode for publication that succeeded before final attestation evidence was observed

## Why

The first release run proved that Actions `GITHUB_TOKEN` cannot read the repository-administration immutable-release policy endpoint. The workflow failed before building artifacts, creating a tag, or staging a release. This keeps the admin token local while preserving the release gates: Linux and Windows verify both the candidate and downloaded draft before Actions can report readiness, and the local publisher checks immutable-release policy immediately before its sole numeric-ID PATCH.

## Verification

- `bash scripts/validate-all.sh`: 571 tests passed, 43 skipped; all repository checks passed
- focused publisher/artifact suite: 19 passed
- `actionlint .github/workflows/release.yml`
- component manifest: 11 components, 211 exact paths
- exact-SHA Claude Opus/Fable and free Hermes Inkling reviews
- three independent publication-integrity audits: PASS

No tag or release is published by this PR. The revised release workflow stops at a verified unpublished draft.

Closes #139
