### PR TITLE
docs: include Shortcut in v0.12 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## [Unreleased]
 
-### Added
-- `shortcut-mcp` integration catalog entry for Shortcut's hosted MCP server with
-  granular OAuth scopes and dedicated read-only mode (#49).
-
 ---
 
-## [0.12.0] — 2026-08-29 — Immutable full-template release
+## [0.12.0] — 2026-08-31 — Immutable full-template release
 
 v0.12.0 publishes the colocated full-template, full-component-closure contract.
 It does not claim external repository attachment or a durable slim workspace
@@ -86,6 +82,9 @@ profile; those require later binding and workspace-schema revisions.
 - A reviewed Pandoc catalog entry with a bounded non-PDF profile, explicit network and sensitive-read boundaries, PDF-engine execution guidance, and overwrite confirmation.
 - A reviewed MarkItDown MCP catalog entry covering its local-file and network read boundary, unauthenticated localhost transport, sandboxing guidance, and pinned v0.1.7 evidence.
 - A reviewed Trello MCP catalog entry covering one authorized workspace plus account-level Inbox and Planner permissions, connected-calendar reads, create/update/move/archive capabilities, and a no-permanent-delete surface.
+- A reviewed Shortcut MCP catalog entry for Shortcut's hosted server, with
+  granular OAuth scopes, a dedicated read-only mode, and explicit gates for
+  workspace-wide sensitive reads and story or document updates (#49).
 - Provider-neutral root discovery through validated `contextos.workspace.json`,
   with legacy compound-marker compatibility, nearest-root selection, explicit
   nested Git boundaries, fail-closed invalid markers, and actionable migration

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -783,7 +783,7 @@
         "arbitrary_execution": false,
         "oauth": true,
         "destructive": true,
-        "details": ["Start with the dedicated read OAuth scope for read-only story and epic search", "The hosted service supports granular write, story-write, and comment-write OAuth scopes for explicit creation and update workflows", "The open-source repository is archived but the hosted https://mcp.shortcut.com/mcp service remains actively documented", "The server exposes no destructive card operations; archiving remains within standard Shortcut workflows"]
+        "details": ["Start with the dedicated read OAuth scope for read-only story and epic search", "The hosted service supports granular write, story-write, and comment-write OAuth scopes for explicit creation and update workflows", "The open-source repository is archived but the hosted https://mcp.shortcut.com/mcp service remains actively documented", "The documented surface is overwrite-capable but includes no permanently destructive operations; archiving remains within standard Shortcut workflows"]
       },
       "confirmation": {
         "required_for": ["credential_setup", "external_install", "read_sensitive", "write", "write_remote", "overwrite", "oauth", "destructive"],

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -368,7 +368,7 @@ Capabilities and limits:
 - Start with the dedicated read OAuth scope for read-only story and epic search
 - The hosted service supports granular write, story-write, and comment-write OAuth scopes for explicit creation and update workflows
 - The open-source repository is archived but the hosted https://mcp.shortcut.com/mcp service remains actively documented
-- The server exposes no destructive card operations; archiving remains within standard Shortcut workflows
+- The documented surface is overwrite-capable but includes no permanently destructive operations; archiving remains within standard Shortcut workflows
 
 ## Substack MCP
 


### PR DESCRIPTION
## Summary

- move the newly merged Shortcut MCP entry from `Unreleased` into the v0.12.0 changelog block
- update the v0.12.0 changelog date to the actual release date
- replace leaked Trello `card` terminology in the Shortcut catalog and regenerated reference

## Why

Shortcut merged after the prior release-preparation SHA but before v0.12 was tagged. Because the release workflow requires the exact tip of `main`, Shortcut is now part of the canonical full-template closure and must be accounted for in v0.12 rather than described as unreleased.

## Verification

- canonical validator: 572 passed, 43 skipped; all repository checks passed
- integration suite: 22 passed
- `scripts/integrations.py check`
- exact-SHA Claude Fable 5 review: PASS
- exact-SHA free Hermes Inkling review: PASS

No tag, draft, or release exists.
