### PR TITLE
fix: make secret filename tripwire path-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   colocated v0.12 command form remains compatible.
 
 ### Fixed
+- The pre-commit secret filename tripwire now checks nested basenames and reads
+  staged paths NUL-safely, including names with spaces and rename destinations,
+  while allowing deletions. It remains a limited tripwire, not content scanning.
 - The enabled Claude worktree guard now counts exact Claude executable names and identifies linked worktrees from Git's common-directory structure, with must-fire and must-not-fire controls for primary, linked, guarded, unguarded, and single-session paths.
 - Release draft staging now creates only after a classified HTTP 404, recovers duplicate-create races without re-uploading, and binds publication and recovery to an operator-supplied positive numeric release ID.
 

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -57,7 +57,7 @@ while IFS= read -r -d '' staged_file; do
       ERRORS+=("BLOCKED: $staged_file looks like a secrets file. Remove from staging.")
       ;;
   esac
-done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
+done < <(git diff --cached --name-only --diff-filter=ACMRT -z 2>/dev/null)
 
 # ── Report ───────────────────────────────────────────────────────────────────
 

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -32,7 +32,7 @@ fi
 
 CONTEXT_LIMIT=300
 
-for staged_file in $(git diff --cached --name-only --diff-filter=ACM 2>/dev/null); do
+while IFS= read -r -d '' staged_file; do
   case "$staged_file" in
     identity/*|projects/*/skills/*)
       if [ -f "$staged_file" ]; then
@@ -43,17 +43,21 @@ for staged_file in $(git diff --cached --name-only --diff-filter=ACM 2>/dev/null
       fi
       ;;
   esac
-done
+done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
 
 # ── 4. Prevent committing common secret files ───────────────────────────────
 
-for staged_file in $(git diff --cached --name-only 2>/dev/null); do
-  case "$staged_file" in
+# This is a filename tripwire, not a content scanner. Match the basename so
+# nested secret files cannot bypass it, and exclude deletions so the hook never
+# tries to block removal of an already tracked secret.
+while IFS= read -r -d '' staged_file; do
+  staged_basename=${staged_file##*/}
+  case "$staged_basename" in
     .env|.env.*|credentials.json|token.json|client_secret*)
       ERRORS+=("BLOCKED: $staged_file looks like a secrets file. Remove from staging.")
       ;;
   esac
-done
+done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
 
 # ── Report ───────────────────────────────────────────────────────────────────
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -223,6 +223,89 @@ if [ "$SEPARATE_GUARD_STATUS" -ne 2 ] || ! printf '%s' "$SEPARATE_GUARD_STDERR" 
   fail "worktree-guard mistook a primary checkout for a linked worktree from a path substring"
 fi
 
+prepare_precommit_repo() {
+  local repo=$1
+  mkdir -p "$repo/scripts"
+  git -C "$repo" init -q -b main
+  cp "$ROOT/scripts/pre-commit-hook.sh" "$repo/scripts/pre-commit-hook.sh"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$repo/scripts/validate-skills.sh"
+}
+
+# The filename tripwire must inspect basenames at any depth and preserve paths
+# containing spaces without splitting them into separate candidates.
+PRECOMMIT_BLOCK_REPO="$TEMP_ROOT_WIN/precommit-block"
+prepare_precommit_repo "$PRECOMMIT_BLOCK_REPO"
+mkdir -p "$PRECOMMIT_BLOCK_REPO/config" "$PRECOMMIT_BLOCK_REPO/secrets" \
+  "$PRECOMMIT_BLOCK_REPO/space dir"
+printf 'secret\n' > "$PRECOMMIT_BLOCK_REPO/.env"
+printf 'secret\n' > "$PRECOMMIT_BLOCK_REPO/config/.env.local"
+printf 'secret\n' > "$PRECOMMIT_BLOCK_REPO/secrets/token.json"
+printf 'secret\n' > "$PRECOMMIT_BLOCK_REPO/space dir/credentials.json"
+git -C "$PRECOMMIT_BLOCK_REPO" add -f -- .env config/.env.local \
+  secrets/token.json "space dir/credentials.json"
+set +e
+PRECOMMIT_BLOCK_OUTPUT=$(cd "$PRECOMMIT_BLOCK_REPO" && bash scripts/pre-commit-hook.sh 2>&1)
+PRECOMMIT_BLOCK_STATUS=$?
+set -e
+[ "$PRECOMMIT_BLOCK_STATUS" -eq 1 ] \
+  || fail "pre-commit secret tripwire did not block nested and spaced secret filenames"
+for blocked_path in .env config/.env.local secrets/token.json "space dir/credentials.json"; do
+  printf '%s' "$PRECOMMIT_BLOCK_OUTPUT" | grep -Fq "BLOCKED: $blocked_path looks like a secrets file" \
+    || fail "pre-commit secret tripwire omitted $blocked_path"
+done
+
+# Deletions must remain possible, and ordinary filenames that merely contain a
+# secret-looking name must not fire the basename rules.
+PRECOMMIT_SAFE_REPO="$TEMP_ROOT_WIN/precommit-safe"
+prepare_precommit_repo "$PRECOMMIT_SAFE_REPO"
+printf 'tracked secret\n' > "$PRECOMMIT_SAFE_REPO/token.json"
+git -C "$PRECOMMIT_SAFE_REPO" add -f -- token.json
+git -C "$PRECOMMIT_SAFE_REPO" -c user.name=Test -c user.email=test@example.invalid \
+  commit -qm baseline
+rm "$PRECOMMIT_SAFE_REPO/token.json"
+mkdir -p "$PRECOMMIT_SAFE_REPO/config" "$PRECOMMIT_SAFE_REPO/notes with spaces"
+printf 'safe\n' > "$PRECOMMIT_SAFE_REPO/config/credentials.json.example"
+printf 'safe\n' > "$PRECOMMIT_SAFE_REPO/notes with spaces/token.json.md"
+printf 'safe\n' > "$PRECOMMIT_SAFE_REPO/client-secret.txt"
+git -C "$PRECOMMIT_SAFE_REPO" add -A -- token.json config/credentials.json.example \
+  "notes with spaces/token.json.md" client-secret.txt
+PRECOMMIT_SAFE_OUTPUT=$(cd "$PRECOMMIT_SAFE_REPO" && bash scripts/pre-commit-hook.sh 2>&1) \
+  || fail "pre-commit secret tripwire blocked a deletion or near-miss filename"
+printf '%s' "$PRECOMMIT_SAFE_OUTPUT" | grep -Fq 'Pre-commit checks passed' \
+  || fail "pre-commit hook omitted its success result for safe staged paths"
+
+# A rename into a secret basename is an addition at the destination and must
+# still fire even though the source is removed.
+PRECOMMIT_RENAME_REPO="$TEMP_ROOT_WIN/precommit-rename"
+prepare_precommit_repo "$PRECOMMIT_RENAME_REPO"
+printf 'ordinary\n' > "$PRECOMMIT_RENAME_REPO/settings.json"
+git -C "$PRECOMMIT_RENAME_REPO" add settings.json
+git -C "$PRECOMMIT_RENAME_REPO" -c user.name=Test -c user.email=test@example.invalid \
+  commit -qm baseline
+mkdir -p "$PRECOMMIT_RENAME_REPO/nested"
+git -C "$PRECOMMIT_RENAME_REPO" mv settings.json nested/token.json
+set +e
+PRECOMMIT_RENAME_OUTPUT=$(cd "$PRECOMMIT_RENAME_REPO" && bash scripts/pre-commit-hook.sh 2>&1)
+PRECOMMIT_RENAME_STATUS=$?
+set -e
+if [ "$PRECOMMIT_RENAME_STATUS" -ne 1 ] || \
+  ! printf '%s' "$PRECOMMIT_RENAME_OUTPUT" | grep -Fq \
+    'BLOCKED: nested/token.json looks like a secrets file'; then
+  fail "pre-commit secret tripwire did not block a rename into a secret basename"
+fi
+
+# Context warnings use the same NUL-safe staged-path transport.
+PRECOMMIT_CONTEXT_REPO="$TEMP_ROOT_WIN/precommit-context"
+prepare_precommit_repo "$PRECOMMIT_CONTEXT_REPO"
+mkdir -p "$PRECOMMIT_CONTEXT_REPO/identity"
+seq 301 > "$PRECOMMIT_CONTEXT_REPO/identity/large context.md"
+git -C "$PRECOMMIT_CONTEXT_REPO" add "identity/large context.md"
+PRECOMMIT_CONTEXT_OUTPUT=$(cd "$PRECOMMIT_CONTEXT_REPO" && bash scripts/pre-commit-hook.sh 2>&1) \
+  || fail "pre-commit hook blocked a large context warning fixture"
+printf '%s' "$PRECOMMIT_CONTEXT_OUTPUT" | grep -Fq \
+  'identity/large context.md is 301 lines' \
+  || fail "pre-commit context warning split a staged path containing spaces"
+
 for hook in "$ROOT"/.claude/hooks/*.sh; do
   bash -n "$hook"
 done

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -294,6 +294,30 @@ if [ "$PRECOMMIT_RENAME_STATUS" -ne 1 ] || \
   fail "pre-commit secret tripwire did not block a rename into a secret basename"
 fi
 
+# A staged type change still modifies a secret basename and must not disappear
+# when deletions are excluded from the diff filter.
+PRECOMMIT_TYPECHANGE_REPO="$TEMP_ROOT_WIN/precommit-typechange"
+prepare_precommit_repo "$PRECOMMIT_TYPECHANGE_REPO"
+mkdir -p "$PRECOMMIT_TYPECHANGE_REPO/nested"
+printf 'ordinary\n' > "$PRECOMMIT_TYPECHANGE_REPO/nested/token.json"
+git -C "$PRECOMMIT_TYPECHANGE_REPO" add -f -- nested/token.json
+git -C "$PRECOMMIT_TYPECHANGE_REPO" -c user.name=Test -c user.email=test@example.invalid \
+  commit -qm baseline
+TYPECHANGE_BLOB=$(printf 'link-target\n' | \
+  git -C "$PRECOMMIT_TYPECHANGE_REPO" hash-object -w --stdin)
+git -C "$PRECOMMIT_TYPECHANGE_REPO" update-index \
+  --cacheinfo 120000,"$TYPECHANGE_BLOB",nested/token.json
+set +e
+PRECOMMIT_TYPECHANGE_OUTPUT=$(cd "$PRECOMMIT_TYPECHANGE_REPO" && \
+  bash scripts/pre-commit-hook.sh 2>&1)
+PRECOMMIT_TYPECHANGE_STATUS=$?
+set -e
+if [ "$PRECOMMIT_TYPECHANGE_STATUS" -ne 1 ] || \
+  ! printf '%s' "$PRECOMMIT_TYPECHANGE_OUTPUT" | grep -Fq \
+    'BLOCKED: nested/token.json looks like a secrets file'; then
+  fail "pre-commit secret tripwire did not block a secret basename type change"
+fi
+
 # Context warnings use the same NUL-safe staged-path transport.
 PRECOMMIT_CONTEXT_REPO="$TEMP_ROOT_WIN/precommit-context"
 prepare_precommit_repo "$PRECOMMIT_CONTEXT_REPO"


### PR DESCRIPTION
Closes #144

## Summary
- Read staged paths NUL-safely in the context-warning and secret filename checks.
- Match secret rules against basenames at any directory depth while allowing deletions and checking rename destinations and type changes.
- Add must-fire and must-not-fire controls for nested paths, spaces, deletions, renames, type changes, near-misses, and large context filenames.
- Preserve the documented boundary: this is a limited filename tripwire, not content scanning.

## Validation
- bash -n scripts/pre-commit-hook.sh tests/test-hooks.sh
- bash tests/test-hooks.sh
- bash scripts/validate-all.sh at b953221 (625 passed, 47 skipped; all validation passed)
- Hosted Linux, Windows, and minimum-Python checks passed at b953221
- git diff --check

## Exact-SHA review
- claude-opus-5 reviewed b9532214d309b41fe5338c1cd26395b1d09fc4d9
- thinkingmachines/inkling:free reviewed b9532214d309b41fe5338c1cd26395b1d09fc4d9
- Repair cycle 1 restored staged type-change coverage; both reruns found no remaining in-scope defect