### PR TITLE
fix: bind release staging and publication identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,43 +212,29 @@ jobs:
           fi
           test "$(git ls-remote origin "refs/tags/$TAG" | cut -f1)" = "$RELEASE_COMMIT"
 
-          if gh release view "$TAG" --json isDraft,isPrerelease > "$RUNNER_TEMP/existing-release.json" 2>/dev/null; then
-            python -c 'import json, os, pathlib; value=json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/existing-release.json").read_text()); assert value == {"isDraft": True, "isPrerelease": False}'
-            gh release download "$TAG" --dir "$RUNNER_TEMP/existing-assets"
-            python scripts/release-artifacts.py verify \
-              --artifacts "$RUNNER_TEMP/existing-assets" \
-              --extract-to "$RUNNER_TEMP/existing-extracted" \
-              --version "$VERSION" \
-              --tag "$TAG" \
-              --commit "$RELEASE_COMMIT" \
-              > "$RUNNER_TEMP/existing-verification.json"
-            diff --recursive --brief "$RUNNER_TEMP/assets" "$RUNNER_TEMP/existing-assets"
-          else
-            gh release create "$TAG" \
-              "$RUNNER_TEMP/assets/$ASSET_STEM.tar" \
-              "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
-              "$RUNNER_TEMP/assets/$ASSET_STEM.provenance.json" \
-              "$RUNNER_TEMP/assets/$ASSET_STEM.OFFLINE-VERIFY.md" \
-              "$RUNNER_TEMP/assets/SHA256SUMS" \
-              --draft \
-              --verify-tag \
-              --title "Context OS v0.12.0" \
-              --notes-file docs/releases/v0.12.0.md
-            READY=false
-            for attempt in 1 2 3 4 5; do
-              if gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null | grep -Fx true; then
-                READY=true
-                break
-              fi
-              sleep 2
-            done
-            if [[ "$READY" != "true" ]]; then
-              echo "draft release did not become readable" >&2
-              exit 1
-            fi
-          fi
-          RELEASE_ID=$(gh release view "$TAG" --json databaseId --jq .databaseId)
+          python scripts/stage-release.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$TAG" \
+            --title "Context OS v0.12.0" \
+            --notes-file docs/releases/v0.12.0.md \
+            --artifact "$RUNNER_TEMP/assets/$ASSET_STEM.tar" \
+            --artifact "$RUNNER_TEMP/assets/$ASSET_STEM.bundle.lock.json" \
+            --artifact "$RUNNER_TEMP/assets/$ASSET_STEM.provenance.json" \
+            --artifact "$RUNNER_TEMP/assets/$ASSET_STEM.OFFLINE-VERIFY.md" \
+            --artifact "$RUNNER_TEMP/assets/SHA256SUMS" \
+            > "$RUNNER_TEMP/staged-release.json"
+          RELEASE_ID=$(python -c 'import json, os, pathlib; print(json.loads(pathlib.Path(os.environ["RUNNER_TEMP"] + "/staged-release.json").read_text())["release_id"])')
           [[ "$RELEASE_ID" =~ ^[0-9]+$ ]]
+
+          gh release download "$TAG" --dir "$RUNNER_TEMP/existing-assets"
+          python scripts/release-artifacts.py verify \
+            --artifacts "$RUNNER_TEMP/existing-assets" \
+            --extract-to "$RUNNER_TEMP/existing-extracted" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT" \
+            > "$RUNNER_TEMP/existing-verification.json"
+          diff --recursive --brief "$RUNNER_TEMP/assets" "$RUNNER_TEMP/existing-assets"
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
   verify-draft-linux:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - The enabled Claude worktree guard now counts exact Claude executable names and identifies linked worktrees from Git's common-directory structure, with must-fire and must-not-fire controls for primary, linked, guarded, unguarded, and single-session paths.
+- Release draft staging now creates only after a classified HTTP 404, recovers duplicate-create races without re-uploading, and binds publication and recovery to an operator-supplied positive numeric release ID.
 
 ---
 

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -348,6 +348,10 @@
                     "policy": "development"
                 },
                 {
+                    "path": "scripts/stage-release.py",
+                    "policy": "development"
+                },
+                {
                     "path": "scripts/pre-commit-hook.sh",
                     "policy": "managed"
                 },
@@ -437,6 +441,10 @@
                 },
                 {
                     "path": "tests/test_release_artifacts.py",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_stage_release.py",
                     "policy": "development"
                 },
                 {

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -61,8 +61,11 @@ The workflow then fails closed through these gates:
    jobs, including execution of `python -m contextos bundle check` from the
    extracted archive;
 5. only after both candidate jobs pass, create or confirm the exact lightweight
-   tag through the GitHub API, stage all five assets in an unpublished draft,
-   and carry that draft's immutable numeric release ID through every later job;
+   tag through the GitHub API, classify the release-by-tag lookup by HTTP status,
+   and create only after an exact 404; auth, network, rate-limit, and server
+   failures stop the workflow. Stage all five assets in an unpublished draft,
+   recover a duplicate-create race by rereading the exact draft without another
+   upload, and carry its positive numeric release ID through every later job;
 6. download those staged release assets—not the Actions copies—and verify them
    again in separate Linux and Windows directories; and
 7. only after both staged-asset jobs pass, re-download the exact-run Actions
@@ -81,12 +84,14 @@ executable bits. That is an explicit limitation, not a skipped success.
 ## Local admin publication
 
 Publish only from a clean checkout of the exact commit named by the successful
-workflow. Use the checked-in publisher with the exact workflow run ID:
+workflow. Use the checked-in publisher with the exact workflow run ID and the
+positive numeric release ID reported by `stage-draft` and `ready-to-publish`:
 
 ```bash
 python scripts/publish-release.py \
   --repository conorbronsdon/agent-context-os \
   --run-id RUN_ID \
+  --release-id RELEASE_ID \
   --commit REVIEWED_40_HEX_COMMIT \
   --version 0.12.0 \
   --tag v0.12.0
@@ -104,7 +109,8 @@ irreversible numeric-release-ID PATCH, it requires all of the following:
 - local `HEAD` and the target repository's GitHub API `main` and
   `refs/tags/v0.12.0` equal the reviewed commit (the local `origin` is not an
   independent authority);
-- the numeric release is still a draft, is not a prerelease, and has the exact
+- the operator-selected numeric release is still a draft, is not a prerelease,
+  and has the exact
   tag, title, checked-in body, and five asset IDs/names/sizes/digests;
 - independently verified candidate and draft downloads are byte-identical, with
   the release state unchanged across repeated numeric-ID reads;
@@ -145,13 +151,16 @@ state, asset metadata, and attestation results.
 python scripts/publish-release.py \
   --repository conorbronsdon/agent-context-os \
   --run-id RUN_ID \
+  --release-id RELEASE_ID \
   --commit REVIEWED_40_HEX_COMMIT \
   --version 0.12.0 \
   --tag v0.12.0 \
   --verify-published
 ```
 
-This mode requires the numeric release to be published and immutable, repeats
+Both modes bind the numeric ID before any tag-based download; the tag is only an
+identity and attestation cross-check and never selects the PATCH target. This
+mode requires the numeric release to be published and immutable, repeats
 the run, attempt, artifact, repository-ref, metadata, byte, and attestation
 checks, and never issues a publication PATCH. Any post-publication integrity
 mismatch retires v0.12.0 rather than authorizing mutation.

--- a/scripts/publish-release.py
+++ b/scripts/publish-release.py
@@ -271,10 +271,16 @@ def _require_same_files(left: Path, right: Path, expected_names: set[str]) -> No
 
 
 def _release_by_id(runner: CommandRunner, repository: str, release_id: int) -> Any:
-    return runner.json([
+    value = runner.json([
         "gh", "api", "-H", "X-GitHub-Api-Version: 2026-03-10",
         f"repos/{repository}/releases/{release_id}",
     ])
+    _require(
+        isinstance(value, dict) and type(value.get("id")) is int
+        and value["id"] == release_id,
+        "release response does not match the selected numeric ID",
+    )
+    return value
 
 
 def _require_no_competing_runs(
@@ -340,7 +346,7 @@ def _recheck_run_attempt(
 
 
 def publish_release(
-    *, root: Path, repository: str, run_id: int, commit: str,
+    *, root: Path, repository: str, run_id: int, release_id: int, commit: str,
     version: str, tag: str, wait_attempts: int, wait_seconds: float,
     verify_published: bool = False,
     runner: CommandRunner | None = None,
@@ -350,6 +356,8 @@ def publish_release(
     _require(COMMIT_RE.fullmatch(commit) is not None, "commit must be exact lowercase 40-hex")
     _require(tag == f"v{version}", "tag must equal v<version>")
     _require(type(run_id) is int and run_id > 0, "run ID must be a positive integer")
+    _require(type(release_id) is int and release_id > 0,
+             "release ID must be a positive integer")
     _require(wait_attempts > 0 and wait_seconds >= 0, "attestation wait settings are invalid")
 
     _require(_git_text(runner, root, "rev-parse", "HEAD") == commit, "local HEAD is not the release commit")
@@ -375,12 +383,6 @@ def publish_release(
         runner, repository, run_id, version=version, commit=commit, attempt=attempt,
     )
 
-    release_id_text = runner.run([
-        "gh", "release", "view", tag, "--repo", repository,
-        "--json", "databaseId", "--jq", ".databaseId",
-    ]).stdout.strip()
-    _require(release_id_text.isdigit(), "draft release numeric ID is invalid")
-    release_id = int(release_id_text)
     expected_title = f"Context OS v{version}"
     expected_body = (root / f"docs/releases/v{version}.md").read_text(encoding="utf-8")
 
@@ -392,6 +394,13 @@ def publish_release(
         candidate.mkdir()
         release_assets.mkdir()
         published.mkdir()
+        expected_draft = not verify_published
+        first_state = _release_by_id(runner, repository, release_id)
+        first_snapshot = _asset_snapshot(
+            first_state, expected_names=expected_names, expected_tag=tag,
+            expected_title=expected_title, expected_body=expected_body,
+            draft=expected_draft,
+        )
         runner.download_artifact(repository, candidate_record, candidate, expected_names)
         _recheck_artifact(
             runner, repository, artifact=candidate_record, expected_name=candidate_name,
@@ -410,12 +419,6 @@ def publish_release(
         )
         _require_same_files(candidate, release_assets, expected_names)
 
-        expected_draft = not verify_published
-        first_state = _release_by_id(runner, repository, release_id)
-        first_snapshot = _asset_snapshot(
-            first_state, expected_names=expected_names, expected_tag=tag,
-            expected_title=expected_title, expected_body=expected_body, draft=expected_draft,
-        )
         _require_server_bytes(first_snapshot, release_assets)
         second_state = _release_by_id(runner, repository, release_id)
         second_snapshot = _asset_snapshot(
@@ -564,6 +567,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository", required=True)
     parser.add_argument("--run-id", type=int, required=True)
+    parser.add_argument("--release-id", type=int, required=True)
     parser.add_argument("--commit", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--tag", required=True)
@@ -577,6 +581,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         result = publish_release(
             root=ROOT, repository=args.repository, run_id=args.run_id,
+            release_id=args.release_id,
             commit=args.commit, version=args.version, tag=args.tag,
             wait_attempts=args.wait_attempts, wait_seconds=args.wait_seconds,
             verify_published=args.verify_published,

--- a/scripts/stage-release.py
+++ b/scripts/stage-release.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Create or recover one exact GitHub draft release without retrying uploads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+
+HTTP_STATUS_RE = re.compile(r"(?m)^HTTP/\S+\s+(\d{3})(?:\s|$)")
+
+
+class StageReleaseError(RuntimeError):
+    """Raised when draft lookup or creation cannot be proven safe."""
+
+
+class CommandRunner:
+    def run(
+        self, arguments: Sequence[str], *, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                list(arguments), check=check, capture_output=True,
+                text=True, encoding="utf-8",
+            )
+        except OSError as exc:
+            raise StageReleaseError(
+                "command could not start: " + " ".join(arguments)
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or "").strip()
+            raise StageReleaseError(
+                "command failed: " + " ".join(arguments)
+                + (f": {detail}" if detail else "")
+            ) from exc
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise StageReleaseError(message)
+
+
+def _normalized_body(value: str) -> str:
+    return value.replace("\r\n", "\n").rstrip("\n")
+
+
+def _included_json(completed: subprocess.CompletedProcess[str]) -> tuple[int, Any]:
+    output = completed.stdout.replace("\r\n", "\n")
+    statuses = HTTP_STATUS_RE.findall(output)
+    _require(bool(statuses), "release lookup did not expose an HTTP status")
+    status = int(statuses[-1])
+    if completed.returncode != 0:
+        if status == 404:
+            return status, None
+        detail = completed.stderr.strip()
+        raise StageReleaseError(
+            f"release lookup failed with HTTP {status}"
+            + (f": {detail}" if detail else "")
+        )
+    _require(200 <= status < 300, f"release lookup returned HTTP {status}")
+    separator = output.rfind("\n\n")
+    _require(separator >= 0, "release lookup response did not contain a body")
+    try:
+        return status, json.loads(output[separator + 2:])
+    except json.JSONDecodeError as exc:
+        raise StageReleaseError("release lookup did not return valid JSON") from exc
+
+
+def _lookup_by_tag(
+    runner: CommandRunner, repository: str, tag: str,
+) -> dict[str, Any] | None:
+    completed = runner.run([
+        "gh", "api", "--include", "-H", "X-GitHub-Api-Version: 2026-03-10",
+        f"repos/{repository}/releases/tags/{tag}",
+    ], check=False)
+    status, value = _included_json(completed)
+    if status == 404:
+        return None
+    _require(isinstance(value, dict), "release lookup response must be an object")
+    return value
+
+
+def _exact_draft(
+    value: Any, *, tag: str, title: str, body: str,
+) -> int:
+    _require(isinstance(value, dict), "draft release response must be an object")
+    release_id = value.get("id")
+    _require(type(release_id) is int and release_id > 0,
+             "draft release numeric ID is invalid")
+    _require(value.get("tag_name") == tag, "draft release tag does not match")
+    _require(value.get("name") == title, "draft release title does not match")
+    _require(_normalized_body(value.get("body") or "") == _normalized_body(body),
+             "draft release body does not match")
+    _require(value.get("draft") is True, "release is not an unpublished draft")
+    _require(value.get("prerelease") is False, "release must not be a prerelease")
+    return release_id
+
+
+def stage_release(
+    *, repository: str, tag: str, title: str, notes_file: Path,
+    artifacts: Sequence[Path], visibility_attempts: int = 5,
+    visibility_seconds: float = 2.0, runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    runner = runner or CommandRunner()
+    _require(bool(repository), "repository is required")
+    _require(bool(tag), "tag is required")
+    _require(bool(title), "title is required")
+    _require(visibility_attempts > 0 and visibility_seconds >= 0,
+             "visibility wait settings are invalid")
+    _require(notes_file.is_file(), "release notes file is absent")
+    artifact_paths = [path.absolute().resolve() for path in artifacts]
+    _require(len(artifact_paths) == 5, "exactly five release artifacts are required")
+    _require(len({path.name for path in artifact_paths}) == 5,
+             "release artifact names must be unique")
+    _require(all(path.is_file() for path in artifact_paths),
+             "one or more release artifacts are absent")
+    body = notes_file.read_text(encoding="utf-8")
+
+    existing = _lookup_by_tag(runner, repository, tag)
+    if existing is not None:
+        return {
+            "schema_version": 1,
+            "release_id": _exact_draft(existing, tag=tag, title=title, body=body),
+            "created_by_this_run": False,
+        }
+
+    create = runner.run([
+        "gh", "release", "create", tag,
+        *(str(path) for path in artifact_paths),
+        "--repo", repository, "--draft", "--verify-tag",
+        "--title", title, "--notes-file", str(notes_file),
+    ], check=False)
+
+    for attempt in range(visibility_attempts):
+        current = _lookup_by_tag(runner, repository, tag)
+        if current is not None:
+            return {
+                "schema_version": 1,
+                "release_id": _exact_draft(current, tag=tag, title=title, body=body),
+                "created_by_this_run": create.returncode == 0,
+            }
+        if attempt + 1 < visibility_attempts:
+            time.sleep(visibility_seconds)
+
+    detail = create.stderr.strip()
+    if create.returncode != 0:
+        raise StageReleaseError(
+            "release creation failed and no exact draft appeared"
+            + (f": {detail}" if detail else "")
+        )
+    raise StageReleaseError("created draft release did not become readable")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--notes-file", required=True, type=Path)
+    parser.add_argument("--artifact", action="append", required=True, type=Path)
+    parser.add_argument("--visibility-attempts", type=int, default=5)
+    parser.add_argument("--visibility-seconds", type=float, default=2.0)
+    args = parser.parse_args(argv)
+    try:
+        result = stage_release(
+            repository=args.repository, tag=args.tag, title=args.title,
+            notes_file=args.notes_file, artifacts=args.artifact,
+            visibility_attempts=args.visibility_attempts,
+            visibility_seconds=args.visibility_seconds,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+    except (StageReleaseError, OSError, UnicodeError, ValueError) as exc:
+        print(f"stage release: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -108,8 +108,6 @@ class FakeGitHubRunner:
             return self._completed(args, COMMIT + "\n")
         if args[:2] == ("git", "status"):
             return self._completed(args, "")
-        if args[:3] == ("gh", "release", "view"):
-            return self._completed(args, str(RELEASE_ID) + "\n")
         if args[:3] == ("gh", "release", "download"):
             destination = Path(args[args.index("--dir") + 1])
             for name, payload in self.payloads.items():
@@ -148,8 +146,10 @@ class FakeGitHubRunner:
             return {"artifacts": [self._artifact()]}
         if endpoint.endswith(f"/actions/artifacts/{ARTIFACT_ID}"):
             return self._artifact()
-        if endpoint.endswith(f"/releases/{RELEASE_ID}"):
+        if "/releases/" in endpoint and "/actions/" not in endpoint:
             if "PATCH" in args:
+                if not endpoint.endswith(f"/releases/{RELEASE_ID}"):
+                    raise AssertionError("PATCH targeted an unselected release")
                 self.patch_count += 1
                 self.published = True
                 self.immutable = True
@@ -171,10 +171,14 @@ class FakeGitHubRunner:
 
 
 class PublishReleaseTest(unittest.TestCase):
-    def _publish(self, fake: FakeGitHubRunner, *, verify_published: bool = False):
+    def _publish(
+        self, fake: FakeGitHubRunner, *, release_id: int = RELEASE_ID,
+        verify_published: bool = False,
+    ):
         with mock.patch.object(publish_release, "_load_release_artifacts", return_value=FakeArtifacts):
             return publish_release.publish_release(
-                root=ROOT, repository=REPOSITORY, run_id=RUN_ID, commit=COMMIT,
+                root=ROOT, repository=REPOSITORY, run_id=RUN_ID,
+                release_id=release_id, commit=COMMIT,
                 version=VERSION, tag=TAG, wait_attempts=1, wait_seconds=0,
                 verify_published=verify_published, runner=fake,
             )
@@ -189,7 +193,45 @@ class PublishReleaseTest(unittest.TestCase):
         patches = [call for call in fake.calls if "PATCH" in call]
         self.assertEqual(len(patches), 1)
         self.assertIn(f"repos/{REPOSITORY}/releases/{RELEASE_ID}", patches[0])
+        self.assertFalse(any(call[:3] == ("gh", "release", "view") for call in fake.calls))
         self.assertFalse(any(call[:3] == ("git", "ls-remote", "origin") for call in fake.calls))
+
+    def test_wrong_numeric_release_id_prevents_patch(self) -> None:
+        fake = FakeGitHubRunner(ROOT)
+        with self.assertRaisesRegex(
+            publish_release.PublishError, "selected numeric ID"
+        ):
+            self._publish(fake, release_id=RELEASE_ID + 1)
+        self.assertEqual(fake.patch_count, 0)
+        self.assertFalse(any("PATCH" in call for call in fake.calls))
+        self.assertFalse(
+            any(call[:3] == ("gh", "release", "download") for call in fake.calls)
+        )
+
+    def test_invalid_release_id_fails_before_runner_calls_in_both_modes(self) -> None:
+        for release_id in (0, -1, True):
+            for verify_published in (False, True):
+                with self.subTest(
+                    release_id=release_id, verify_published=verify_published
+                ):
+                    fake = FakeGitHubRunner(ROOT, published=verify_published)
+                    with self.assertRaisesRegex(
+                        publish_release.PublishError, "release ID must be"
+                    ):
+                        self._publish(
+                            fake, release_id=release_id,
+                            verify_published=verify_published,
+                        )
+                    self.assertEqual(fake.calls, [])
+                    self.assertEqual(fake.patch_count, 0)
+
+    def test_cli_requires_release_id(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            publish_release.main([
+                "--repository", REPOSITORY, "--run-id", str(RUN_ID),
+                "--commit", COMMIT, "--version", VERSION, "--tag", TAG,
+            ])
+        self.assertEqual(raised.exception.code, 2)
 
     def test_binary_artifact_download_binds_zip_digest_and_exact_files(self) -> None:
         payloads = {name: (name + "\n").encode() for name in FakeArtifacts.names.values()}
@@ -271,6 +313,13 @@ class PublishReleaseTest(unittest.TestCase):
         self.assertEqual(
             result["asset_attestations_verified"], sorted(FakeArtifacts.names.values())
         )
+
+    def test_read_only_published_verification_is_patch_free(self) -> None:
+        fake = FakeGitHubRunner(ROOT, published=True)
+        result = self._publish(fake, verify_published=True)
+        self.assertEqual(result["mode"], "verify-published")
+        self.assertEqual(fake.patch_count, 0)
+        self.assertFalse(any("PATCH" in call for call in fake.calls))
 
     def test_read_only_mode_rejects_draft_without_patch(self) -> None:
         fake = FakeGitHubRunner(ROOT)

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -266,7 +266,15 @@ class ReleaseArtifactTest(unittest.TestCase):
         self.assertNotIn("always()", workflow)
         self.assertEqual(workflow.count("contents: write"), 4)
         self.assertIn('-f "ref=refs/tags/$TAG"', workflow)
-        self.assertIn("--verify-tag", workflow)
+        staging = (ROOT / "scripts/stage-release.py").read_text(encoding="utf-8")
+        self.assertIn("--verify-tag", staging)
+        self.assertIn("python scripts/stage-release.py", workflow)
+        stage = workflow.split("  stage-draft:", 1)[1].split(
+            "  verify-draft-linux:", 1
+        )[0]
+        self.assertNotIn("gh release create", stage)
+        self.assertNotIn("gh release view", stage)
+        self.assertIn('echo "release_id=$RELEASE_ID"', stage)
         self.assertNotIn('--target "$RELEASE_COMMIT"', workflow)
         self.assertIn("retention-days: 7", workflow)
         build = workflow.split("  build-linux:", 1)[1].split(

--- a/tests/test_stage_release.py
+++ b/tests/test_stage_release.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "stage_release", ROOT / "scripts/stage-release.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+stage_release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(stage_release)
+
+
+REPOSITORY = "conorbronsdon/agent-context-os"
+TAG = "v0.12.0"
+TITLE = "Context OS v0.12.0"
+RELEASE_ID = 24680
+
+
+class FakeRunner:
+    def __init__(
+        self, responses: list[tuple[int | None, dict[str, object] | None]], *,
+        create_returncode: int = 0,
+    ) -> None:
+        self.responses = list(responses)
+        self.create_returncode = create_returncode
+        self.create_count = 0
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, arguments, *, check=True):
+        args = tuple(str(value) for value in arguments)
+        self.calls.append(args)
+        if args[:3] == ("gh", "api", "--include"):
+            if not self.responses:
+                raise AssertionError("unexpected lookup")
+            status, value = self.responses.pop(0)
+            if status is None:
+                return subprocess.CompletedProcess(args, 1, "", "transport failure")
+            body = json.dumps(value or {"message": "Not Found"})
+            output = f"HTTP/2.0 {status} status\r\ncontent-type: application/json\r\n\r\n{body}\n"
+            return subprocess.CompletedProcess(
+                args, 0 if 200 <= status < 300 else 1, output, f"HTTP {status}"
+            )
+        if args[:3] == ("gh", "release", "create"):
+            self.create_count += 1
+            return subprocess.CompletedProcess(
+                args, self.create_returncode, "", "duplicate" if self.create_returncode else ""
+            )
+        raise AssertionError(f"unexpected command: {args}")
+
+
+class StageReleaseTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        root = Path(self.temporary.name)
+        self.notes = root / "notes.md"
+        self.notes.write_text("release notes\n", encoding="utf-8")
+        self.artifacts = []
+        for index in range(5):
+            path = root / f"artifact-{index}"
+            path.write_text(str(index), encoding="utf-8")
+            self.artifacts.append(path)
+
+    def _release(self, **changes: object) -> dict[str, object]:
+        value: dict[str, object] = {
+            "id": RELEASE_ID, "tag_name": TAG, "name": TITLE,
+            "body": "release notes\n", "draft": True, "prerelease": False,
+        }
+        value.update(changes)
+        return value
+
+    def _stage(self, fake: FakeRunner):
+        return stage_release.stage_release(
+            repository=REPOSITORY, tag=TAG, title=TITLE,
+            notes_file=self.notes, artifacts=self.artifacts,
+            visibility_attempts=3, visibility_seconds=0, runner=fake,
+        )
+
+    def test_existing_exact_draft_is_reused_without_create(self) -> None:
+        fake = FakeRunner([(200, self._release())])
+        result = self._stage(fake)
+        self.assertEqual(result["release_id"], RELEASE_ID)
+        self.assertFalse(result["created_by_this_run"])
+        self.assertEqual(fake.create_count, 0)
+
+    def test_only_classified_404_creates_once(self) -> None:
+        fake = FakeRunner([(404, None), (200, self._release())])
+        result = self._stage(fake)
+        self.assertEqual(result["release_id"], RELEASE_ID)
+        self.assertTrue(result["created_by_this_run"])
+        self.assertEqual(fake.create_count, 1)
+
+    def test_auth_rate_limit_server_and_transport_fail_without_create(self) -> None:
+        for status in (401, 403, 429, 500, 503, None):
+            with self.subTest(status=status):
+                fake = FakeRunner([(status, None)])
+                with self.assertRaisesRegex(
+                    stage_release.StageReleaseError, "HTTP|status"
+                ):
+                    self._stage(fake)
+                self.assertEqual(fake.create_count, 0)
+
+    def test_duplicate_create_race_rereads_exact_draft_without_retry(self) -> None:
+        fake = FakeRunner(
+            [(404, None), (200, self._release())], create_returncode=1
+        )
+        result = self._stage(fake)
+        self.assertEqual(result["release_id"], RELEASE_ID)
+        self.assertFalse(result["created_by_this_run"])
+        self.assertEqual(fake.create_count, 1)
+
+    def test_create_failure_with_continued_404_fails_without_retry(self) -> None:
+        fake = FakeRunner(
+            [(404, None), (404, None), (404, None), (404, None)],
+            create_returncode=1,
+        )
+        with self.assertRaisesRegex(
+            stage_release.StageReleaseError, "creation failed"
+        ):
+            self._stage(fake)
+        self.assertEqual(fake.create_count, 1)
+
+    def test_malformed_existing_or_race_winner_fails_closed(self) -> None:
+        malformed = (
+            {"id": 0}, {"id": "24680"}, {"draft": False},
+            {"prerelease": True}, {"tag_name": "v0.12.1"},
+            {"name": "wrong"}, {"body": "wrong"},
+        )
+        for initial in (True, False):
+            for change in malformed:
+                with self.subTest(initial=initial, change=change):
+                    response = self._release(**change)
+                    sequence = [(200, response)] if initial else [
+                        (404, None), (200, response)
+                    ]
+                    fake = FakeRunner(sequence, create_returncode=1)
+                    with self.assertRaises(stage_release.StageReleaseError):
+                        self._stage(fake)
+                    self.assertEqual(fake.create_count, 0 if initial else 1)
+
+    def test_successful_create_tolerates_only_bounded_404_visibility_delay(self) -> None:
+        fake = FakeRunner([
+            (404, None), (404, None), (200, self._release()),
+        ])
+        result = self._stage(fake)
+        self.assertEqual(result["release_id"], RELEASE_ID)
+        self.assertEqual(fake.create_count, 1)
+
+    def test_post_create_fatal_lookup_is_not_reclassified_as_absent(self) -> None:
+        fake = FakeRunner([(404, None), (503, None)])
+        with self.assertRaisesRegex(stage_release.StageReleaseError, "HTTP 503"):
+            self._stage(fake)
+        self.assertEqual(fake.create_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- classify release-by-tag failures by HTTP status and create only after an exact 404
- recover duplicate-create races by rereading the exact draft without another upload
- require an operator-supplied positive numeric release ID for publication and read-only recovery
- add fake-CLI controls for lookup failures, race recovery, malformed drafts, wrong IDs, exact IDs, and PATCH-free verification

## Validation

- focused release suite: 31 tests passed
- `scripts/validate-all.sh`: 584 Python tests passed with 43 expected skips; all other repository validators passed
- strict-404 mutation made the new failure-classification control fail as expected
- exact-SHA authenticated Claude Fable 5 review: PASS
- exact-SHA free Hermes Inkling review: PASS

Closes #143
