### PR TITLE
docs: route integration prose to generated catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   colocated v0.12 command form remains compatible.
 
 ### Fixed
+- README and launch copy now route readers to the generated integration catalog
+  and chooser as the current inventory instead of freezing incomplete lists in
+  hand-maintained prose.
 - The enabled Claude worktree guard now counts exact Claude executable names and identifies linked worktrees from Git's common-directory structure, with must-fire and must-not-fire controls for primary, linked, guarded, unguarded, and single-session paths.
 - Release draft staging now creates only after a classified HTTP 404, recovers duplicate-create races without re-uploading, and binds publication and recovery to an operator-supplied positive numeric release ID.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,11 @@ The [optional integrations catalog](references/integrations.md) is generated fro
 
 Start with the task-based [integration chooser](docs/integrations-guide.md), add at most one new trust boundary at a time, then read the selected generated entry in full.
 
-The current catalog includes portable skill collections and creator tools, plus reviewed paths for MarkItDown MCP, Tolaria MCP, Obsidian CLI, Beads for Gemini CLI, Granola MCP, Google Workspace CLI, Notion MCP, and Substack MCP. `listed` and `experimental` entries are leads, not endorsements. Setup never installs, authenticates, or activates them.
+The catalog spans portable skill collections, creator tools, CLIs, and MCP
+servers. Treat the generated catalog and task-based chooser as the current
+inventory rather than relying on a hand-maintained summary. `listed` and
+`experimental` entries are leads, not endorsements. Setup never installs,
+authenticates, or activates them.
 
 ## Repository layout
 

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -44,7 +44,12 @@ Context OS update:
 
 Codex is now a first-class path, not a fork. The same repository state powers `$setup`, `$start`, `$update`, and `$end`, while Claude Code keeps its slash-command adapters.
 
-The optional integration catalog now covers portable skill collections and creator tools, plus reviewed paths for Tolaria, Obsidian, Beads, Granola, Google Workspace, Notion, and Substack. Each entry declares data access, side effects, confirmation gates, evidence, health checks, and uninstall behavior.
+The optional integration catalog covers portable skill collections, creator
+tools, CLIs, and MCP servers. The [generated catalog](../references/integrations.md)
+and its source, [`integrations/catalog.json`](../integrations/catalog.json), are
+the current inventory rather than this launch summary. Each entry declares data
+access, side effects, confirmation gates, evidence, health checks, and uninstall
+behavior.
 
 I also rewrote the onboarding and migration docs around the actual user journey: bring forward selected context, choose a host, add only the tools you need, and keep the result current.
 

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -146,13 +146,26 @@ class DocumentationPositioningTests(unittest.TestCase):
         self.assertIn("not live authentication", guide)
 
     def test_integration_prose_routes_to_the_generated_current_inventory(self) -> None:
-        for path in ("README.md", "docs/launch-copy.md"):
-            prose = self.text(path)
+        catalog = json.loads(self.text("integrations/catalog.json"))
+        sections = {
+            "README.md": self.text("README.md")
+            .split("## Optional integrations", 1)[1]
+            .split("\n## ", 1)[0],
+            "docs/launch-copy.md": self.text("docs/launch-copy.md")
+            .split("## Changelog post", 1)[1]
+            .split("\n## ", 1)[0],
+        }
+        for path, prose in sections.items():
             normalized = re.sub(r"\s+", " ", prose.casefold())
             self.assertIn("generated catalog", normalized, path)
             self.assertIn("current inventory", normalized, path)
-            self.assertNotRegex(
-                normalized, r"current catalog includes|catalog now covers"
+            enumerated = [
+                item["name"]
+                for item in catalog["integrations"]
+                if item["name"].casefold() in normalized
+            ]
+            self.assertEqual(
+                [], enumerated, f"{path} must not enumerate catalog entries"
             )
         self.assertIn("references/integrations.md", self.text("README.md"))
         launch = self.text("docs/launch-copy.md")

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -145,6 +145,20 @@ class DocumentationPositioningTests(unittest.TestCase):
         self.assertIn("Nothing in this guide installs", guide)
         self.assertIn("not live authentication", guide)
 
+    def test_integration_prose_routes_to_the_generated_current_inventory(self) -> None:
+        for path in ("README.md", "docs/launch-copy.md"):
+            prose = self.text(path)
+            normalized = re.sub(r"\s+", " ", prose.casefold())
+            self.assertIn("generated catalog", normalized, path)
+            self.assertIn("current inventory", normalized, path)
+            self.assertNotRegex(
+                normalized, r"current catalog includes|catalog now covers"
+            )
+        self.assertIn("references/integrations.md", self.text("README.md"))
+        launch = self.text("docs/launch-copy.md")
+        self.assertIn("../references/integrations.md", launch)
+        self.assertIn("../integrations/catalog.json", launch)
+
     def test_uncataloged_integrations_are_not_live(self) -> None:
         tracked_mcp = subprocess.run(
             ["git", "ls-files", "--", ".mcp.json"],


### PR DESCRIPTION
Closes #145

## Summary
- Replace incomplete named integration lists with durable positioning language.
- Route readers to the generated catalog and chooser as the current inventory.
- Add section-scoped regression coverage that rejects catalog-entry enumeration.

## Validation
- python -m unittest tests.test_docs_positioning (24 passed)
- python scripts/integrations.py check
- bash scripts/validate-all.sh at 5d5743e (626 passed, 47 skipped; all validation passed)
- Hosted Linux, Windows, and minimum-Python checks passed at 5d5743e

## Exact-SHA review
- claude-sonnet-5 reviewed 5d5743e0c71078ef6dbdc8ff1cbf2f7287e9e8a1
- thinkingmachines/inkling:free reviewed 5d5743e0c71078ef6dbdc8ff1cbf2f7287e9e8a1
- Repair cycle 1 strengthened the stale-list invariant; final post-main-merge reviews found no remaining defect
- Changelog-only conflict resolution retained both #144 and #145 entries