### PR TITLE
fix: harden worktree guard identity checks

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -59,10 +59,26 @@ fi
 # Normalize Claude's native Windows paths before dirname/git inspection.
 FILE_PATH="${FILE_PATH//\\//}"
 
-# 3. Session count. tasklist on Windows, ps elsewhere.
-SESSION_COUNT=$(tasklist //FI "IMAGENAME eq claude.exe" 2>/dev/null | grep -c "^claude.exe")
+# 3. Session count. tasklist on Windows, ps elsewhere. Match executable names,
+# not arbitrary command-line text: the hook itself contains "claude" and must
+# never count itself as another session.
+SESSION_COUNT=0
+if command -v tasklist >/dev/null 2>&1; then
+  SESSION_COUNT=$(tasklist //FI "IMAGENAME eq claude.exe" 2>/dev/null | awk '
+    tolower($1) == "claude.exe" { count++ }
+    END { print count + 0 }
+  ')
+fi
 if [ "$SESSION_COUNT" -eq 0 ]; then
-  SESSION_COUNT=$(ps aux 2>/dev/null | grep -E "\\bclaude(\\.exe)?\\b" | grep -v grep | wc -l)
+  SESSION_COUNT=$(ps -A -o comm= 2>/dev/null | awk '
+    {
+      executable = $0
+      sub(/^.*\//, "", executable)
+      executable = tolower(executable)
+      if (executable == "claude" || executable == "claude.exe") count++
+    }
+    END { print count + 0 }
+  ')
 fi
 [ "$SESSION_COUNT" -le 1 ] && exit 0
 
@@ -74,22 +90,22 @@ while [ ! -d "$TARGET_DIR" ] && [ "$TARGET_DIR" != "/" ] && [ "$TARGET_DIR" != "
 done
 [ ! -d "$TARGET_DIR" ] && exit 0
 
-GIT_DIR=$(git -C "$TARGET_DIR" rev-parse --git-dir 2>/dev/null) || exit 0
-
-# 5. Inside a worktree? Allow.
-case "$GIT_DIR" in
-  *worktrees*) exit 0 ;;
-esac
-
 REPO_ROOT=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
-# Resolve canonical repo via git-common-dir (worktrees report their own dirname).
-GIT_COMMON_DIR=$(git -C "$TARGET_DIR" rev-parse --git-common-dir 2>/dev/null)
+GIT_DIR=$(git -C "$TARGET_DIR" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+GIT_COMMON_DIR=$(git -C "$TARGET_DIR" rev-parse --git-common-dir 2>/dev/null) || exit 0
+
+GIT_DIR=$(cd "$GIT_DIR" 2>/dev/null && pwd -P) || exit 0
 case "$GIT_COMMON_DIR" in
-  /*|[A-Za-z]:*) CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR") ;;
-  *) CANONICAL_ROOT=$(cd "$TARGET_DIR/$(dirname "$GIT_COMMON_DIR")" 2>/dev/null && pwd) ;;
+  /*|[A-Za-z]:*) GIT_COMMON_DIR=$(cd "$GIT_COMMON_DIR" 2>/dev/null && pwd -P) || exit 0 ;;
+  *) GIT_COMMON_DIR=$(cd "$TARGET_DIR/$GIT_COMMON_DIR" 2>/dev/null && pwd -P) || exit 0 ;;
 esac
-[ -z "$CANONICAL_ROOT" ] && CANONICAL_ROOT="$REPO_ROOT"
-REPO_NAME=$(basename "$CANONICAL_ROOT")
+
+# 5. A linked worktree has a per-worktree git directory and a distinct common
+# directory. A primary checkout (including one with --separate-git-dir) has the
+# same directory for both. Compare Git's structure; path names are not identity.
+[ "$GIT_DIR" != "$GIT_COMMON_DIR" ] && exit 0
+
+REPO_NAME=$(basename "$REPO_ROOT")
 
 # 6. Is this repo guarded?
 if ! tr -d '\r' < "$GUARD_LIST" | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$' | grep -Fxq "$REPO_NAME"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- The enabled Claude worktree guard now counts exact Claude executable names and identifies linked worktrees from Git's common-directory structure, with must-fire and must-not-fire controls for primary, linked, guarded, unguarded, and single-session paths.
+
 ---
 
 ## [0.12.0] — 2026-08-31 — Immutable full-template release

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -104,6 +104,9 @@ mkdir -p "$TEST_REPO/.claude/hooks" "$TEMP_ROOT/bin"
 git -C "$TEMP_ROOT_WIN" init -q -b main guarded-repo
 cp "$ROOT/.claude/hooks/worktree-guard.sh" "$TEST_REPO/.claude/hooks/worktree-guard.sh"
 printf 'guarded-repo\r\n' > "$TEST_REPO/.claude/hooks/guarded-repos.txt"
+printf 'baseline\n' > "$TEST_REPO/README.md"
+git -C "$TEST_REPO" add README.md
+git -C "$TEST_REPO" -c user.name=Test -c user.email=test@example.invalid commit -qm baseline
 printf '%s\n' '#!/usr/bin/env bash' 'printf "claude.exe one\\nclaude.exe two\\n"' > "$TEMP_ROOT/bin/tasklist"
 chmod +x "$TEMP_ROOT/bin/tasklist"
 
@@ -143,6 +146,81 @@ set -e
 if [ "$WINDOWS_GUARD_STATUS" -ne 2 ] || ! printf '%s' "$WINDOWS_GUARD_STDERR" | grep -q "Blocked: 2 Claude sessions"; then
   echo "worktree-guard did not normalize backslash paths or CRLF guard entries" >&2
   exit 1
+fi
+
+# One session must never block a guarded primary checkout.
+printf '%s\n' '#!/usr/bin/env bash' 'printf "claude.exe one\\n"' > "$TEMP_ROOT/bin/tasklist"
+set +e
+printf '%s' "{\"tool_input\":{\"file_path\":\"$TEST_REPO/note.md\"}}" | \
+  PATH="$TEMP_ROOT/bin:$PATH" bash "$TEST_REPO/.claude/hooks/worktree-guard.sh" >/dev/null 2>&1
+ONE_SESSION_STATUS=$?
+set -e
+[ "$ONE_SESSION_STATUS" -eq 0 ] \
+  || fail "worktree-guard fired with only one Claude session"
+
+# The POSIX fallback must match the executable name, not helper processes or
+# command-line text that merely contains the word claude.
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$TEMP_ROOT/bin/tasklist"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'printf "/usr/local/bin/claude-helper\\nclaude-monitor\\nmyclaude\\nbash\\n"' > "$TEMP_ROOT/bin/ps"
+chmod +x "$TEMP_ROOT/bin/tasklist" "$TEMP_ROOT/bin/ps"
+set +e
+printf '%s' "{\"tool_input\":{\"file_path\":\"$TEST_REPO/note.md\"}}" | \
+  PATH="$TEMP_ROOT/bin:$PATH" bash "$TEST_REPO/.claude/hooks/worktree-guard.sh" >/dev/null 2>&1
+NON_CLAUDE_STATUS=$?
+set -e
+[ "$NON_CLAUDE_STATUS" -eq 0 ] \
+  || fail "worktree-guard counted non-Claude process names"
+
+# The same POSIX path must still fire for two exact Claude executables.
+printf '%s\n' '#!/usr/bin/env bash' \
+  'printf "/usr/local/bin/claude\\nclaude.exe\\n"' > "$TEMP_ROOT/bin/ps"
+set +e
+POSIX_GUARD_STDERR=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$TEST_REPO/note.md\"}}" | \
+  PATH="$TEMP_ROOT/bin:$PATH" bash "$TEST_REPO/.claude/hooks/worktree-guard.sh" 2>&1 >/dev/null)
+POSIX_GUARD_STATUS=$?
+set -e
+if [ "$POSIX_GUARD_STATUS" -ne 2 ] || ! printf '%s' "$POSIX_GUARD_STDERR" | grep -q "Blocked: 2 Claude sessions"; then
+  fail "worktree-guard POSIX fallback did not count exact Claude executables"
+fi
+
+# Two sessions do not block a repository that is absent from the guard list.
+UNGUARDED_REPO="$TEMP_ROOT_WIN/unguarded-repo"
+git -C "$TEMP_ROOT_WIN" init -q -b main unguarded-repo
+printf '%s\n' '#!/usr/bin/env bash' 'printf "claude.exe one\\nclaude.exe two\\n"' > "$TEMP_ROOT/bin/tasklist"
+set +e
+printf '%s' "{\"tool_input\":{\"file_path\":\"$UNGUARDED_REPO/note.md\"}}" | \
+  PATH="$TEMP_ROOT/bin:$PATH" bash "$TEST_REPO/.claude/hooks/worktree-guard.sh" >/dev/null 2>&1
+UNGUARDED_STATUS=$?
+set -e
+[ "$UNGUARDED_STATUS" -eq 0 ] \
+  || fail "worktree-guard fired for an unguarded repository"
+
+# A real linked worktree must remain editable with two sessions.
+LINKED_REPO="$TEMP_ROOT_WIN/guarded-repo-linked"
+git -C "$TEST_REPO" worktree add -q -b linked-test "$LINKED_REPO"
+set +e
+printf '%s' "{\"tool_input\":{\"file_path\":\"$LINKED_REPO/note.md\"}}" | \
+  PATH="$TEMP_ROOT/bin:$PATH" bash "$TEST_REPO/.claude/hooks/worktree-guard.sh" >/dev/null 2>&1
+LINKED_STATUS=$?
+set -e
+[ "$LINKED_STATUS" -eq 0 ] \
+  || fail "worktree-guard fired inside a real linked worktree"
+
+# A primary checkout can legitimately use a separate Git directory whose path
+# contains "worktrees". It must still block; path substrings are not identity.
+SEPARATE_REPO="$TEMP_ROOT_WIN/guarded-separate"
+SEPARATE_GIT_DIR="$TEMP_ROOT_WIN/worktrees-metadata/guarded-separate.git"
+mkdir -p "$(dirname "$SEPARATE_GIT_DIR")"
+git init -q -b main --separate-git-dir "$SEPARATE_GIT_DIR" "$SEPARATE_REPO"
+printf 'guarded-separate\r\n' >> "$TEST_REPO/.claude/hooks/guarded-repos.txt"
+set +e
+SEPARATE_GUARD_STDERR=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SEPARATE_REPO/note.md\"}}" | \
+  PATH="$TEMP_ROOT/bin:$PATH" bash "$TEST_REPO/.claude/hooks/worktree-guard.sh" 2>&1 >/dev/null)
+SEPARATE_GUARD_STATUS=$?
+set -e
+if [ "$SEPARATE_GUARD_STATUS" -ne 2 ] || ! printf '%s' "$SEPARATE_GUARD_STDERR" | grep -q "guarded-separate"; then
+  fail "worktree-guard mistook a primary checkout for a linked worktree from a path substring"
 fi
 
 for hook in "$ROOT"/.claude/hooks/*.sh; do


### PR DESCRIPTION
## Summary

- count only exact Claude executable names on Windows and POSIX hosts
- identify linked worktrees from Git's per-worktree/common-dir metadata
- add must-fire and must-not-fire controls for process names, primary checkouts, linked worktrees, and separate Git directories

## Validation

- `tests/test-hooks.sh`
- `scripts/validate-all.sh` (572 Python tests with expected skips; all repository validators passed)
- `git diff --check origin/main...HEAD`
- exact-SHA authenticated Claude Fable 5 review: PASS
- exact-SHA free Hermes Inkling review: PASS

Closes #142
