### PR TITLE
Workspace schema v2 and guided reconciliation

### DIFF
--- a/components/manifest.json
+++ b/components/manifest.json
@@ -108,6 +108,10 @@
                     "policy": "managed"
                 },
                 {
+                    "path": "contextos/installed_state.py",
+                    "policy": "managed"
+                },
+                {
                     "path": "contextos/coordination.py",
                     "policy": "managed"
                 },
@@ -129,6 +133,14 @@
                 },
                 {
                     "path": "contextos/workspace_schema.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/workspace_composition.py",
+                    "policy": "managed"
+                },
+                {
+                    "path": "contextos/workspace_projection.py",
                     "policy": "managed"
                 },
                 {
@@ -521,6 +533,10 @@
                 },
                 {
                     "path": "tests/fixtures/workspace-migrations.json",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/fixtures/workspace-v2-migrations.json",
                     "policy": "development"
                 },
                 {

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -614,11 +614,12 @@ def verify_bundle(
     """Verify all bytes, retaining either every payload or only requested paths.
 
     Verification streams one source payload at a time. With ``retain_paths`` the
-    peak raw-payload-buffer bound is that set plus verified Markdown needed for
-    closure-aware projection, manifest/runtime descriptor bytes needed for
-    schema validation, and the current and preceding source payloads during
-    generator handoff. Text normalization and directory snapshot assembly have
-    separate transient allocations.
+    peak raw-payload-buffer bound is that exact set plus manifest/runtime
+    descriptor bytes needed for schema validation and the current and preceding
+    source payloads during generator handoff. Selected-profile projection runs a
+    separate verification with its owned Markdown paths as ``retain_paths``.
+    Text normalization and directory snapshot assembly have separate transient
+    allocations.
     """
     expected_sha256 = _sha256(expected_sha256, "expected_sha256")
     lock_path = lock_path.absolute()
@@ -804,13 +805,6 @@ def _projected_records(
                 source_mode=bundle.source_mode,
                 role=bundle.role,
                 retain_paths=projection_paths,
-            )
-        missing_inputs = set(projection_paths) - set(projected_bundle.verified_bytes)
-        if missing_inputs:
-            _fail(
-                "projection_inputs",
-                "verified Markdown inputs are missing: "
-                + ", ".join(sorted(missing_inputs, key=portable_path_identity)),
             )
         try:
             source_texts = {

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -35,6 +35,7 @@ from .primitives import (
     sha256_bytes,
 )
 from .workspace_schema import (
+    LEGACY_WORKSPACE_SCHEMA_VERSION,
     WORKSPACE_SCHEMA_VERSION,
     WorkspaceConfigError,
     render_workspace_config,
@@ -42,6 +43,12 @@ from .workspace_schema import (
     validate_workspace_config,
     validate_workspace_path,
 )
+from .workspace_composition import (
+    WorkspaceCompositionError,
+    component_ids as workspace_component_ids,
+    desired_component_closure,
+)
+from .workspace_projection import closure_aware_files
 
 
 BUNDLE_LOCK_SCHEMA_VERSION = 1
@@ -763,8 +770,48 @@ def _owned_records(bundle: VerifiedBundle, component_ids: Sequence[str]) -> dict
     }
 
 
+def _projected_records(
+    bundle: VerifiedBundle,
+    config: dict[str, Any],
+    component_ids: Sequence[str],
+    records: dict[str, dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    source_texts = {
+        path: bundle.verified_bytes[path].decode("utf-8")
+        for path in records
+        if path.endswith(".md") and path in bundle.verified_bytes
+    }
+    generated = closure_aware_files(
+        config,
+        bundle.runtimes,
+        component_ids,
+        source_texts=source_texts,
+        available_paths=tuple(bundle.records),
+    )
+    projected = {path: dict(record) for path, record in records.items()}
+    for path, text in generated.items():
+        if path not in projected:
+            continue
+        payload = text.encode("utf-8")
+        projected[path].update(
+            {
+                "sha256_raw": sha256_bytes(payload),
+                "sha256_text_lf": sha256_bytes(payload),
+                "size": len(payload),
+                "executable": False,
+            }
+        )
+    return projected, {
+        path: text for path, text in generated.items() if path in projected
+    }
+
+
 def _runtime_ids(bundle: VerifiedBundle) -> list[str]:
     return sorted(bundle.runtimes)
+
+
+def _component_ids(bundle: VerifiedBundle) -> list[str]:
+    return workspace_component_ids(bundle.manifest)
 
 
 def _configured_components(bundle: VerifiedBundle, agents: Sequence[str]) -> list[str]:
@@ -774,6 +821,34 @@ def _configured_components(bundle: VerifiedBundle, agents: Sequence[str]) -> lis
             _fail("workspace.agents", f"runtime {agent!r} is unavailable in the bundle")
         requested.update(bundle.runtimes[agent]["components"])
     return _component_closure(bundle.manifest, sorted(requested))
+
+
+def _workspace_template(bundle: VerifiedBundle, schema_version: int) -> dict[str, str]:
+    template = {"source": bundle.name, "version": bundle.version}
+    if schema_version != LEGACY_WORKSPACE_SCHEMA_VERSION:
+        template["bundle_sha256"] = bundle.digest
+    return template
+
+
+def _desired_components(
+    bundle: VerifiedBundle,
+    config: dict[str, Any],
+    supplied_components: Sequence[str],
+) -> list[str]:
+    supplied = _component_closure(bundle.manifest, supplied_components)
+    if config["schema_version"] == LEGACY_WORKSPACE_SCHEMA_VERSION:
+        return supplied
+
+    try:
+        desired = desired_component_closure(config, bundle.manifest, bundle.runtimes)
+    except (WorkspaceCompositionError, ComponentManifestError) as exc:
+        _fail("workspace.composition", str(exc))
+    if supplied != desired:
+        _fail(
+            "desired_components",
+            "must equal the closure derived from workspace schema v2",
+        )
+    return desired
 
 
 def _assert_bundle_current(bundle: VerifiedBundle, field: str) -> None:
@@ -796,6 +871,7 @@ def create_structural_plan(
     desired_components: Sequence[str],
     current: VerifiedBundle | None = None,
     current_components: Sequence[str] = (),
+    intended_workspace: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic, digest-bound plan without mutating either tree."""
     target_root = _source_root(target_root, "target_root")
@@ -828,18 +904,42 @@ def create_structural_plan(
             config_bytes.decode("utf-8"), source=config_relative
         )
         config = validate_workspace_config(
-            config_value, known_runtime_ids=_runtime_ids(candidate)
+            config_value,
+            known_runtime_ids=_runtime_ids(candidate),
+            known_component_ids=_component_ids(candidate),
         )
     except (UnicodeError, WorkspaceConfigError) as exc:
         raise BundleError(str(exc)) from exc
-    if config["template"] != {"source": authority.name, "version": authority.version}:
+    if config["template"] != _workspace_template(
+        authority, config["schema_version"]
+    ):
         authority_role = "current" if current is not None else "candidate"
         _fail(
             "workspace.template",
             f"does not match the {authority_role} bundle identity",
         )
-    desired_ids = _component_closure(candidate.manifest, desired_components)
-    required_desired_ids = _configured_components(candidate, config["agents"])
+    if intended_workspace is None:
+        intended = {
+            **config,
+            "template": _workspace_template(candidate, config["schema_version"]),
+        }
+    else:
+        try:
+            intended = validate_workspace_config(
+                intended_workspace,
+                known_runtime_ids=_runtime_ids(candidate),
+                known_component_ids=_component_ids(candidate),
+            )
+        except WorkspaceConfigError as exc:
+            raise BundleError(str(exc)) from exc
+        if intended["schema_version"] != WORKSPACE_SCHEMA_VERSION:
+            _fail("intended_workspace.schema_version", "must equal schema v2")
+        if intended["paths"] != config["paths"]:
+            _fail("intended_workspace.paths", "path changes require a separate migration")
+        if intended["template"] != _workspace_template(candidate, WORKSPACE_SCHEMA_VERSION):
+            _fail("intended_workspace.template", "does not match the candidate bundle pin")
+    desired_ids = _desired_components(candidate, intended, desired_components)
+    required_desired_ids = _configured_components(candidate, intended["agents"])
     if not set(required_desired_ids).issubset(desired_ids):
         missing = sorted(
             set(required_desired_ids) - set(desired_ids), key=portable_path_identity
@@ -848,12 +948,22 @@ def create_structural_plan(
             "desired_components",
             "omits components required by configured agents: " + ", ".join(missing),
         )
-    desired = _owned_records(candidate, desired_ids)
+    desired, generated_files = _projected_records(
+        candidate,
+        intended,
+        desired_ids,
+        _owned_records(candidate, desired_ids),
+    )
     base: dict[str, dict[str, Any]] = {}
     current_ids: list[str] = []
     if current is not None:
         current_ids = _component_closure(current.manifest, current_components)
-        base = _owned_records(current, current_ids)
+        base, _current_generated = _projected_records(
+            current,
+            config,
+            current_ids,
+            _owned_records(current, current_ids),
+        )
         all_current_ids = [item["id"] for item in current.manifest["components"]]
         all_current = _owned_records(current, all_current_ids)
         for relative in sorted(set(all_current) - set(base), key=portable_path_identity):
@@ -886,7 +996,12 @@ def create_structural_plan(
         policy = (after or before)["policy"]
         if before is None:
             if observed is not None:
-                if policy == "seed":
+                if _matches_base(observed_value, after_value):
+                    action, reason = (
+                        "noop",
+                        "unrecorded path already matches the selected bundle",
+                    )
+                elif policy == "seed":
                     action, reason = (
                         "preserve-seed",
                         "pre-existing seed path remains user-owned",
@@ -961,12 +1076,10 @@ def create_structural_plan(
             "current_source": current.mode_verified if current is not None else None,
             "target": os.name != "nt",
         },
-        "intended_workspace": {
-            **config,
-            "template": {"source": candidate.name, "version": candidate.version},
-        },
+        "intended_workspace": intended,
         "current_components": current_ids,
         "desired_components": desired_ids,
+        "generated_files": generated_files,
         "actions": actions,
     }
     return {
@@ -991,16 +1104,15 @@ def create_initial_structural_plan(
         raise BundleError(f"cannot compare source and target roots: {exc}") from exc
     try:
         config = validate_workspace_config(
-            workspace_config, known_runtime_ids=_runtime_ids(candidate)
+            workspace_config,
+            known_runtime_ids=_runtime_ids(candidate),
+            known_component_ids=_component_ids(candidate),
         )
     except WorkspaceConfigError as exc:
         raise BundleError(str(exc)) from exc
-    if config["template"] != {
-        "source": candidate.name,
-        "version": candidate.version,
-    }:
+    if config["template"] != _workspace_template(candidate, config["schema_version"]):
         _fail("workspace.template", "does not match the candidate bundle identity")
-    desired_ids = _component_closure(candidate.manifest, desired_components)
+    desired_ids = _desired_components(candidate, config, desired_components)
     required_desired_ids = _configured_components(candidate, config["agents"])
     if not set(required_desired_ids).issubset(desired_ids):
         missing = sorted(
@@ -1010,7 +1122,12 @@ def create_initial_structural_plan(
             "desired_components",
             "omits components required by configured agents: " + ", ".join(missing),
         )
-    desired = _owned_records(candidate, desired_ids)
+    desired, generated_files = _projected_records(
+        candidate,
+        config,
+        desired_ids,
+        _owned_records(candidate, desired_ids),
+    )
     actions: list[dict[str, Any]] = []
     for relative in sorted(desired, key=portable_path_identity):
         after = desired[relative]
@@ -1066,6 +1183,7 @@ def create_initial_structural_plan(
         "intended_workspace": config,
         "current_components": [],
         "desired_components": desired_ids,
+        "generated_files": generated_files,
         "actions": actions,
     }
     return {

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -614,15 +614,22 @@ def verify_bundle(
     """Verify all bytes, retaining either every payload or only requested paths.
 
     Verification streams one source payload at a time. With ``retain_paths`` the
-    peak raw-payload-buffer bound is the retained set plus the manifest/runtime
-    descriptor bytes needed for schema validation plus the current and
-    preceding source payloads during generator handoff. Text normalization and
-    directory snapshot assembly have separate transient allocations.
+    peak raw-payload-buffer bound is that set plus verified Markdown needed for
+    closure-aware projection, manifest/runtime descriptor bytes needed for
+    schema validation, and the current and preceding source payloads during
+    generator handoff. Text normalization and directory snapshot assembly have
+    separate transient allocations.
     """
     expected_sha256 = _sha256(expected_sha256, "expected_sha256")
     lock_path = lock_path.absolute()
     lock = load_bundle_lock(lock_path)
     _validate_compatibility(lock, role)
+    compatibility = lock["bundle"]["compatibility"]
+    projection_capable = role == "candidate" or (
+        compatibility["runtime_descriptor_schema"]
+        == RUNTIME_DESCRIPTOR_SCHEMA_VERSION
+        and compatibility["workspace_schema"] == WORKSPACE_SCHEMA_VERSION
+    )
     if lock["bundle_sha256"] != expected_sha256:
         _fail("expected_sha256", "does not match the supplied bundle lock")
     root = _source_root(source_root, "source_root")
@@ -635,12 +642,17 @@ def verify_bundle(
             _fail("bundle.source_git_commit", "does not match the local Git HEAD commit")
     records = {item["path"]: item for item in lock["bundle"]["files"]}
     requested = set(records) if retain_paths is None else set(retain_paths)
+    # Selected-profile projection must be computed from the exact verified
+    # Markdown bytes at both proposal and apply boundaries. Retain those inputs
+    # consistently even when callers otherwise request a payload-bounded view.
+    if projection_capable and retain_paths is not None:
+        requested.update(path for path in records if path.endswith(".md"))
     unknown = requested - set(records)
     if unknown:
         _fail("retain_paths", "contains paths absent from the bundle: " + ", ".join(sorted(unknown)))
     manifest_relative = lock["bundle"]["component_manifest_path"]
     schema_paths = {manifest_relative}
-    if role == "candidate":
+    if projection_capable:
         schema_paths.update(
             path for path in records
             if len(PurePosixPath(path).parts) == 2
@@ -690,7 +702,7 @@ def verify_bundle(
         _fail("bundle.files", "does not equal the non-development component inventory: " + "; ".join(details))
     runtimes = (
         _validated_runtimes(verified_bytes, manifest, root=root)
-        if role == "candidate" else {}
+        if projection_capable else {}
     )
     missing_retained = requested - set(verified_bytes)
     if missing_retained:
@@ -786,6 +798,7 @@ def _projected_records(
         bundle.runtimes,
         component_ids,
         source_texts=source_texts,
+        selected_paths=tuple(records),
         available_paths=tuple(bundle.records),
     )
     projected = {path: dict(record) for path, record in records.items()}

--- a/contextos/bundle_schema.py
+++ b/contextos/bundle_schema.py
@@ -642,11 +642,6 @@ def verify_bundle(
             _fail("bundle.source_git_commit", "does not match the local Git HEAD commit")
     records = {item["path"]: item for item in lock["bundle"]["files"]}
     requested = set(records) if retain_paths is None else set(retain_paths)
-    # Selected-profile projection must be computed from the exact verified
-    # Markdown bytes at both proposal and apply boundaries. Retain those inputs
-    # consistently even when callers otherwise request a payload-bounded view.
-    if projection_capable and retain_paths is not None:
-        requested.update(path for path in records if path.endswith(".md"))
     unknown = requested - set(records)
     if unknown:
         _fail("retain_paths", "contains paths absent from the bundle: " + ", ".join(sorted(unknown)))
@@ -788,11 +783,42 @@ def _projected_records(
     component_ids: Sequence[str],
     records: dict[str, dict[str, Any]],
 ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
-    source_texts = {
-        path: bundle.verified_bytes[path].decode("utf-8")
-        for path in records
-        if path.endswith(".md") and path in bundle.verified_bytes
-    }
+    source_texts: dict[str, str] = {}
+    if config.get("composition", {}).get("profile") == "selected":
+        missing_runtimes = sorted(set(config["agents"]) - set(bundle.runtimes))
+        if missing_runtimes:
+            _fail(
+                "current_bundle",
+                "cannot reconstruct selected-profile runtime projection: "
+                + ", ".join(missing_runtimes),
+            )
+        projection_paths = tuple(
+            path for path in records if path.endswith(".md")
+        )
+        projected_bundle = bundle
+        if not set(projection_paths).issubset(bundle.verified_bytes):
+            projected_bundle = verify_bundle(
+                bundle.lock_path,
+                bundle.root,
+                expected_sha256=bundle.digest,
+                source_mode=bundle.source_mode,
+                role=bundle.role,
+                retain_paths=projection_paths,
+            )
+        missing_inputs = set(projection_paths) - set(projected_bundle.verified_bytes)
+        if missing_inputs:
+            _fail(
+                "projection_inputs",
+                "verified Markdown inputs are missing: "
+                + ", ".join(sorted(missing_inputs, key=portable_path_identity)),
+            )
+        try:
+            source_texts = {
+                path: projected_bundle.verified_bytes[path].decode("utf-8")
+                for path in projection_paths
+            }
+        except UnicodeDecodeError as exc:
+            _fail("projection_inputs", f"selected Markdown must be UTF-8: {exc}")
     generated = closure_aware_files(
         config,
         bundle.runtimes,
@@ -809,7 +835,7 @@ def _projected_records(
         projected[path].update(
             {
                 "sha256_raw": sha256_bytes(payload),
-                "sha256_text_lf": sha256_bytes(payload),
+                "sha256_text_lf": _text_lf_digest(payload),
                 "size": len(payload),
                 "executable": False,
             }

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -50,11 +50,27 @@ from .coordination import (
     validate_board,
 )
 from .materializer import (
+    INSTALLED_STATE_PATH,
     MATERIALIZE_OPERATION,
     create_composition_proposal,
+    create_guided_composition_proposal,
     create_materialization_proposal,
 )
-from .workspace_schema import WorkspaceConfigError, parse_agent_selection
+from .installed_state import InstalledStateError, validate_installed_state
+from .primitives import read_regular_file_snapshot, sha256_bytes
+from .workspace_composition import (
+    WorkspaceCompositionError,
+    desired_component_closure,
+)
+from .workspace_schema import (
+    DEFAULT_PATHS,
+    WORKSPACE_SCHEMA_VERSION,
+    WorkspaceConfigError,
+    analyze_legacy_workspace,
+    load_workspace_config,
+    parse_agent_selection,
+    strict_json_loads,
+)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -207,6 +223,41 @@ def parser() -> argparse.ArgumentParser:
         "migrate-local-runtime",
         help="Atomically copy legacy local runtime state into hosts.json",
     )
+    for guided_name, guided_help in (
+        ("init", "Propose a schema-v2 composition into a clean target"),
+        ("update", "Propose runtime, profile, extras, or bundle changes"),
+        ("reconcile", "Propose convergence to existing schema-v2 intent"),
+    ):
+        guided = workspace_commands.add_parser(guided_name, help=guided_help)
+        guided.add_argument("--target", type=Path, required=True)
+        guided.add_argument("--lock", type=Path, required=True)
+        guided.add_argument("--source", type=Path, required=True)
+        guided.add_argument("--expect-sha256", required=True)
+        guided.add_argument(
+            "--source-mode", choices=("git-index", "directory"), default="directory"
+        )
+        guided.add_argument("--now", help="ISO-8601 timestamp for deterministic proposal IDs")
+        if guided_name in {"init", "update"}:
+            guided.add_argument(
+                "--agents", required=True,
+                help="Comma-separated runtime ids, or none for core-only",
+            )
+            guided.add_argument(
+                "--profile", choices=("selected", "full-template"), required=True
+            )
+            guided.add_argument(
+                "--extras", default="none",
+                help="Comma-separated optional component roots, or none",
+            )
+        if guided_name in {"update", "reconcile"}:
+            guided.add_argument("--current-lock", type=Path)
+            guided.add_argument("--current-source", type=Path)
+            guided.add_argument("--expect-current-sha256")
+            guided.add_argument(
+                "--current-source-mode",
+                choices=("git-index", "directory"),
+                default="directory",
+            )
 
     board = commands.add_parser(
         "board", help="Coordination board operations (contract: coordination/README.md)"
@@ -356,6 +407,223 @@ def component_selection(raw: str, field: str) -> list[str]:
     return values
 
 
+def _guided_extras(raw: str) -> list[str]:
+    return [] if raw.strip() == "none" else component_selection(raw, "extras")
+
+
+def _guided_report(
+    target: Path, proposal_path: Path, proposal: dict[str, object]
+) -> dict[str, object]:
+    authorization = proposal["authorization"]
+    assert isinstance(authorization, dict)
+    plan = authorization["plan"]
+    assert isinstance(plan, dict)
+    return {
+        "schema_version": 1,
+        "proposal": proposal_path.relative_to(target).as_posix(),
+        "proposal_id": proposal["proposal_id"],
+        "proposal_digest": proposal["proposal_digest"],
+        "plan_digest": plan["plan_digest"],
+        "desired_components": plan["desired_components"],
+        "current_components": plan["current_components"],
+        "intended_workspace": plan["intended_workspace"],
+        "changes": [
+            {
+                "action": change["action"],
+                "path": change["path"],
+                "owner": change["authorization"]["owner"],
+                "policy": change["authorization"]["policy"],
+                "summary": change["diff"].strip(),
+            }
+            for change in proposal["changes"]
+        ],
+        "writes": True,
+        "applied": False,
+        "next": (
+            "review this single structural proposal, then run bundle apply with "
+            "the exact proposal digest"
+        ),
+    }
+
+
+def _load_guided_installed_state(target: Path) -> dict[str, object] | None:
+    path = target / INSTALLED_STATE_PATH
+    if not path.exists():
+        return None
+    try:
+        raw, _metadata = read_regular_file_snapshot(
+            path, subject="installed bundle state"
+        )
+        return validate_installed_state(
+            strict_json_loads(raw.decode("utf-8"), source=INSTALLED_STATE_PATH)
+        )
+    except (OSError, UnicodeError, WorkspaceConfigError, InstalledStateError) as exc:
+        raise BundleError(str(exc)) from exc
+
+
+def _guided_workspace_main(args: argparse.Namespace) -> int:
+    target = args.target.absolute().resolve()
+    if not target.is_dir():
+        raise BundleError("target must be an existing local directory")
+    candidate = verify_bundle(
+        args.lock,
+        args.source,
+        expected_sha256=args.expect_sha256,
+        source_mode=args.source_mode,
+        retain_paths=(),
+    )
+    component_ids = [item["id"] for item in candidate.manifest["components"]]
+    if args.workspace_command == "init":
+        agents = parse_agent_selection(
+            args.agents, known_runtime_ids=sorted(candidate.runtimes)
+        )
+        assert agents is not None
+        paths = dict(DEFAULT_PATHS)
+        legacy_path = target / "workspace.yaml"
+        if legacy_path.exists():
+            try:
+                legacy_bytes, _metadata = read_regular_file_snapshot(
+                    legacy_path, subject="legacy workspace configuration"
+                )
+                legacy = analyze_legacy_workspace(
+                    legacy_bytes.decode("utf-8-sig")
+                )
+            except (OSError, UnicodeError, WorkspaceConfigError) as exc:
+                raise BundleError(str(exc)) from exc
+            if legacy.issues:
+                raise BundleError(
+                    "workspace.yaml cannot be migrated losslessly: "
+                    + "; ".join(legacy.issues)
+                )
+            paths.update(legacy.values)
+        intended = {
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "agents": agents,
+            "composition": {
+                "profile": args.profile,
+                "extras": _guided_extras(args.extras),
+            },
+            "paths": paths,
+            "template": {
+                "source": candidate.name,
+                "version": candidate.version,
+                "bundle_sha256": candidate.digest,
+            },
+        }
+        desired = desired_component_closure(
+            intended, candidate.manifest, candidate.runtimes
+        )
+        proposal_path, proposal = create_guided_composition_proposal(
+            target_root=target,
+            workspace_config=intended,
+            candidate=candidate,
+            desired_components=desired,
+            now=parse_now(args.now),
+        )
+        emit(_guided_report(target, proposal_path, proposal))
+        return 0
+
+    config_path = target / "contextos.workspace.json"
+    try:
+        current_config, _canonical = load_workspace_config(
+            config_path,
+            root=target,
+            known_runtime_ids=sorted(candidate.runtimes),
+            known_component_ids=component_ids,
+        )
+    except WorkspaceConfigError as exc:
+        raise BundleError(str(exc)) from exc
+    legacy_v1 = current_config["schema_version"] != WORKSPACE_SCHEMA_VERSION
+    if legacy_v1 and args.workspace_command == "reconcile":
+        raise BundleError("schema v1 must be migrated with workspace update")
+    if legacy_v1 and args.profile != "full-template":
+        raise BundleError(
+            "schema-v1 migration must first preserve the full-template profile"
+        )
+    installed = _load_guided_installed_state(target)
+    current_values = (
+        args.current_lock,
+        args.current_source,
+        args.expect_current_sha256,
+    )
+    if any(value is not None for value in current_values) and not all(
+        value is not None for value in current_values
+    ):
+        raise BundleError(
+            "current bundle inputs are all required together: --current-lock, "
+            "--current-source, --expect-current-sha256"
+        )
+    current = None
+    current_components: list[str] = []
+    if installed is not None:
+        current_components = list(installed["components"])
+        installed_digest = installed["bundle"]["sha256"]
+        if installed_digest == candidate.digest:
+            current = candidate
+        elif args.current_lock is not None:
+            current = verify_bundle(
+                args.current_lock,
+                args.current_source,
+                expected_sha256=args.expect_current_sha256,
+                source_mode=args.current_source_mode,
+                role="current",
+                retain_paths=(),
+            )
+        else:
+            raise BundleError(
+                "installed bundle differs from the candidate; pinned current bundle inputs are required"
+            )
+    elif args.workspace_command == "update" and not legacy_v1:
+        raise BundleError(
+            "workspace update requires installed state; run workspace reconcile first"
+        )
+
+    if args.workspace_command == "reconcile":
+        intended = current_config
+        if intended["template"] != {
+            "source": candidate.name,
+            "version": candidate.version,
+            "bundle_sha256": candidate.digest,
+        }:
+            raise BundleError("reconcile candidate does not match the tracked bundle pin")
+    else:
+        agents = parse_agent_selection(
+            args.agents, known_runtime_ids=sorted(candidate.runtimes)
+        )
+        assert agents is not None
+        intended = {
+            **current_config,
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "agents": agents,
+            "composition": {
+                "profile": args.profile,
+                "extras": _guided_extras(args.extras),
+            },
+            "template": {
+                "source": candidate.name,
+                "version": candidate.version,
+                "bundle_sha256": candidate.digest,
+            },
+        }
+        intended.pop("mode", None)
+    desired = desired_component_closure(
+        intended, candidate.manifest, candidate.runtimes
+    )
+    proposal_path, proposal = create_materialization_proposal(
+        target_root=target,
+        workspace_config_path=config_path,
+        expected_config_sha256=sha256_bytes(config_path.read_bytes()),
+        candidate=candidate,
+        desired_components=desired,
+        current=current,
+        current_components=current_components,
+        intended_workspace=intended,
+        now=parse_now(args.now),
+    )
+    emit(_guided_report(target, proposal_path, proposal))
+    return 0
+
+
 def _bundle_main(args: argparse.Namespace) -> int:
     if args.bundle_command == "apply":
         root = args.target.absolute().resolve()
@@ -365,7 +633,12 @@ def _bundle_main(args: argparse.Namespace) -> int:
         receipt_path, receipt = apply_proposal(
             root, proposal, args.confirm, args.runtime
         )
-        emit({"receipt": receipt_path.relative_to(root).as_posix(), **receipt})
+        validation = doctor(root)
+        emit({
+            "receipt": receipt_path.relative_to(root).as_posix(),
+            **receipt,
+            "validation": validation,
+        })
         return 0
     if args.bundle_command == "generate":
         lock = create_bundle_lock(
@@ -591,6 +864,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.command == "bundle":
             return _bundle_main(args)
+        if args.command == "workspace" and args.workspace_command in {
+            "init", "update", "reconcile"
+        }:
+            return _guided_workspace_main(args)
         roles = _resolve_cli_roles(args)
         root = roles.context_root
         split_mode = args.context_root is not None or args.working_root is not None
@@ -804,6 +1081,7 @@ def main(argv: list[str] | None = None) -> int:
         ContextOSError,
         BundleError,
         WorkspaceConfigError,
+        WorkspaceCompositionError,
         AttachmentError,
         json.JSONDecodeError,
         OSError,

--- a/contextos/installed_state.py
+++ b/contextos/installed_state.py
@@ -1,0 +1,60 @@
+"""Validation for machine-local bundle materialization state."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+INSTALLED_STATE_SCHEMA_VERSION = 1
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+TOP_LEVEL_KEYS = {"schema_version", "bundle", "components", "plan_digest"}
+BUNDLE_KEYS = {"name", "version", "sha256", "source_git_commit"}
+
+
+class InstalledStateError(ValueError):
+    """Raised when installed-bundle.json is malformed."""
+
+
+def _text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise InstalledStateError(f"{field}: must be a non-empty string")
+    return value
+
+
+def validate_installed_state(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != TOP_LEVEL_KEYS:
+        raise InstalledStateError("installed bundle state has an invalid shape")
+    if value.get("schema_version") != INSTALLED_STATE_SCHEMA_VERSION:
+        raise InstalledStateError("installed bundle state schema_version must equal 1")
+    bundle = value.get("bundle")
+    if not isinstance(bundle, dict) or set(bundle) != BUNDLE_KEYS:
+        raise InstalledStateError("installed bundle identity has an invalid shape")
+    parsed_bundle = {
+        key: _text(bundle.get(key), f"bundle.{key}")
+        for key in ("name", "version")
+    }
+    source_git_commit = bundle.get("source_git_commit")
+    if source_git_commit is not None and not isinstance(source_git_commit, str):
+        raise InstalledStateError("bundle.source_git_commit must be a string or null")
+    parsed_bundle["source_git_commit"] = source_git_commit
+    digest = bundle.get("sha256")
+    if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+        raise InstalledStateError("bundle.sha256 must be a lowercase SHA-256 digest")
+    parsed_bundle["sha256"] = digest
+    components = value.get("components")
+    if (
+        not isinstance(components, list)
+        or any(not isinstance(item, str) or not item for item in components)
+        or len(components) != len(set(components))
+    ):
+        raise InstalledStateError("components must be a unique string array")
+    plan_digest = value.get("plan_digest")
+    if not isinstance(plan_digest, str) or not SHA256_RE.fullmatch(plan_digest):
+        raise InstalledStateError("plan_digest must be a lowercase SHA-256 digest")
+    return {
+        "schema_version": INSTALLED_STATE_SCHEMA_VERSION,
+        "bundle": parsed_bundle,
+        "components": components,
+        "plan_digest": plan_digest,
+    }

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -34,8 +34,8 @@ from .workspace_schema import (
     DEFAULT_PATHS,
     DEFAULT_TEMPLATE_SOURCE,
     DEFAULT_TEMPLATE_VERSION,
+    LEGACY_WORKSPACE_SCHEMA_VERSION,
     WORKSPACE_MODE,
-    WORKSPACE_SCHEMA_VERSION,
     WorkspaceConfigError,
     analyze_legacy_workspace,
     legacy_workspace_values,
@@ -46,6 +46,11 @@ from .workspace_schema import (
     strict_json_loads,
     validate_workspace_config,
     validate_workspace_path,
+)
+from .installed_state import InstalledStateError, validate_installed_state
+from .workspace_composition import (
+    WorkspaceCompositionError,
+    desired_component_closure,
 )
 from .primitives import (
     SnapshotError,
@@ -327,6 +332,7 @@ def discover_root(start: Path | None = None) -> Path:
                     marker,
                     root=path,
                     known_runtime_ids=runtime_ids(path),
+                    known_component_ids=_workspace_component_ids(path),
                 )
             except WorkspaceConfigError as exc:
                 raise ContextOSError(
@@ -430,6 +436,7 @@ def resolve_workspace(root: Path) -> WorkspaceResolution:
                 json_path,
                 root=root,
                 known_runtime_ids=runtime_ids(root),
+                known_component_ids=_workspace_component_ids(root),
             )
         except WorkspaceConfigError as exc:
             raise ContextOSError(f"invalid tracked workspace configuration: {exc}") from exc
@@ -672,7 +679,7 @@ def plan_workspace_migration(
         source = "legacy-yaml"
 
     candidate = {
-        "schema_version": WORKSPACE_SCHEMA_VERSION,
+        "schema_version": LEGACY_WORKSPACE_SCHEMA_VERSION,
         "mode": WORKSPACE_MODE,
         "agents": list(agents),
         "paths": paths,
@@ -836,6 +843,21 @@ def _selection_components(root: Path, agents: Sequence[str]) -> list[str]:
         raise ContextOSError(
             f"invalid component manifest: {component_path} ({exc})"
         ) from exc
+
+
+def _workspace_component_ids(root: Path) -> list[str] | None:
+    component_path = safe_repo_path(root, "components/manifest.json")
+    if not component_path.exists():
+        return None
+    try:
+        manifest = load_component_manifest(
+            component_path, root=root, check_paths=False
+        )
+    except (ComponentManifestError, OSError, UnicodeError) as exc:
+        raise ContextOSError(
+            f"invalid component manifest: {component_path} ({exc})"
+        ) from exc
+    return sorted(item["id"] for item in manifest["components"])
 
 
 def _agent_change(
@@ -1021,7 +1043,7 @@ def create_workspace_setup_proposal(
     """Create an additive setup proposal without inferring tracked intent."""
     requested_config = validate_workspace_config(
         {
-            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "schema_version": LEGACY_WORKSPACE_SCHEMA_VERSION,
             "mode": WORKSPACE_MODE,
             "agents": list(requested_agents),
             "paths": dict(DEFAULT_PATHS),
@@ -4755,6 +4777,14 @@ def doctor(
     workspace_source = "invalid"
     configured_agents: tuple[str, ...] | None = None
     workspace_valid = False
+    workspace_resolution: WorkspaceResolution | None = None
+    composition_report: dict[str, Any] = {
+        "status": "unknown",
+        "desired_components": [],
+        "installed_components": None,
+        "missing_components": [],
+        "extra_components": [],
+    }
     try:
         workspace_resolution = resolve_workspace(root)
         workspace = workspace_resolution.workspace
@@ -5005,6 +5035,100 @@ def doctor(
         add("component-inventory", "pass", "structurally valid")
     except (ContextOSError, ComponentManifestError, OSError, UnicodeError) as exc:
         add("component-inventory", "fail", str(exc))
+
+    if (
+        workspace_valid
+        and workspace_resolution is not None
+        and workspace_resolution.config is not None
+        and component_inventory is not None
+    ):
+        workspace_config = workspace_resolution.config
+        if workspace_config["schema_version"] == LEGACY_WORKSPACE_SCHEMA_VERSION:
+            composition_report["status"] = "legacy-undeclared"
+            add(
+                "desired-installed-components",
+                "warn",
+                "schema v1 does not declare reconstructable desired component closure",
+            )
+        else:
+            try:
+                selected_runtimes = {
+                    runtime_id: runtime_manifest(root, runtime_id, check_paths=False)
+                    for runtime_id in workspace_config["agents"]
+                }
+                desired = desired_component_closure(
+                    workspace_config, component_inventory, selected_runtimes
+                )
+                composition_report["desired_components"] = desired
+                installed_path = root / ".context-os" / "installed-bundle.json"
+                _guard_local_artifact_path(root, installed_path)
+                if not installed_path.exists():
+                    composition_report["status"] = "not-installed"
+                    composition_report["missing_components"] = desired
+                    add(
+                        "desired-installed-components",
+                        "warn",
+                        f"installed state absent; {len(desired)} desired component(s) require reconcile",
+                    )
+                else:
+                    installed_bytes, _metadata = read_regular_file_snapshot(
+                        installed_path, subject="installed bundle state"
+                    )
+                    installed = validate_installed_state(
+                        strict_json_loads(
+                            installed_bytes.decode("utf-8"),
+                            source=".context-os/installed-bundle.json",
+                        )
+                    )
+                    actual = installed["components"]
+                    missing = [item for item in desired if item not in set(actual)]
+                    extra = [item for item in actual if item not in set(desired)]
+                    expected_bundle = {
+                        "name": workspace_config["template"]["source"],
+                        "version": workspace_config["template"]["version"],
+                        "sha256": workspace_config["template"]["bundle_sha256"],
+                    }
+                    actual_bundle = {
+                        key: installed["bundle"][key]
+                        for key in ("name", "version", "sha256")
+                    }
+                    bundle_matches = actual_bundle == expected_bundle
+                    matches = not missing and not extra and bundle_matches
+                    composition_report.update(
+                        {
+                            "status": "current" if matches else "drifted",
+                            "installed_components": actual,
+                            "missing_components": missing,
+                            "extra_components": extra,
+                            "desired_bundle": expected_bundle,
+                            "installed_bundle": actual_bundle,
+                        }
+                    )
+                    detail_parts = []
+                    if missing:
+                        detail_parts.append("missing: " + ", ".join(missing))
+                    if extra:
+                        detail_parts.append("extra: " + ", ".join(extra))
+                    if not bundle_matches:
+                        detail_parts.append("installed bundle identity differs from desired pin")
+                    add(
+                        "desired-installed-components",
+                        "pass" if matches else "fail",
+                        "desired closure is installed" if matches else "; ".join(detail_parts),
+                    )
+            except (
+                ComponentManifestError,
+                ContextOSError,
+                InstalledStateError,
+                OSError,
+                SnapshotError,
+                UnicodeError,
+                WorkspaceCompositionError,
+                WorkspaceConfigError,
+            ) as exc:
+                composition_report["status"] = "invalid"
+                composition_report["detail"] = str(exc)
+                add("desired-installed-components", "fail", str(exc))
 
     if scope == "profile" and not validation_ids and component_inventory is not None:
         try:
@@ -5592,6 +5716,7 @@ def doctor(
             "configured_agents": (
                 list(configured_agents) if configured_agents is not None else None
             ),
+            "composition": composition_report,
         },
         "runtimes": runtime_reports,
         "checks": checks,

--- a/contextos/materializer.py
+++ b/contextos/materializer.py
@@ -18,9 +18,14 @@ from .bundle_schema import (
     verify_bundle,
 )
 from .component_schema import portable_path_identity
+from .installed_state import (
+    InstalledStateError,
+    validate_installed_state as validate_installed_state_document,
+)
 from .primitives import canonical_json, read_regular_file_snapshot, sha256_bytes
 from .workspace_schema import (
     WorkspaceConfigError,
+    analyze_legacy_workspace,
     render_workspace_config,
     strict_json_loads,
     validate_workspace_config,
@@ -207,12 +212,11 @@ def _validate_installed_state(
         raw, _metadata = read_regular_file_snapshot(
             path, subject="installed bundle state"
         )
-        value = strict_json_loads(raw.decode("utf-8"), source=INSTALLED_STATE_PATH)
-    except (OSError, UnicodeError, WorkspaceConfigError) as exc:
+        value = validate_installed_state_document(
+            strict_json_loads(raw.decode("utf-8"), source=INSTALLED_STATE_PATH)
+        )
+    except (OSError, UnicodeError, WorkspaceConfigError, InstalledStateError) as exc:
         raise BundleError(str(exc)) from exc
-    expected_keys = {"schema_version", "bundle", "components", "plan_digest"}
-    if not isinstance(value, dict) or set(value) != expected_keys:
-        raise BundleError("installed bundle state has an invalid shape")
     bundle = value.get("bundle")
     expected_bundle = {
         "name": current.name,
@@ -224,12 +228,6 @@ def _validate_installed_state(
         raise BundleError("installed bundle state contradicts the current bundle")
     if value.get("components") != plan["current_components"]:
         raise BundleError("installed bundle state contradicts current_components")
-    if (
-        value.get("schema_version") != 1
-        or not isinstance(value.get("plan_digest"), str)
-        or not SHA256_RE.fullmatch(value["plan_digest"])
-    ):
-        raise BundleError("installed bundle state is invalid")
 
 
 def _expected_changes(
@@ -248,9 +246,15 @@ def _expected_changes(
         relative = item["path"]
         record = candidate.records.get(relative)
         if action in {"add", "replace"}:
+            generated_text = plan.get("generated_files", {}).get(relative)
             if record is None:
                 raise BundleError(f"plan.{relative}: candidate record is missing")
             target = kernel.safe_repo_path(root, relative)
+            after_hash = (
+                sha256_bytes(generated_text.encode("utf-8"))
+                if generated_text is not None
+                else record["sha256_raw"]
+            )
             changes.append(
                 _change(
                     root,
@@ -259,9 +263,16 @@ def _expected_changes(
                     owner=item["owner"],
                     policy=item["policy"],
                     kind="component",
-                    after_hash=record["sha256_raw"],
-                    after_mode=_mode_for_write(target, executable=record["executable"]),
-                    content_ref=_bundle_ref(relative),
+                    after_hash=after_hash,
+                    after_mode=_mode_for_write(
+                        target,
+                        executable=False if generated_text is not None else record["executable"],
+                    ),
+                    content_ref=(
+                        _inline_ref(generated_text)
+                        if generated_text is not None
+                        else _bundle_ref(relative)
+                    ),
                     reason=item["reason"],
                 )
             )
@@ -315,6 +326,46 @@ def _expected_changes(
             reason="record the exact installed bundle and component closure",
         )
     )
+    legacy_path = kernel.safe_repo_path(root, "workspace.yaml")
+    if legacy_path.exists():
+        try:
+            legacy_bytes, _metadata = read_regular_file_snapshot(
+                legacy_path, subject="legacy workspace configuration"
+            )
+            legacy = analyze_legacy_workspace(
+                legacy_bytes.decode("utf-8-sig")
+            )
+        except (OSError, UnicodeError, WorkspaceConfigError) as exc:
+            raise BundleError(str(exc)) from exc
+        if legacy.issues:
+            raise BundleError(
+                "workspace.yaml cannot be retired losslessly: "
+                + "; ".join(legacy.issues)
+            )
+        conflicts = [
+            key
+            for key, value in legacy.values.items()
+            if plan["intended_workspace"]["paths"][key] != value
+        ]
+        if conflicts:
+            raise BundleError(
+                "workspace.yaml conflicts with intended paths: "
+                + ", ".join(conflicts)
+            )
+        changes.append(
+            _change(
+                root,
+                relative="workspace.yaml",
+                action="delete",
+                owner="legacy-workspace-config",
+                policy="migration-only",
+                kind="workspace-config",
+                after_hash=None,
+                after_mode=None,
+                content_ref=None,
+                reason="retire losslessly migrated legacy workspace configuration",
+            )
+        )
     return sorted(changes, key=lambda item: portable_path_identity(item["path"]))
 
 
@@ -328,6 +379,7 @@ def create_materialization_proposal(
     now: datetime,
     current: VerifiedBundle | None = None,
     current_components: Sequence[str] = (),
+    intended_workspace: dict[str, Any] | None = None,
 ) -> tuple[Path, dict[str, Any]]:
     kernel = _kernel()
     root = target_root.absolute()
@@ -339,6 +391,7 @@ def create_materialization_proposal(
         desired_components=desired_components,
         current=current,
         current_components=current_components,
+        intended_workspace=intended_workspace,
     )
     _validate_installed_state(root, current, plan)
     config_relative = _workspace_config_relative(root, workspace_config_path)
@@ -365,6 +418,11 @@ def create_materialization_proposal(
         "workspace_config": {
             "path": config_relative,
             "expected_sha256": expected_config_sha256,
+            **(
+                {"intended": intended_workspace}
+                if intended_workspace is not None
+                else {}
+            ),
         },
         "recovery_policy": recovery_policy,
     }
@@ -401,6 +459,119 @@ def create_materialization_proposal(
     return path, document
 
 
+def _create_composition_document(
+    *,
+    root: Path,
+    workspace_config_path: Path,
+    intended: dict[str, Any],
+    config_digest: str,
+    candidate: VerifiedBundle,
+    desired_components: Sequence[str],
+    now: datetime,
+    input_path: Path | None,
+) -> tuple[Path, dict[str, Any]]:
+    kernel = _kernel()
+    plan = create_initial_structural_plan(
+        target_root=root,
+        workspace_config=intended,
+        candidate=candidate,
+        desired_components=desired_components,
+    )
+    config_relative = _workspace_config_relative(root, workspace_config_path)
+    if kernel.raw_file_digest(kernel.safe_repo_path(root, config_relative)) is not None:
+        raise BundleError("workspace_config_path: clean composition target already exists")
+    _validate_installed_state(root, None, plan)
+    changes = _expected_changes(
+        root,
+        candidate=candidate,
+        plan=plan,
+        workspace_config_relative=config_relative,
+    )
+    recovery_policy = {
+        change["path"]: {
+            "action": change["action"],
+            "owner": change["authorization"]["owner"],
+            "policy": change["authorization"]["policy"],
+        }
+        for change in changes
+    }
+    workspace_authorization = {
+        "path": config_relative,
+        "expected_sha256": config_digest,
+        "intended": intended,
+    }
+    source_hashes = {
+        str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes())
+    }
+    if input_path is not None:
+        workspace_authorization["input_path"] = str(input_path)
+        source_hashes[str(input_path)] = config_digest
+    authorization = {
+        "policy": "component-materialization-v1",
+        "mode": "compose",
+        "plan": plan,
+        "candidate": _bundle_spec(candidate),
+        "current": None,
+        "workspace_config": workspace_authorization,
+        "recovery_policy": recovery_policy,
+    }
+    document: dict[str, Any] = {
+        "schema_version": kernel.SCHEMA_VERSION,
+        "workflow": kernel.AGENT_LIFECYCLE_WORKFLOW,
+        "operation": MATERIALIZE_OPERATION,
+        "created_at": now.isoformat(),
+        "proposal_id": kernel.proposal_id(
+            kernel.AGENT_LIFECYCLE_WORKFLOW, now, changes
+        ),
+        "changes": changes,
+        "authorization": authorization,
+        "source_hashes": dict(sorted(source_hashes.items())),
+        "source_git_head": kernel.git_head(root),
+        "invariants": list(MATERIALIZE_INVARIANTS),
+    }
+    document["proposal_digest"] = sha256_bytes(
+        canonical_json(document).encode("utf-8")
+    )
+    path = root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
+    kernel._write_exclusive_text(
+        path, json.dumps(document, indent=2, ensure_ascii=False) + "\n", root=root
+    )
+    return path, document
+
+
+def create_guided_composition_proposal(
+    *,
+    target_root: Path,
+    workspace_config: dict[str, Any],
+    candidate: VerifiedBundle,
+    desired_components: Sequence[str],
+    now: datetime,
+) -> tuple[Path, dict[str, Any]]:
+    """Create one proposal from schema-v2 intent embedded in the digest-bound document."""
+    root = target_root.absolute()
+    try:
+        intended = validate_workspace_config(
+            workspace_config,
+            known_runtime_ids=sorted(candidate.runtimes),
+            known_component_ids=sorted(
+                item["id"] for item in candidate.manifest["components"]
+            ),
+        )
+    except WorkspaceConfigError as exc:
+        raise BundleError(str(exc)) from exc
+    config_digest = sha256_bytes(render_workspace_config(intended).encode("utf-8"))
+    return _create_composition_document(
+        root=root,
+        workspace_config_path=root / "contextos.workspace.json",
+        intended=intended,
+        config_digest=config_digest,
+        candidate=candidate,
+        desired_components=desired_components,
+        now=now,
+        input_path=None,
+    )
+
+
 def create_composition_proposal(
     *,
     target_root: Path,
@@ -426,74 +597,24 @@ def create_composition_proposal(
             input_bytes.decode("utf-8"), source=str(input_path)
         )
         intended = validate_workspace_config(
-            input_value, known_runtime_ids=sorted(candidate.runtimes)
+            input_value,
+            known_runtime_ids=sorted(candidate.runtimes),
+            known_component_ids=sorted(
+                item["id"] for item in candidate.manifest["components"]
+            ),
         )
     except (OSError, UnicodeError, WorkspaceConfigError) as exc:
         raise BundleError(str(exc)) from exc
-    plan = create_initial_structural_plan(
-        target_root=root,
-        workspace_config=intended,
+    return _create_composition_document(
+        root=root,
+        workspace_config_path=workspace_config_path,
+        intended=intended,
+        config_digest=input_digest,
         candidate=candidate,
         desired_components=desired_components,
+        now=now,
+        input_path=input_path,
     )
-    config_relative = _workspace_config_relative(root, workspace_config_path)
-    if kernel.raw_file_digest(kernel.safe_repo_path(root, config_relative)) is not None:
-        raise BundleError("workspace_config_path: clean composition target already exists")
-    _validate_installed_state(root, None, plan)
-    changes = _expected_changes(
-        root,
-        candidate=candidate,
-        plan=plan,
-        workspace_config_relative=config_relative,
-    )
-    recovery_policy = {
-        change["path"]: {
-            "action": change["action"],
-            "owner": change["authorization"]["owner"],
-            "policy": change["authorization"]["policy"],
-        }
-        for change in changes
-    }
-    authorization = {
-        "policy": "component-materialization-v1",
-        "mode": "compose",
-        "plan": plan,
-        "candidate": _bundle_spec(candidate),
-        "current": None,
-        "workspace_config": {
-            "path": config_relative,
-            "expected_sha256": expected_config_input_sha256,
-            "input_path": str(input_path),
-            "intended": intended,
-        },
-        "recovery_policy": recovery_policy,
-    }
-    source_hashes = dict(sorted({
-        str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes()),
-        str(input_path): input_digest,
-    }.items()))
-    document: dict[str, Any] = {
-        "schema_version": kernel.SCHEMA_VERSION,
-        "workflow": kernel.AGENT_LIFECYCLE_WORKFLOW,
-        "operation": MATERIALIZE_OPERATION,
-        "created_at": now.isoformat(),
-        "proposal_id": kernel.proposal_id(
-            kernel.AGENT_LIFECYCLE_WORKFLOW, now, changes
-        ),
-        "changes": changes,
-        "authorization": authorization,
-        "source_hashes": source_hashes,
-        "source_git_head": kernel.git_head(root),
-        "invariants": list(MATERIALIZE_INVARIANTS),
-    }
-    document["proposal_digest"] = sha256_bytes(
-        canonical_json(document).encode("utf-8")
-    )
-    path = root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
-    kernel._write_exclusive_text(
-        path, json.dumps(document, indent=2, ensure_ascii=False) + "\n", root=root
-    )
-    return path, document
 
 
 def _materialization_context(
@@ -527,8 +648,15 @@ def _materialization_context(
         raise BundleError("materialization workspace config path is not canonical")
     if mode == "upgrade":
         if (
-            set(config) != {"path", "expected_sha256"}
+            set(config) not in (
+                {"path", "expected_sha256"},
+                {"path", "expected_sha256", "intended"},
+            )
             or not SHA256_RE.fullmatch(str(config.get("expected_sha256")))
+            or (
+                "intended" in config
+                and not isinstance(config.get("intended"), dict)
+            )
         ):
             raise BundleError("authorization.workspace_config is invalid")
         recomputed = create_structural_plan(
@@ -539,26 +667,52 @@ def _materialization_context(
             desired_components=plan.get("desired_components", []),
             current=current,
             current_components=plan.get("current_components", []),
+            intended_workspace=config.get("intended"),
         )
     else:
+        external_input = "input_path" in config
         if (
-            set(config) != {"path", "expected_sha256", "input_path", "intended"}
+            set(config) not in (
+                {"path", "expected_sha256", "intended"},
+                {"path", "expected_sha256", "input_path", "intended"},
+            )
             or not SHA256_RE.fullmatch(str(config.get("expected_sha256")))
-            or not isinstance(config.get("input_path"), str)
-            or not Path(config["input_path"]).is_absolute()
+            or not isinstance(config.get("intended"), dict)
+            or (
+                external_input
+                and (
+                    not isinstance(config.get("input_path"), str)
+                    or not Path(config["input_path"]).is_absolute()
+                )
+            )
         ):
             raise BundleError("authorization.workspace_config is invalid")
-        input_path = Path(config["input_path"])
         try:
-            input_bytes, _metadata = read_regular_file_snapshot(
-                input_path, subject="workspace configuration input"
-            )
-            if sha256_bytes(input_bytes) != config["expected_sha256"]:
-                raise BundleError("workspace configuration input became stale")
+            if external_input:
+                input_path = Path(config["input_path"])
+                input_bytes, _metadata = read_regular_file_snapshot(
+                    input_path, subject="workspace configuration input"
+                )
+                if sha256_bytes(input_bytes) != config["expected_sha256"]:
+                    raise BundleError("workspace configuration input became stale")
+                input_value = strict_json_loads(
+                    input_bytes.decode("utf-8"), source=str(input_path)
+                )
+            else:
+                input_value = config["intended"]
             parsed = validate_workspace_config(
-                strict_json_loads(input_bytes.decode("utf-8"), source=str(input_path)),
+                input_value,
                 known_runtime_ids=sorted(candidate.runtimes),
+                known_component_ids=sorted(
+                    item["id"] for item in candidate.manifest["components"]
+                ),
             )
+            if (
+                not external_input
+                and sha256_bytes(render_workspace_config(parsed).encode("utf-8"))
+                != config["expected_sha256"]
+            ):
+                raise BundleError("embedded workspace configuration digest is invalid")
         except (OSError, UnicodeError, WorkspaceConfigError) as exc:
             raise BundleError(str(exc)) from exc
         if parsed != config["intended"]:
@@ -643,15 +797,15 @@ def _validate_materialization_document(
     if document["authorization"].get("recovery_policy") != expected_recovery:
         raise BundleError("materialization recovery policy is invalid")
     config = document["authorization"]["workspace_config"]
-    config_source = (
-        config["input_path"]
-        if document["authorization"]["mode"] == "compose"
-        else str(_kernel().safe_repo_path(root, config["path"]))
-    )
     expected_sources = {
         str(candidate.lock_path.absolute()): sha256_bytes(candidate.lock_path.read_bytes()),
-        config_source: config["expected_sha256"],
     }
+    if document["authorization"]["mode"] != "compose":
+        expected_sources[
+            str(_kernel().safe_repo_path(root, config["path"]))
+        ] = config["expected_sha256"]
+    elif "input_path" in config:
+        expected_sources[config["input_path"]] = config["expected_sha256"]
     current_spec = document["authorization"].get("current")
     if current_spec is not None:
         expected_sources[current_spec["lock"]] = sha256_bytes(Path(current_spec["lock"]).read_bytes())

--- a/contextos/workspace_composition.py
+++ b/contextos/workspace_composition.py
@@ -1,0 +1,65 @@
+"""Derive one deterministic component closure from workspace schema v2 intent."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .component_schema import component_closure, portable_path_identity
+from .workspace_schema import LEGACY_WORKSPACE_SCHEMA_VERSION
+
+
+class WorkspaceCompositionError(ValueError):
+    """Raised when desired composition is internally contradictory."""
+
+
+def component_ids(manifest: Mapping[str, Any]) -> list[str]:
+    return sorted(
+        (item["id"] for item in manifest["components"]),
+        key=portable_path_identity,
+    )
+
+
+def runtime_required_components(
+    config: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    runtimes: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    requested: set[str] = {"core"}
+    for runtime_id in config["agents"]:
+        runtime = runtimes.get(runtime_id)
+        if runtime is None:
+            raise WorkspaceCompositionError(
+                f"workspace runtime {runtime_id!r} is unavailable"
+            )
+        requested.update(runtime["components"])
+    return component_closure(manifest, sorted(requested, key=portable_path_identity))
+
+
+def desired_component_closure(
+    config: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    runtimes: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    """Return schema-v2 desired closure; reject redundant runtime components."""
+    if config["schema_version"] == LEGACY_WORKSPACE_SCHEMA_VERSION:
+        raise WorkspaceCompositionError(
+            "schema v1 does not declare a reconstructable component closure"
+        )
+    composition = config["composition"]
+    if composition["profile"] == "full-template":
+        requested = component_ids(manifest)
+    else:
+        required = runtime_required_components(config, manifest, runtimes)
+        redundant = sorted(
+            set(composition["extras"]) & set(required), key=portable_path_identity
+        )
+        if redundant:
+            raise WorkspaceCompositionError(
+                "composition.extras duplicates runtime-required components: "
+                + ", ".join(redundant)
+            )
+        requested = sorted(
+            {"core", *required, *composition["extras"]},
+            key=portable_path_identity,
+        )
+    return component_closure(manifest, requested)

--- a/contextos/workspace_projection.py
+++ b/contextos/workspace_projection.py
@@ -129,12 +129,12 @@ def closure_aware_files(
     """Return generated entry surfaces for selected profile only."""
     if config.get("composition", {}).get("profile") != "selected":
         return {}
-    selected = _selected_runtimes(config, runtimes)
-    result = {"README.md": _readme(config, selected)}
+    selected_runtimes = _selected_runtimes(config, runtimes)
+    result = {"README.md": _readme(config, selected_runtimes)}
     if "agents-instructions" in desired_components:
-        result["AGENTS.md"] = _agents(selected)
+        result["AGENTS.md"] = _agents(selected_runtimes)
     if source_texts is not None:
-        selected = set(selected_paths)
+        selected_path_set = set(selected_paths)
         available = set(available_paths)
         for path, text in source_texts.items():
             if not path.endswith(".md") or path in result:
@@ -144,7 +144,7 @@ def closure_aware_files(
                 target = posixpath.normpath(
                     posixpath.join(posixpath.dirname(path), match.group(2))
                 )
-                if target in available and target not in selected:
+                if target in available and target not in selected_path_set:
                     return match.group(1)
                 return match.group(0)
 

--- a/contextos/workspace_projection.py
+++ b/contextos/workspace_projection.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Sequence
 
 
 RELATIVE_LINK_RE = re.compile(
-    r"\[[^\]]*\]\((?!https?://|mailto:|#)([^)#]+)(?:#[^)]+)?\)"
+    r"!?\[([^\]]*)\]\((?!https?://|mailto:|#)([^)#]+)(?:#[^)]+)?\)"
 )
 
 
@@ -123,6 +123,7 @@ def closure_aware_files(
     desired_components: Sequence[str],
     *,
     source_texts: Mapping[str, str] | None = None,
+    selected_paths: Sequence[str] = (),
     available_paths: Sequence[str] = (),
 ) -> dict[str, str]:
     """Return generated entry surfaces for selected profile only."""
@@ -133,26 +134,21 @@ def closure_aware_files(
     if "agents-instructions" in desired_components:
         result["AGENTS.md"] = _agents(selected)
     if source_texts is not None:
-        selected_paths = set(source_texts)
+        selected = set(selected_paths)
         available = set(available_paths)
         for path, text in source_texts.items():
             if not path.endswith(".md") or path in result:
                 continue
-            kept: list[str] = []
-            changed = False
-            for line in text.splitlines(keepends=True):
-                omitted_link = False
-                for link in RELATIVE_LINK_RE.findall(line):
-                    target = posixpath.normpath(
-                        posixpath.join(posixpath.dirname(path), link)
-                    )
-                    if target in available and target not in selected_paths:
-                        omitted_link = True
-                        break
-                if omitted_link:
-                    changed = True
-                else:
-                    kept.append(line)
-            if changed:
-                result[path] = "".join(kept)
+
+            def preserve_label(match: re.Match[str]) -> str:
+                target = posixpath.normpath(
+                    posixpath.join(posixpath.dirname(path), match.group(2))
+                )
+                if target in available and target not in selected:
+                    return match.group(1)
+                return match.group(0)
+
+            rendered = RELATIVE_LINK_RE.sub(preserve_label, text)
+            if rendered != text:
+                result[path] = rendered
     return result

--- a/contextos/workspace_projection.py
+++ b/contextos/workspace_projection.py
@@ -1,0 +1,158 @@
+"""Deterministic closure-aware shared entry surfaces for selected workspaces."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from typing import Any, Mapping, Sequence
+
+
+RELATIVE_LINK_RE = re.compile(
+    r"\[[^\]]*\]\((?!https?://|mailto:|#)([^)#]+)(?:#[^)]+)?\)"
+)
+
+
+def _selected_runtimes(
+    config: Mapping[str, Any],
+    runtimes: Mapping[str, Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    return [runtimes[runtime_id] for runtime_id in config["agents"]]
+
+
+def _support_table(selected: Sequence[Mapping[str, Any]]) -> list[str]:
+    lines = ["| Host | Tier | Support |", "|---|---|---|"]
+    if not selected:
+        lines.append(
+            "| Core-only | portable | No runtime adapter is selected; use the "
+            "reviewed kernel proposal/apply workflow directly. |"
+        )
+    for runtime in selected:
+        summary = str(runtime["support_summary"]).replace("|", "\\|")
+        lines.append(
+            f"| {runtime['display_name']} | {runtime['support_tier']} | {summary} |"
+        )
+    return lines
+
+
+def _readme(config: Mapping[str, Any], selected: Sequence[Mapping[str, Any]]) -> str:
+    lines = [
+        "# Context OS",
+        "",
+        "<!-- contextos:closure-aware-generated owner=core -->",
+        "",
+        "This workspace is a pinned, reconstructable Context OS composition. Durable",
+        "context lives in plain Markdown; local installation state lives under",
+        "`.context-os/` and is not tracked.",
+        "",
+        "## Selected runtime support",
+        "",
+        *_support_table(selected),
+        "",
+        "## Lifecycle",
+        "",
+    ]
+    if selected:
+        lines.extend(
+            f"- {runtime['display_name']}: "
+            + ", ".join(
+                f"{name} `{value}`"
+                for name, value in next(iter(runtime["surfaces"].values()))[
+                    "invocation"
+                ].items()
+            )
+            for runtime in selected
+        )
+    else:
+        lines.append(
+            "- Use `scripts/contextos.sh` for read-only reports and reviewed proposal/apply."
+        )
+    lines.extend(
+        [
+            "",
+            "Run `bash scripts/contextos.sh doctor` to compare tracked desired closure",
+            "with `.context-os/installed-bundle.json`. Reconcile only from the exact",
+            "local bundle digest pinned in `contextos.workspace.json`.",
+            "",
+            "## Safety and configuration",
+            "",
+            "- [Safety contract](docs/safety-contract.md)",
+            "",
+            f"Profile: `{config['composition']['profile']}`.",
+        ]
+    )
+    for runtime in selected:
+        onboarding = runtime.get("onboarding_doc")
+        if onboarding:
+            lines.append(f"- [{runtime['display_name']} onboarding]({onboarding})")
+    return "\n".join(lines) + "\n"
+
+
+def _agents(selected: Sequence[Mapping[str, Any]]) -> str:
+    lines = [
+        "# Context OS",
+        "",
+        "<!-- contextos:closure-aware-generated owner=agents-instructions -->",
+        "",
+        "This repository is the durable source of truth for personal, project, and",
+        "session context. Read `ROUTING.md`, keep each fact in one canonical file,",
+        "and use the lifecycle kernel's reviewed proposal/apply boundary for writes.",
+        "",
+        "Never commit or push without explicit approval. Follow",
+        "`docs/safety-contract.md` before external, destructive, credential, or",
+        "permission-changing actions. Host-local memory is never shared automatically.",
+        "",
+        "## Selected runtimes",
+        "",
+    ]
+    for runtime in selected:
+        invocation = next(iter(runtime["surfaces"].values()))["invocation"]
+        rendered = ", ".join(f"{key} `{value}`" for key, value in invocation.items())
+        lines.append(f"- {runtime['display_name']}: {rendered}.")
+    lines.extend(
+        [
+            "",
+            "Run `bash scripts/contextos.sh doctor` to diagnose desired/installed drift.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def closure_aware_files(
+    config: Mapping[str, Any],
+    runtimes: Mapping[str, Mapping[str, Any]],
+    desired_components: Sequence[str],
+    *,
+    source_texts: Mapping[str, str] | None = None,
+    available_paths: Sequence[str] = (),
+) -> dict[str, str]:
+    """Return generated entry surfaces for selected profile only."""
+    if config.get("composition", {}).get("profile") != "selected":
+        return {}
+    selected = _selected_runtimes(config, runtimes)
+    result = {"README.md": _readme(config, selected)}
+    if "agents-instructions" in desired_components:
+        result["AGENTS.md"] = _agents(selected)
+    if source_texts is not None:
+        selected_paths = set(source_texts)
+        available = set(available_paths)
+        for path, text in source_texts.items():
+            if not path.endswith(".md") or path in result:
+                continue
+            kept: list[str] = []
+            changed = False
+            for line in text.splitlines(keepends=True):
+                omitted_link = False
+                for link in RELATIVE_LINK_RE.findall(line):
+                    target = posixpath.normpath(
+                        posixpath.join(posixpath.dirname(path), link)
+                    )
+                    if target in available and target not in selected_paths:
+                        omitted_link = True
+                        break
+                if omitted_link:
+                    changed = True
+                else:
+                    kept.append(line)
+            if changed:
+                result[path] = "".join(kept)
+    return result

--- a/contextos/workspace_schema.py
+++ b/contextos/workspace_schema.py
@@ -7,11 +7,14 @@ import re
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from collections.abc import Set as AbstractSet
 from typing import Any, Iterable, Sequence
 
 
-WORKSPACE_SCHEMA_VERSION = 1
+LEGACY_WORKSPACE_SCHEMA_VERSION = 1
+WORKSPACE_SCHEMA_VERSION = 2
 WORKSPACE_MODE = "full-template"
+WORKSPACE_PROFILES = {"full-template", "selected"}
 DEFAULT_TEMPLATE_VERSION = "0.12.0"
 DEFAULT_TEMPLATE_SOURCE = "agent-context-os-template"
 DEFAULT_PATHS = {
@@ -20,9 +23,14 @@ DEFAULT_PATHS = {
     "task_file": "TODO.md",
 }
 RUNTIME_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
-TOP_LEVEL_KEYS = {"schema_version", "mode", "agents", "paths", "template"}
+V1_TOP_LEVEL_KEYS = {"schema_version", "mode", "agents", "paths", "template"}
+V2_TOP_LEVEL_KEYS = {
+    "schema_version", "agents", "composition", "paths", "template"
+}
 PATH_KEYS = {"state_dir", "sessions_dir", "task_file"}
-TEMPLATE_KEYS = {"version", "source"}
+V1_TEMPLATE_KEYS = {"version", "source"}
+V2_TEMPLATE_KEYS = {"version", "source", "bundle_sha256"}
+COMPOSITION_KEYS = {"profile", "extras"}
 LEGACY_KEYS = tuple(DEFAULT_PATHS)
 RESERVED_AGENT_TOKENS = {"auto", "generic", "none"}
 RESERVED_PATH_PARTS = {".git", ".context-os"}
@@ -32,6 +40,7 @@ WINDOWS_DEVICE_NAMES = {
     *(f"lpt{index}" for index in range(1, 10)),
 }
 WINDOWS_ILLEGAL_CHARACTERS = set('<>:"|?*')
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class WorkspaceConfigError(ValueError):
@@ -137,35 +146,75 @@ def _reject_path_role_collisions(paths: dict[str, str]) -> None:
         _fail("paths", "task_file must not be an ancestor of a configured directory")
 
 
-def validate_workspace_config(
-    value: Any, *, known_runtime_ids: Iterable[str]
-) -> dict[str, Any]:
-    document = _exact_keys(value, TOP_LEVEL_KEYS, "workspace")
-    if (
-        type(document.get("schema_version")) is not int
-        or document["schema_version"] != WORKSPACE_SCHEMA_VERSION
-    ):
-        _fail("schema_version", f"must equal integer {WORKSPACE_SCHEMA_VERSION}")
-    if document.get("mode") != WORKSPACE_MODE:
-        _fail("mode", f"must equal {WORKSPACE_MODE!r}")
+def _validate_identifier_set(
+    raw_values: Any,
+    *,
+    field: str,
+    known_values: Iterable[str] | None,
+    reserved: AbstractSet[str] = frozenset(),
+) -> list[str]:
+    if not isinstance(raw_values, list):
+        _fail(field, "must be an array")
+    known = set(known_values) if known_values is not None else None
+    values: list[str] = []
+    seen: set[str] = set()
+    for index, raw_value in enumerate(raw_values):
+        value = _text(raw_value, f"{field}[{index}]")
+        if not RUNTIME_ID_RE.fullmatch(value) or value in reserved:
+            _fail(f"{field}[{index}]", "must be a registered lowercase id")
+        identity = portable_identity(value)
+        if identity in seen:
+            _fail(field, f"duplicate id {value!r}")
+        if known is not None and value not in known:
+            _fail(f"{field}[{index}]", f"unknown id {value!r}")
+        seen.add(identity)
+        values.append(value)
+    return sorted(values)
 
-    raw_agents = document.get("agents")
+
+def _validate_agents(raw_agents: Any, known_runtime_ids: Iterable[str]) -> list[str]:
     if not isinstance(raw_agents, list):
         _fail("agents", "must be an array")
-    known = set(known_runtime_ids)
-    agents: list[str] = []
-    seen: set[str] = set()
-    for index, raw_agent in enumerate(raw_agents):
-        agent = _text(raw_agent, f"agents[{index}]")
-        if not RUNTIME_ID_RE.fullmatch(agent) or agent in RESERVED_AGENT_TOKENS:
-            _fail(f"agents[{index}]", "must be a registered lowercase runtime id")
-        identity = portable_identity(agent)
-        if identity in seen:
-            _fail("agents", f"duplicate runtime id {agent!r}")
-        if agent not in known:
-            _fail(f"agents[{index}]", f"unknown runtime id {agent!r}")
-        seen.add(identity)
-        agents.append(agent)
+    try:
+        return _validate_identifier_set(
+            raw_agents,
+            field="agents",
+            known_values=known_runtime_ids,
+            reserved=RESERVED_AGENT_TOKENS,
+        )
+    except WorkspaceConfigError as exc:
+        message = str(exc).replace("registered lowercase id", "registered lowercase runtime id")
+        message = message.replace("duplicate id", "duplicate runtime id")
+        message = message.replace("unknown id", "unknown runtime id")
+        raise WorkspaceConfigError(message) from exc
+
+
+def validate_workspace_config(
+    value: Any,
+    *,
+    known_runtime_ids: Iterable[str],
+    known_component_ids: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _fail("workspace", "must be an object")
+    version = value.get("schema_version")
+    if type(version) is not int or version not in {
+        LEGACY_WORKSPACE_SCHEMA_VERSION,
+        WORKSPACE_SCHEMA_VERSION,
+    }:
+        _fail(
+            "schema_version",
+            f"must equal integer {LEGACY_WORKSPACE_SCHEMA_VERSION} or {WORKSPACE_SCHEMA_VERSION}",
+        )
+    document = _exact_keys(
+        value,
+        V1_TOP_LEVEL_KEYS if version == LEGACY_WORKSPACE_SCHEMA_VERSION else V2_TOP_LEVEL_KEYS,
+        "workspace",
+    )
+    if version == LEGACY_WORKSPACE_SCHEMA_VERSION and document.get("mode") != WORKSPACE_MODE:
+        _fail("mode", f"must equal {WORKSPACE_MODE!r}")
+
+    agents = _validate_agents(document.get("agents"), known_runtime_ids)
 
     raw_paths = _exact_keys(document.get("paths"), PATH_KEYS, "paths")
     paths = {
@@ -174,18 +223,90 @@ def validate_workspace_config(
     }
     _reject_path_role_collisions(paths)
 
-    raw_template = _exact_keys(document.get("template"), TEMPLATE_KEYS, "template")
+    if version == LEGACY_WORKSPACE_SCHEMA_VERSION:
+        composition = None
+        template_keys = V1_TEMPLATE_KEYS
+    else:
+        raw_composition = _exact_keys(
+            document.get("composition"), COMPOSITION_KEYS, "composition"
+        )
+        profile = raw_composition.get("profile")
+        if profile not in WORKSPACE_PROFILES:
+            _fail(
+                "composition.profile",
+                "must equal 'full-template' or 'selected'",
+            )
+        extras = _validate_identifier_set(
+            raw_composition.get("extras"),
+            field="composition.extras",
+            known_values=known_component_ids,
+        )
+        if profile == "full-template" and extras:
+            _fail(
+                "composition.extras",
+                "must be empty for the full-template profile",
+            )
+        composition = {"profile": profile, "extras": extras}
+        template_keys = V2_TEMPLATE_KEYS
+
+    raw_template = _exact_keys(document.get("template"), template_keys, "template")
     template = {
         "version": _text(raw_template.get("version"), "template.version"),
         "source": _text(raw_template.get("source"), "template.source"),
     }
-    return {
-        "schema_version": WORKSPACE_SCHEMA_VERSION,
-        "mode": WORKSPACE_MODE,
+    if version == WORKSPACE_SCHEMA_VERSION:
+        digest = raw_template.get("bundle_sha256")
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            _fail("template.bundle_sha256", "must be a lowercase SHA-256 digest")
+        template["bundle_sha256"] = digest
+
+    result = {
+        "schema_version": version,
         "agents": sorted(agents),
         "paths": paths,
         "template": template,
     }
+    if version == LEGACY_WORKSPACE_SCHEMA_VERSION:
+        result["mode"] = WORKSPACE_MODE
+        return {
+            key: result[key]
+            for key in ("schema_version", "mode", "agents", "paths", "template")
+        }
+    result["composition"] = composition
+    return {
+        key: result[key]
+        for key in ("schema_version", "agents", "composition", "paths", "template")
+    }
+
+
+def migrate_v1_workspace_config(
+    value: Any,
+    *,
+    known_runtime_ids: Iterable[str],
+    known_component_ids: Iterable[str],
+    bundle_sha256: str,
+) -> dict[str, Any]:
+    legacy = validate_workspace_config(
+        value,
+        known_runtime_ids=known_runtime_ids,
+        known_component_ids=known_component_ids,
+    )
+    if legacy["schema_version"] != LEGACY_WORKSPACE_SCHEMA_VERSION:
+        _fail("schema_version", "migration source must use schema version 1")
+    return validate_workspace_config(
+        {
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "agents": legacy["agents"],
+            "composition": {"profile": "full-template", "extras": []},
+            "paths": legacy["paths"],
+            "template": {
+                **legacy["template"],
+                "bundle_sha256": bundle_sha256,
+            },
+        },
+        known_runtime_ids=known_runtime_ids,
+        known_component_ids=known_component_ids,
+    )
 
 
 def render_workspace_config(value: dict[str, Any]) -> str:
@@ -210,17 +331,7 @@ def parse_agent_selection(
         return []
     if "none" in tokens:
         _fail("agents", "none cannot be combined with runtime ids")
-    probe = {
-        "schema_version": WORKSPACE_SCHEMA_VERSION,
-        "mode": WORKSPACE_MODE,
-        "agents": tokens,
-        "paths": DEFAULT_PATHS,
-        "template": {
-            "version": DEFAULT_TEMPLATE_VERSION,
-            "source": DEFAULT_TEMPLATE_SOURCE,
-        },
-    }
-    return validate_workspace_config(probe, known_runtime_ids=known_runtime_ids)["agents"]
+    return _validate_agents(tokens, known_runtime_ids)
 
 
 def _reject_constant(value: str) -> None:
@@ -252,7 +363,11 @@ def strict_json_loads(raw: str, *, source: str) -> Any:
 
 
 def load_workspace_config(
-    path: Path, *, root: Path, known_runtime_ids: Iterable[str]
+    path: Path,
+    *,
+    root: Path,
+    known_runtime_ids: Iterable[str],
+    known_component_ids: Iterable[str] | None = None,
 ) -> tuple[dict[str, Any], bool]:
     if path.is_symlink():
         raise WorkspaceConfigError(f"{path.name}: must not be a symlink")
@@ -274,6 +389,7 @@ def load_workspace_config(
     document = validate_workspace_config(
         strict_json_loads(raw, source=path.name),
         known_runtime_ids=known_runtime_ids,
+        known_component_ids=known_component_ids,
     )
     return document, raw == render_workspace_config(document)
 
@@ -390,20 +506,39 @@ def workspace_schema_document() -> dict[str, Any]:
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$comment": (
             "Generated structural subset. contextos.workspace_schema is authoritative "
-            "for runtime-registry membership, portable path safety, semantic set "
-            "uniqueness, role collisions, and canonical rendering."
+            "for runtime/component-registry membership, portable path safety, "
+            "semantic set uniqueness, role collisions, and canonical rendering. "
+            "Schema-v1 documents are accepted only as migration inputs."
         ),
         "title": "Context OS tracked workspace configuration",
         "type": "object",
         "additionalProperties": False,
-        "required": ["schema_version", "mode", "agents", "paths", "template"],
+        "required": ["schema_version", "agents", "composition", "paths", "template"],
         "properties": {
             "schema_version": {"const": WORKSPACE_SCHEMA_VERSION},
-            "mode": {"const": WORKSPACE_MODE},
             "agents": {
                 "type": "array",
                 "uniqueItems": True,
                 "items": {"type": "string", "pattern": RUNTIME_ID_RE.pattern},
+            },
+            "composition": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["profile", "extras"],
+                "properties": {
+                    "profile": {"enum": sorted(WORKSPACE_PROFILES)},
+                    "extras": {
+                        "type": "array",
+                        "uniqueItems": True,
+                        "items": {"type": "string", "pattern": RUNTIME_ID_RE.pattern},
+                    },
+                },
+                "allOf": [
+                    {
+                        "if": {"properties": {"profile": {"const": "full-template"}}},
+                        "then": {"properties": {"extras": {"maxItems": 0}}},
+                    }
+                ],
             },
             "paths": {
                 "type": "object",
@@ -414,8 +549,15 @@ def workspace_schema_document() -> dict[str, Any]:
             "template": {
                 "type": "object",
                 "additionalProperties": False,
-                "required": ["version", "source"],
-                "properties": {"version": text, "source": text},
+                "required": ["version", "source", "bundle_sha256"],
+                "properties": {
+                    "version": text,
+                    "source": text,
+                    "bundle_sha256": {
+                        "type": "string",
+                        "pattern": SHA256_RE.pattern,
+                    },
+                },
             },
         },
     }

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -164,21 +164,22 @@ payloads are not retained again unless they are themselves selected Markdown.
 Apply retains only candidate bundle payloads referenced by write changes; those
 verified bytes are released when transaction staging completes.
 
-Maintainers can report the current full-component compose and upgrade bounds on
-Linux or Windows with:
+Maintainers can report the current full-template and selected-profile compose
+and upgrade bounds on Linux or Windows with:
 
 ```bash
 python scripts/measure-bundle-materialization.py --check
 ```
 
 The JSON report includes Git subprocess counts, elapsed wall time, the logical
-payload peak and bound, observed staging-payload retention, and Python's traced
-allocation peak. The upgrade measurement changes one managed bundle path so
-its retained-payload observation is nonzero. CI checks process batching and
-exact subprocess counts on
-both platforms, but records time and memory without platform-sensitive
+payload peak and bound, observed staging-payload retention, projection Markdown
+path counts, and Python's traced allocation peak. The upgrade measurements
+change one managed bundle path so their retained-payload observations are
+nonzero. CI checks process batching and exact subprocess counts for all four
+flows on both platforms, but records time and memory without platform-sensitive
 thresholds because shared-runner measurements are not stable correctness
-signals. Exact subset-retention tests enforce the payload policy separately.
+signals. Exact subset-retention tests enforce the payload policy separately,
+including exclusion of omitted-component Markdown.
 
 ## Low-level materializer interface
 

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -154,7 +154,13 @@ loop payload, which remains live until the next generator result is unpacked;
 it may double-count requested or schema payloads. Text decoding and LF
 normalization, directory-source snapshot assembly, parsed JSON objects, lock
 and plan metadata, filesystem snapshots, and interpreter overhead are outside
-this raw-buffer metric. Proposal planning requests no bundle payload retention.
+this raw-buffer metric. Full-template proposal planning requests no bundle
+payload retention. Selected-profile planning performs a separate streaming
+verification that retains only Markdown paths in the selected component closure
+while it computes closure-aware projections. Its bound uses the same formula
+with those selected Markdown paths as the requested set. The projection pass is
+sequential with ordinary candidate/current verification, so candidate write
+payloads are not retained again unless they are themselves selected Markdown.
 Apply retains only candidate bundle payloads referenced by write changes; those
 verified bytes are released when transaction staging completes.
 

--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -36,13 +36,13 @@ Generation prints JSON and does not write a lock. It rejects unclassified or
 owned-but-untracked index paths. Release automation can publish the printed lock
 beside an archive of the recorded commit.
 
-## v0.12 release artifact contract
+## Release artifact and composition contract
 
-The supported v0.12 distribution is the full-template, full-component closure.
-Although the low-level planner accepts explicit component closures for
-conformance and future composition work, workspace schema v1 cannot persist a
-desired slim closure. Guided slim installation and reconciliation wait for
-workspace schema v2.
+One detached release bundle can materialize either the explicit
+`full-template` compatibility profile or a schema-v2 selected closure. The
+tracked workspace document, rather than a second component CLI list, is the
+authority for v2 desired composition. Runtime-required components are derived;
+only optional roots are stored in `composition.extras`.
 
 The maintainer procedure is [`release-process.md`](release-process.md). Its
 canonical Linux build reads exact bytes from a clean Git index at the reviewed
@@ -174,11 +174,12 @@ both platforms, but records time and memory without platform-sensitive
 thresholds because shared-runner measurements are not stable correctness
 signals. Exact subset-retention tests enforce the payload policy separately.
 
-## Developer substrate: materializing a clean workspace
+## Low-level materializer interface
 
-The following component-subset interfaces exercise the materializer and future
-composition boundary. They do not create a supported v0.12 slim-workspace
-profile; release-grade v0.12 installs use the full component closure.
+The explicit component-subset interfaces remain available for conformance and
+schema-v1 migration compatibility. Normal schema-v2 users should use the
+guided `workspace init`, `workspace update`, and `workspace reconcile`
+commands, which derive and display the closure from tracked intent.
 
 Prepare a canonical workspace JSON file whose template name and version match
 the pinned candidate. The target directory must already exist, but its tracked
@@ -262,8 +263,8 @@ and plan digest without making local installation state tracked content.
 Protocol version 1 also fixes three boundaries for that materializer:
 
 - after any interrupted write, journal recovery must restore the pre-plan state
-  before another plan is requested; the planner does not adopt ahead-of-lock
-  files;
+  before another plan is requested; a clean clone may adopt only files whose
+  exact bytes and modes already match the pinned candidate bundle;
 - component ownership and managed/seed policy are immutable between ordinary
   upgrades; changing either requires a future signed migration contract and
   protocol version; and

--- a/docs/component-model.md
+++ b/docs/component-model.md
@@ -87,7 +87,7 @@ stay current.
 
 ## Materialization guarantees
 
-The shipped low-level materializer:
+The shipped materializer:
 
 1. record the selected runtimes and components in workspace-local
    configuration;
@@ -96,12 +96,12 @@ The shipped low-level materializer:
 4. produce an exact add/change/remove plan with immutable source hashes;
 5. require digest-bound approval and use the transaction lock and receipts;
 6. preserve existing `seed` paths and arbitrary files below extensible roots;
-7. keeps generated whole-file artifacts and maintainer-only conformance evidence
-   outside the released component closure; and
+7. projects selected-profile `README.md` support and shared `AGENTS.md`
+   instructions deterministically while retaining their single manifest owner;
 8. validates the selected runtime closure without treating the development test
    tree as a workspace output.
 
-The v0.12 release supports the full-template, full-component closure. Durable
-slim-profile intent, reconciliation, and closure-aware documentation require
-workspace schema v2; the lower-level component-selection interfaces are shipped
-substrate, not a v0.12 slim-workspace support claim.
+Workspace schema v2 supports both the explicit full-template closure and a
+durable selected profile. Guided init/update/reconcile derive that closure from
+runtimes and optional extras, pin the exact bundle digest, and reuse the same
+proposal, journal, rollback, and receipt path as low-level materialization.

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -271,10 +271,11 @@ second ad hoc root path:
   invoking an explicit/bound ContextRoot through KernelRoot.
 - Apply and hooks read runtime/component authority from KernelRoot, never from
   writable context or application content.
-- OpenClaw plugin alias attachment and desired component composition remain
-  separately bounded follow-ups; this slice does not overclaim them.
+- OpenClaw plugin alias attachment remains separately bounded. Desired
+  component composition is tracked by workspace schema v2 and changes only the
+  explicit ContextRoot through the materialization transaction.
 
-Issue #116 owns that implementation and its Windows/Linux Claude-to-Codex
-golden path. Issue #118 owns later desired-composition schema work and is not a
-v0.12 dependency except for the bounded verification task tracked separately in
-#106.
+Issue #116 owns distinct-root execution and its Windows/Linux Claude-to-Codex
+golden path. Schema-v2 composition does not broaden those root roles: guided
+init/update/reconcile target one explicit ContextRoot, and pre-mutation bundle
+source revalidation remains mandatory.

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -11,20 +11,24 @@ an external application-repository binding. See
 
 | Layer | Location | Meaning |
 |---|---|---|
-| Tracked workspace intent | `contextos.workspace.json` | Selected runtime set, full-template mode, repository paths, and template source |
+| Tracked workspace intent | `contextos.workspace.json` | Selected runtimes, desired profile/extras, repository paths, and exact bundle pin |
 | Legacy tracked paths | `workspace.yaml` | Read-compatible input while migration is pending; never merged into JSON |
 | Local host state | `.context-os/hosts.json` | Runtime manifests configured on this machine; gitignored and never a source of tracked agent intent |
+| Installed bundle state | `.context-os/installed-bundle.json` | Actual local bundle identity and materialized component closure; compared with tracked intent by `doctor` |
 | Operation receipts | `.context-os/receipts/` | The runtime that executed one approved lifecycle transaction |
 
 ## Canonical tracked JSON
 
-Schema v1 has exact keys:
+Schema v2 has exact keys:
 
 ```json
 {
-  "schema_version": 1,
-  "mode": "full-template",
+  "schema_version": 2,
   "agents": ["claude", "codex"],
+  "composition": {
+    "profile": "selected",
+    "extras": ["example-project"]
+  },
   "paths": {
     "state_dir": "state",
     "sessions_dir": "sessions",
@@ -32,7 +36,8 @@ Schema v1 has exact keys:
   },
   "template": {
     "version": "0.12.0",
-    "source": "agent-context-os-template"
+    "source": "agent-context-os-template",
+    "bundle_sha256": "<exact-64-character-lowercase-digest>"
   }
 }
 ```
@@ -43,18 +48,23 @@ means core-only. The CLI token `none` maps to that empty set but is never stored
 `auto` describes local launch detection only and can never become repository
 intent. `generic` is reserved for operation receipts and is not a runtime ID.
 
-Version 1 intentionally uses only `full-template`. Selecting agents records
-intent and controls bare `doctor` validation scope. Activation and disable never
-remove adapter files. A low-level detached-bundle materializer exists, but a
-durable desired slim closure and supported slim reconciliation require workspace
-schema v2.
+The `full-template` compatibility profile derives every released component and
+requires an empty `extras` array. The `selected` profile derives `core` plus the
+components required by `agents`, then adds optional component roots from
+`extras`. Runtime-required components must not be copied into `extras`.
+`template.bundle_sha256` pins the exact verified local release bundle; no
+workflow resolves or downloads `latest`.
 
-The public template ships `workspace/example.json` with `agents: []`, but no
+Schema v1 remains readable only as a migration source. Its `mode:
+"full-template"`, agents, paths, template name, and version migrate to the v2
+`full-template` profile only when the caller also supplies the exact bundle
+digest. Legacy YAML path migration remains a separate compatibility step.
+
+The public template ships a schema-v2 `workspace/example.json` with `agents: []`, but no
 live root configuration. This avoids overriding an existing clone's legacy YAML
 before migration is reviewed. All adapter files remain present in `full-template`
-mode. The transaction-backed migration path can create the root JSON and record
-choices explicitly rather than inferring from installed binaries; setup-time
-selection and adapter composition remain separate work.
+profile. Guided composition records choices explicitly rather than inferring
+from installed binaries or host registrations.
 
 Canonical JSON paths use POSIX repository-relative syntax on every platform.
 Drives, UNC and absolute paths, backslashes, dot segments, Windows device
@@ -284,13 +294,81 @@ intent with these rules:
   copied skills, external plugin, or project aliases. Both retain separate
   host-local onboarding steps.
 
+## Guided composition and reconciliation
+
+All guided composition commands require an existing target directory plus an
+explicit local lock, source directory, and independently obtained exact bundle
+digest. They verify that bundle before calculating intent and display the
+derived closure in one structural proposal. Nothing installs a host runtime,
+changes authentication, downloads a release, or removes native host memory.
+
+Initialize a clean target:
+
+```bash
+bash scripts/contextos.sh workspace init \
+  --target /path/to/workspace \
+  --lock /path/to/contextos.bundle.lock.json \
+  --source /path/to/extracted-bundle \
+  --expect-sha256 <bundle-digest> \
+  --agents codex --profile selected --extras example-project
+```
+
+Converge a clone or moved workspace after gitignored installed state is absent:
+
+```bash
+bash scripts/contextos.sh workspace reconcile \
+  --target /path/to/workspace \
+  --lock /path/to/contextos.bundle.lock.json \
+  --source /path/to/extracted-bundle \
+  --expect-sha256 <digest-pinned-in-contextos.workspace.json>
+```
+
+Use `workspace update` with the complete desired `--agents`, `--profile`, and
+`--extras` values to add or remove components. For a bundle upgrade, also pass
+the pinned `--current-lock`, `--current-source`, and
+`--expect-current-sha256`. Update requires valid installed state so removals
+have an exact content/ownership base; reconcile restores that state first after
+a clean clone.
+
+A schema-v1 workspace first uses `workspace update --profile full-template`
+against its matching pinned bundle. This preserves its full closure while the
+transaction adds the digest and v2 composition. A safe legacy `workspace.yaml`
+can instead seed `workspace init`; its normalized paths are preserved and the
+legacy file is retired in that same transaction. Ambiguous or conflicting
+legacy input fails before proposal publication.
+
+Every path produces the same digest-bound proposal. Apply it only after review:
+
+```bash
+bash scripts/contextos.sh bundle apply \
+  --target /path/to/workspace \
+  --proposal .context-os/proposals/<proposal-id>.json \
+  --confirm <proposal-digest>
+```
+
+The apply transaction publishes tracked configuration, managed/seed files, and
+installed state together through the shared journal, rollback, receipt, and
+second pre-mutation source revalidation path. For `selected` profiles, README
+runtime support and shared `AGENTS.md` instructions are deterministically
+projected from the selected runtime descriptors; their component owner remains
+`core` and `agents-instructions`, respectively.
+
+After the receipt is durable, `bundle apply` runs bare `doctor` in the tracked
+profile scope and includes that validation report in its output. A post-commit
+warning or failure is reported without pretending the already committed
+transaction rolled back.
+
+`doctor` reports the desired and installed bundle identities, desired and
+installed closures, and exact missing/extra components. Missing local state is
+a reconcile warning; contradictory bundle or closure state is a failure.
+
 ## Root discovery
 
 In this section, `root` means the v0.12 colocated ContextRoot selected by the
 CLI. `--root` does not designate a separate application WorkingRoot. External
 attachment instead requires exact `--kernel-root`, `--context-root`, and
 `--working-root` roles plus a validated project binding; it does not revise or
-overload workspace schema v1.
+overload workspace schema v2.
 
 `contextos.workspace.json` is the provider-neutral root marker. A valid tracked
 configuration is sufficient even for a minimal marker-only workspace with no
@@ -305,9 +383,11 @@ workspace. Marker-only describes a bootstrap root that lacks product
 descriptors: it supports discovery, reports, diagnosis, direct provider-neutral
 hooks, and proposal publication, while apply and agent/runtime configuration
 fail until verified detached-bundle materialization installs the product
-closure. The marker's `template.source` and `template.version` must exactly
-match the candidate bundle. Use `bundle propose` without current-bundle inputs;
-`bundle compose` is only for a clean target where the marker does not exist.
+closure. Schema-v2 marker identity includes `template.source`,
+`template.version`, and `template.bundle_sha256`; all three must exactly match
+the candidate bundle. Use `workspace reconcile` for the supported path. The
+lower-level `bundle compose` command remains only for a clean target where the
+marker does not exist.
 
 Existing clones remain discoverable through the legacy compound marker:
 `AGENTS.md` plus either a `state/` directory or `workspace.yaml`. Discovery

--- a/docs/workspace-configuration.md
+++ b/docs/workspace-configuration.md
@@ -55,6 +55,12 @@ components required by `agents`, then adds optional component roots from
 `template.bundle_sha256` pins the exact verified local release bundle; no
 workflow resolves or downloads `latest`.
 
+The tracked `workspace/example.json` uses an all-zero digest placeholder because
+the example is itself part of the release bundle and therefore cannot pin that
+bundle without creating a self-reference. Replace the placeholder with the
+verified lock digest when creating a real workspace; guided `workspace init`
+does this from the explicit local bundle input.
+
 Schema v1 remains readable only as a migration source. Its `mode:
 "full-template"`, agents, paths, template name, and version migrate to the v2
 `full-template` profile only when the caller also supplies the exact bundle

--- a/scripts/measure-bundle-materialization.py
+++ b/scripts/measure-bundle-materialization.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Measure full-bundle Git-index composition and upgrade resource bounds."""
+"""Measure full-template and selected Git-index materialization bounds."""
 
 from __future__ import annotations
 
@@ -33,7 +33,12 @@ from contextos.primitives import git_environment  # noqa: E402
 
 
 NOW = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
-EXPECTED_GIT_PROCESSES = {"compose": 48, "upgrade": 96}
+EXPECTED_GIT_PROCESSES = {
+    "compose": 48,
+    "upgrade": 96,
+    "selected_compose": 72,
+    "selected_upgrade": 144,
+}
 
 
 def _sha256(path: Path) -> str:
@@ -206,7 +211,9 @@ def _metric(
     retained_paths: set[str],
     observed_retained_payload_bytes: int,
     traced_python_peak_bytes: int,
+    projection_paths: set[str] | None = None,
 ) -> dict[str, Any]:
+    projection_paths = set() if projection_paths is None else projection_paths
     batch_commands = [
         command for command in commands if "cat-file" in command and "--batch" in command
     ]
@@ -220,11 +227,17 @@ def _metric(
         _logical_verification_peak(
             lock, role="candidate", retain_paths=retained_paths
         ),
+        _logical_verification_peak(
+            lock, role="candidate", retain_paths=projection_paths
+        ),
     )
     logical_bound = max(
         _logical_verification_bound(lock, role="candidate", retain_paths=set()),
         _logical_verification_bound(
             lock, role="candidate", retain_paths=retained_paths
+        ),
+        _logical_verification_bound(
+            lock, role="candidate", retain_paths=projection_paths
         ),
     )
     return {
@@ -237,6 +250,7 @@ def _metric(
         "observed_staging_payload_bytes": observed_retained_payload_bytes,
         "tracemalloc_peak_bytes": traced_python_peak_bytes,
         "retained_bundle_path_count": len(retained_paths),
+        "projection_markdown_path_count": len(projection_paths),
         "matches_expected_git_process_count": (
             len(commands) == EXPECTED_GIT_PROCESSES[name]
         ),
@@ -357,6 +371,129 @@ def measure() -> dict[str, Any]:
             max(upgrade_retained, default=0), upgrade_python_peak[0],
         )
 
+        selected_components = ["core"]
+        selected_projection_paths = {
+            entry["path"]
+            for component in manifest["components"]
+            if component["id"] in selected_components
+            for entry in component["paths"]
+            if entry["policy"] != "development" and entry["path"].endswith(".md")
+        }
+        selected_target = root / "selected-target"
+        selected_target.mkdir()
+        selected_config_input = root / "selected-workspace-v2.json"
+        selected_config = {
+            "schema_version": 2,
+            "agents": [],
+            "composition": {"profile": "selected", "extras": []},
+            "paths": {
+                "state_dir": "state",
+                "sessions_dir": "sessions",
+                "task_file": "TODO.md",
+            },
+            "template": {
+                "source": "agent-context-os-template",
+                "version": "1.0.0",
+                "bundle_sha256": current_lock["bundle_sha256"],
+            },
+        }
+        _write_json(selected_config_input, selected_config)
+        with (
+            _git_process_measurement() as selected_compose_commands,
+            _retained_payload_measurement() as selected_compose_retained,
+            _python_peak_measurement() as selected_compose_python_peak,
+        ):
+            selected_compose_started = time.perf_counter()
+            selected_current = verify_bundle(
+                current_lock_path, current_source,
+                expected_sha256=current_lock["bundle_sha256"],
+                source_mode="git-index", retain_paths=(),
+            )
+            selected_compose_path, selected_compose_proposal = (
+                create_composition_proposal(
+                    target_root=selected_target,
+                    workspace_config_path=(
+                        selected_target / "contextos.workspace.json"
+                    ),
+                    workspace_config_input_path=selected_config_input,
+                    expected_config_input_sha256=_sha256(selected_config_input),
+                    candidate=selected_current,
+                    desired_components=selected_components,
+                    now=NOW.replace(second=2),
+                )
+            )
+            apply_proposal(
+                selected_target,
+                selected_compose_path,
+                selected_compose_proposal["proposal_digest"],
+                "generic",
+            )
+        selected_compose = _metric(
+            "selected_compose",
+            selected_compose_started,
+            selected_compose_commands,
+            current_lock,
+            _bundle_references(selected_compose_proposal),
+            max(selected_compose_retained, default=0),
+            selected_compose_python_peak[0],
+            selected_projection_paths,
+        )
+
+        selected_intended = {
+            **selected_config,
+            "template": {
+                "source": "agent-context-os-template",
+                "version": "2.0.0",
+                "bundle_sha256": candidate_lock["bundle_sha256"],
+            },
+        }
+        with (
+            _git_process_measurement() as selected_upgrade_commands,
+            _retained_payload_measurement() as selected_upgrade_retained,
+            _python_peak_measurement() as selected_upgrade_python_peak,
+        ):
+            selected_upgrade_started = time.perf_counter()
+            selected_candidate = verify_bundle(
+                candidate_lock_path, candidate_source,
+                expected_sha256=candidate_lock["bundle_sha256"],
+                source_mode="git-index", retain_paths=(),
+            )
+            selected_current = verify_bundle(
+                current_lock_path, current_source,
+                expected_sha256=current_lock["bundle_sha256"],
+                source_mode="git-index", role="current", retain_paths=(),
+            )
+            selected_config_path = selected_target / "contextos.workspace.json"
+            selected_upgrade_path, selected_upgrade_proposal = (
+                create_materialization_proposal(
+                    target_root=selected_target,
+                    workspace_config_path=selected_config_path,
+                    expected_config_sha256=_sha256(selected_config_path),
+                    candidate=selected_candidate,
+                    desired_components=selected_components,
+                    current=selected_current,
+                    current_components=selected_components,
+                    intended_workspace=selected_intended,
+                    now=NOW.replace(second=3),
+                )
+            )
+            apply_proposal(
+                selected_target,
+                selected_upgrade_path,
+                selected_upgrade_proposal["proposal_digest"],
+                "generic",
+            )
+        selected_upgrade = _metric(
+            "selected_upgrade",
+            selected_upgrade_started,
+            selected_upgrade_commands,
+            candidate_lock,
+            _bundle_references(selected_upgrade_proposal),
+            max(selected_upgrade_retained, default=0),
+            selected_upgrade_python_peak[0],
+            selected_projection_paths,
+        )
+
         return {
             "schema_version": 1,
             "measurement": "full-bundle-materialization-resource-bounds",
@@ -367,6 +504,8 @@ def measure() -> dict[str, Any]:
             "upgrade_changed_bundle_path": changed_path,
             "compose": compose,
             "upgrade": upgrade,
+            "selected_compose": selected_compose,
+            "selected_upgrade": selected_upgrade,
         }
 
 
@@ -380,7 +519,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     report = measure()
     print(json.dumps(report, indent=2, ensure_ascii=False))
     if args.check:
-        for name in ("compose", "upgrade"):
+        for name in (
+            "compose", "upgrade", "selected_compose", "selected_upgrade"
+        ):
             metric = report[name]
             if metric["git_per_blob_process_count"] != 0:
                 print(f"{name}: per-blob Git subprocesses detected", file=sys.stderr)

--- a/scripts/release-artifacts.py
+++ b/scripts/release-artifacts.py
@@ -32,6 +32,7 @@ from contextos.primitives import git_environment  # noqa: E402
 
 
 GENERATOR_VERSION = 1
+EXAMPLE_BUNDLE_SHA256 = "0" * 64
 TEMPLATE_NAME = "agent-context-os-template"
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
@@ -119,7 +120,11 @@ def _require_release_identity(root: Path, version: str, tag: str) -> None:
     if source_match is None or source_match.group(1) != TEMPLATE_NAME:
         raise ReleaseArtifactError("DEFAULT_TEMPLATE_SOURCE does not match the release template")
     workspace = json.loads((root / "workspace/example.json").read_text(encoding="utf-8"))
-    if workspace.get("template") != {"version": version, "source": TEMPLATE_NAME}:
+    if workspace.get("template") != {
+        "version": version,
+        "source": TEMPLATE_NAME,
+        "bundle_sha256": EXAMPLE_BUNDLE_SHA256,
+    }:
         raise ReleaseArtifactError("workspace/example.json template identity does not match")
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     if not re.search(rf"^## \[{re.escape(version)}\] [—-] \d{{4}}-\d{{2}}-\d{{2}}\b", changelog, re.MULTILINE):

--- a/scripts/workspace-config.py
+++ b/scripts/workspace-config.py
@@ -12,7 +12,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from contextos.component_schema import write_generated_file  # noqa: E402
+from contextos.component_schema import (  # noqa: E402
+    load_component_manifest,
+    write_generated_file,
+)
 from contextos.kernel import ContextOSError, runtime_ids  # noqa: E402
 from contextos.workspace_schema import (  # noqa: E402
     WorkspaceConfigError,
@@ -30,10 +33,14 @@ def schema_text() -> str:
 
 
 def check() -> tuple[int, int]:
+    manifest = load_component_manifest(
+        ROOT / "components" / "manifest.json", root=ROOT, check_paths=False
+    )
     config, canonical = load_workspace_config(
         CONFIG_PATH,
         root=ROOT,
         known_runtime_ids=runtime_ids(ROOT),
+        known_component_ids=[item["id"] for item in manifest["components"]],
     )
     if not canonical:
         raise WorkspaceConfigError(

--- a/tests/fixtures/workspace-v2-migrations.json
+++ b/tests/fixtures/workspace-v2-migrations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "v1-full-template-preserves-paths-and-runtime-intent",
+    "source": {
+      "schema_version": 1,
+      "mode": "full-template",
+      "agents": ["codex", "claude"],
+      "paths": {
+        "state_dir": "memory",
+        "sessions_dir": "work/sessions",
+        "task_file": "TASKS.md"
+      },
+      "template": {
+        "version": "9.9.9",
+        "source": "private-bundle"
+      }
+    },
+    "expected": {
+      "schema_version": 2,
+      "agents": ["claude", "codex"],
+      "composition": {
+        "profile": "full-template",
+        "extras": []
+      },
+      "paths": {
+        "state_dir": "memory",
+        "sessions_dir": "work/sessions",
+        "task_file": "TASKS.md"
+      },
+      "template": {
+        "version": "9.9.9",
+        "source": "private-bundle",
+        "bundle_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    }
+  },
+  {
+    "id": "v2-is-not-a-migration-source",
+    "source": {
+      "schema_version": 2,
+      "agents": [],
+      "composition": {
+        "profile": "full-template",
+        "extras": []
+      },
+      "paths": {
+        "state_dir": "state",
+        "sessions_dir": "sessions",
+        "task_file": "TODO.md"
+      },
+      "template": {
+        "version": "0.12.0",
+        "source": "agent-context-os-template",
+        "bundle_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    "error": "migration source must use schema version 1"
+  }
+]

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -133,11 +133,17 @@ class BundleFixture:
             })
         if addon:
             (root / "addon.txt").write_text(f"addon {version}\n", encoding="utf-8")
+            (root / "addon.md").write_text(
+                "# Optional add-on\n", encoding="utf-8"
+            )
             components.append({
                 "id": "addon",
                 "description": "Optional fixture.",
                 "depends_on": ["core"],
-                "paths": [{"path": "addon.txt", "policy": addon_policy}],
+                "paths": [
+                    {"path": "addon.txt", "policy": addon_policy},
+                    {"path": "addon.md", "policy": addon_policy},
+                ],
             })
         manifest = {
             "schema_version": 1,
@@ -462,6 +468,7 @@ class BundleLockTest(unittest.TestCase):
         self.assertEqual(
             [{"AGENTS.md", "GUIDE.md", "README.md"}], retained_sets
         )
+        self.assertNotIn("addon.md", retained_sets[0])
 
     def test_git_batch_reader_rejects_malformed_and_truncated_records(self) -> None:
         class BatchProcess:

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -70,6 +70,7 @@ class BundleFixture:
         self, root: Path, *, version: str, managed: bytes, addon: bool,
         runtime_addon: bool | None = None, include_seed: bool = True,
         addon_policy: str = "managed", source_mode: str = "directory",
+        entry_surfaces: bool = False,
     ) -> None:
         self.root = root
         (root / "components").mkdir(parents=True)
@@ -80,6 +81,8 @@ class BundleFixture:
         if runtime_addon is None:
             runtime_addon = addon
         runtime_components = ["core", "addon"] if runtime_addon else ["core"]
+        if entry_surfaces:
+            runtime_components.append("agents-instructions")
         runtime_descriptor = json.loads(
             (ROOT / "runtimes/codex.json").read_text(encoding="utf-8")
         )
@@ -104,6 +107,22 @@ class BundleFixture:
         ]
         if include_seed:
             components[0]["paths"].append({"path": "seed.txt", "policy": "seed"})
+        if entry_surfaces:
+            (root / "README.md").write_text(
+                "# Full fixture\n\nCodex and Hermes are supported.\n", encoding="utf-8"
+            )
+            (root / "AGENTS.md").write_text(
+                "# Full fixture agents\n\nCodex and Hermes.\n", encoding="utf-8"
+            )
+            components[0]["paths"].append(
+                {"path": "README.md", "policy": "managed"}
+            )
+            components.append({
+                "id": "agents-instructions",
+                "description": "Generated shared instructions fixture.",
+                "depends_on": ["core"],
+                "paths": [{"path": "AGENTS.md", "policy": "managed"}],
+            })
         if addon:
             (root / "addon.txt").write_text(f"addon {version}\n", encoding="utf-8")
             components.append({

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -114,8 +114,16 @@ class BundleFixture:
             (root / "AGENTS.md").write_text(
                 "# Full fixture agents\n\nCodex and Hermes.\n", encoding="utf-8"
             )
+            (root / "GUIDE.md").write_text(
+                "Keep the [managed payload](managed.bin) while the "
+                "[optional add-on](addon.txt) is omitted.\n",
+                encoding="utf-8",
+            )
             components[0]["paths"].append(
                 {"path": "README.md", "policy": "managed"}
+            )
+            components[0]["paths"].append(
+                {"path": "GUIDE.md", "policy": "managed"}
             )
             components.append({
                 "id": "agents-instructions",

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -17,6 +17,7 @@ from contextos.bundle_schema import (
     bundle_schema_document,
     canonical_json,
     create_bundle_lock,
+    create_initial_structural_plan,
     create_structural_plan,
     validate_bundle_lock,
     verify_bundle,
@@ -114,10 +115,9 @@ class BundleFixture:
             (root / "AGENTS.md").write_text(
                 "# Full fixture agents\n\nCodex and Hermes.\n", encoding="utf-8"
             )
-            (root / "GUIDE.md").write_text(
-                "Keep the [managed payload](managed.bin) while the "
-                "[optional add-on](addon.txt) is omitted.\n",
-                encoding="utf-8",
+            (root / "GUIDE.md").write_bytes(
+                b"Keep the [managed payload](managed.bin) while the "
+                b"[optional add-on](addon.txt) is omitted.\r\n"
             )
             components[0]["paths"].append(
                 {"path": "README.md", "policy": "managed"}
@@ -332,7 +332,7 @@ class BundleLockTest(unittest.TestCase):
         git_source.mkdir()
         fixture = BundleFixture(
             git_source, version="1.0.0", managed=b"binary\x00v1\r\n", addon=True,
-            source_mode="git-index",
+            source_mode="git-index", entry_surfaces=True,
         )
         self.assertGreater(len(fixture.lock["bundle"]["files"]), 1)
 
@@ -409,6 +409,59 @@ class BundleLockTest(unittest.TestCase):
                 expected_sha256=rebound["bundle_sha256"],
                 source_mode="git-index", retain_paths=(),
             )
+
+    def test_selected_projection_reverifies_only_owned_markdown_inputs(self) -> None:
+        source = self.root / "selected-projection-source"
+        source.mkdir()
+        fixture = BundleFixture(
+            source,
+            version="2.0.0",
+            managed=b"selected\n",
+            addon=True,
+            runtime_addon=False,
+            entry_surfaces=True,
+        )
+        candidate = verify_bundle(
+            fixture.lock_path,
+            source,
+            expected_sha256=fixture.lock["bundle_sha256"],
+            retain_paths=(),
+        )
+        self.assertEqual({}, candidate.verified_bytes)
+        target = self.root / "selected-projection-target"
+        target.mkdir()
+        config = {
+            "schema_version": 2,
+            "agents": ["codex"],
+            "composition": {"profile": "selected", "extras": []},
+            "paths": {
+                "state_dir": "state",
+                "sessions_dir": "sessions",
+                "task_file": "TODO.md",
+            },
+            "template": {
+                "source": candidate.name,
+                "version": candidate.version,
+                "bundle_sha256": candidate.digest,
+            },
+        }
+        with mock.patch(
+            "contextos.bundle_schema.verify_bundle", wraps=verify_bundle
+        ) as reverification:
+            create_initial_structural_plan(
+                target_root=target,
+                workspace_config=config,
+                candidate=candidate,
+                desired_components=["core", "agents-instructions"],
+            )
+        retained_sets = [
+            set(call.kwargs["retain_paths"])
+            for call in reverification.call_args_list
+            if call.kwargs.get("retain_paths")
+        ]
+        self.assertEqual(
+            [{"AGENTS.md", "GUIDE.md", "README.md"}], retained_sets
+        )
 
     def test_git_batch_reader_rejects_malformed_and_truncated_records(self) -> None:
         class BatchProcess:

--- a/tests/test_docs_positioning.py
+++ b/tests/test_docs_positioning.py
@@ -87,7 +87,8 @@ class DocumentationPositioningTests(unittest.TestCase):
         )
         workspace_contract = self.text("docs/workspace-configuration.md")
         self.assertIn("marker-only root is not the same as a core-only profile", workspace_contract)
-        self.assertIn("`bundle propose` without current-bundle inputs", workspace_contract)
+        self.assertIn("Use `workspace reconcile` for the supported path", workspace_contract)
+        self.assertIn("`template.bundle_sha256`", workspace_contract)
         for root in SETUP_ROOTS:
             self.assertIn(f"`{root}/`", contract)
         for filename in SETUP_FILES:

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -18,10 +18,12 @@ from contextos.kernel import (
     ContextOSError,
     _recover_pending_agent_journals,
     apply_proposal,
+    doctor,
 )
 from contextos.materializer import (
     INSTALLED_STATE_PATH,
     create_composition_proposal,
+    create_guided_composition_proposal,
     create_materialization_proposal,
     prepare_materialization_preflight,
 )
@@ -139,6 +141,12 @@ class MaterializerTest(unittest.TestCase):
             now=NOW,
         )
 
+    def guided_cli(self, *arguments: str) -> dict:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(0, cli_main(list(arguments)))
+        return json.loads(output.getvalue())
+
     def test_clean_composition_installs_config_binary_components_and_state(self) -> None:
         target, config_input = self.composition_input()
         (target / "seed.txt").write_text("personal seed\n", encoding="utf-8")
@@ -157,6 +165,308 @@ class MaterializerTest(unittest.TestCase):
         )
         self.assertEqual("compose", proposal["authorization"]["mode"])
         self.assertEqual("component-materialize", receipt["operation"])
+
+    def test_schema_v2_doctor_reports_desired_vs_installed_drift(self) -> None:
+        target = self.root / "v2-target"
+        target.mkdir()
+        desired = {
+            "schema_version": 2,
+            "agents": [],
+            "composition": {"profile": "full-template", "extras": []},
+            "paths": {
+                "state_dir": "state",
+                "sessions_dir": "sessions",
+                "task_file": "TODO.md",
+            },
+            "template": {
+                "source": self.candidate.name,
+                "version": self.candidate.version,
+                "bundle_sha256": self.candidate.digest,
+            },
+        }
+        proposal_path, proposal = create_guided_composition_proposal(
+            target_root=target,
+            workspace_config=desired,
+            candidate=self.candidate,
+            desired_components=["core", "addon"],
+            now=NOW,
+        )
+        apply_proposal(target, proposal_path, proposal["proposal_digest"], "generic")
+
+        healthy = doctor(target)
+        healthy_check = next(
+            item
+            for item in healthy["checks"]
+            if item["name"] == "desired-installed-components"
+        )
+        self.assertEqual("pass", healthy_check["status"], healthy_check)
+        self.assertEqual(
+            "current", healthy["workspace"]["composition"]["status"]
+        )
+
+        installed_path = target / INSTALLED_STATE_PATH
+        installed = json.loads(installed_path.read_text(encoding="utf-8"))
+        installed["components"] = ["core"]
+        installed_path.write_text(
+            json.dumps(installed, indent=2) + "\n", encoding="utf-8"
+        )
+        drifted = doctor(target)
+        drift_check = next(
+            item
+            for item in drifted["checks"]
+            if item["name"] == "desired-installed-components"
+        )
+        self.assertEqual("fail", drift_check["status"])
+        self.assertEqual(
+            ["addon"],
+            drifted["workspace"]["composition"]["missing_components"],
+        )
+
+    def test_guided_init_reconcile_remove_and_add_share_transaction_path(self) -> None:
+        target = self.root / "guided-target"
+        target.mkdir()
+        common = (
+            "--target", str(target),
+            "--lock", str(self.candidate.lock_path),
+            "--source", str(self.candidate.root),
+            "--expect-sha256", self.candidate.digest,
+            "--now", NOW.isoformat(),
+        )
+        initialized = self.guided_cli(
+            "workspace", "init", *common,
+            "--agents", "none", "--profile", "full-template",
+        )
+        self.assertEqual(["core", "addon"], initialized["desired_components"])
+        apply_proposal(
+            target,
+            target / initialized["proposal"],
+            initialized["proposal_digest"],
+            "generic",
+        )
+        self.assertTrue((target / "addon.txt").is_file())
+
+        (target / INSTALLED_STATE_PATH).unlink()
+        reconciled = self.guided_cli("workspace", "reconcile", *common)
+        self.assertEqual([], reconciled["current_components"])
+        self.assertEqual(["core", "addon"], reconciled["desired_components"])
+        apply_proposal(
+            target,
+            target / reconciled["proposal"],
+            reconciled["proposal_digest"],
+            "generic",
+        )
+
+        removed = self.guided_cli(
+            "workspace", "update", *common,
+            "--agents", "none", "--profile", "selected",
+        )
+        apply_proposal(
+            target,
+            target / removed["proposal"],
+            removed["proposal_digest"],
+            "generic",
+        )
+        self.assertFalse((target / "addon.txt").exists())
+
+        added = self.guided_cli(
+            "workspace", "update", *common,
+            "--agents", "none", "--profile", "selected", "--extras", "addon",
+        )
+        apply_proposal(
+            target,
+            target / added["proposal"],
+            added["proposal_digest"],
+            "generic",
+        )
+        self.assertTrue((target / "addon.txt").is_file())
+        self.assertTrue((target / INSTALLED_STATE_PATH).is_file())
+
+        upgrade_root = self.root / "guided-upgrade-source"
+        upgrade_root.mkdir()
+        upgrade_fixture = BundleFixture(
+            upgrade_root,
+            version="3.0.0",
+            managed=b"binary\x00v3\n",
+            addon=True,
+        )
+        upgrade = upgrade_fixture.verify()
+        upgraded = self.guided_cli(
+            "workspace", "update",
+            "--target", str(target),
+            "--lock", str(upgrade.lock_path),
+            "--source", str(upgrade.root),
+            "--expect-sha256", upgrade.digest,
+            "--current-lock", str(self.candidate.lock_path),
+            "--current-source", str(self.candidate.root),
+            "--expect-current-sha256", self.candidate.digest,
+            "--agents", "none", "--profile", "selected", "--extras", "addon",
+            "--now", NOW.isoformat(),
+        )
+        apply_proposal(
+            target,
+            target / upgraded["proposal"],
+            upgraded["proposal_digest"],
+            "generic",
+        )
+        self.assertEqual(b"binary\x00v3\n", (target / "managed.bin").read_bytes())
+        self.assertEqual(
+            upgrade.digest,
+            json.loads(
+                (target / "contextos.workspace.json").read_text(encoding="utf-8")
+            )["template"]["bundle_sha256"],
+        )
+
+        moved = self.root / "moved-clean-clone"
+        shutil.copytree(target, moved, ignore=shutil.ignore_patterns(".context-os"))
+        moved_common = (
+            "--target", str(moved),
+            "--lock", str(upgrade.lock_path),
+            "--source", str(upgrade.root),
+            "--expect-sha256", upgrade.digest,
+            "--now", NOW.isoformat(),
+        )
+        moved_reconcile = self.guided_cli(
+            "workspace", "reconcile", *moved_common
+        )
+        apply_proposal(
+            moved,
+            moved / moved_reconcile["proposal"],
+            moved_reconcile["proposal_digest"],
+            "generic",
+        )
+        self.assertEqual(
+            "current", doctor(moved)["workspace"]["composition"]["status"]
+        )
+
+    def test_selected_projection_has_one_owner_and_no_omitted_runtime_claims(self) -> None:
+        source = self.root / "entry-source"
+        source.mkdir()
+        fixture = BundleFixture(
+            source,
+            version="4.0.0",
+            managed=b"entry\n",
+            addon=False,
+            runtime_addon=False,
+            entry_surfaces=True,
+        )
+        candidate = fixture.verify()
+        target = self.root / "entry-target"
+        target.mkdir()
+        initialized = self.guided_cli(
+            "workspace", "init",
+            "--target", str(target),
+            "--lock", str(fixture.lock_path),
+            "--source", str(source),
+            "--expect-sha256", candidate.digest,
+            "--agents", "codex",
+            "--profile", "selected",
+            "--now", NOW.isoformat(),
+        )
+        generated_owners = {
+            change["path"]: change["owner"]
+            for change in initialized["changes"]
+            if change["path"] in {"README.md", "AGENTS.md"}
+        }
+        self.assertEqual(
+            {"README.md": "core", "AGENTS.md": "agents-instructions"},
+            generated_owners,
+        )
+        apply_proposal(
+            target,
+            target / initialized["proposal"],
+            initialized["proposal_digest"],
+            "generic",
+        )
+        readme = (target / "README.md").read_text(encoding="utf-8")
+        agents = (target / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn("owner=core", readme)
+        self.assertIn("owner=agents-instructions", agents)
+        self.assertIn("Codex", readme)
+        self.assertIn("Codex", agents)
+        self.assertNotIn("Hermes", readme)
+        self.assertNotIn("Hermes", agents)
+
+        core_target = self.root / "core-entry-target"
+        core_target.mkdir()
+        core_initialized = self.guided_cli(
+            "workspace", "init",
+            "--target", str(core_target),
+            "--lock", str(fixture.lock_path),
+            "--source", str(source),
+            "--expect-sha256", candidate.digest,
+            "--agents", "none",
+            "--profile", "selected",
+            "--now", NOW.isoformat(),
+        )
+        apply_proposal(
+            core_target,
+            core_target / core_initialized["proposal"],
+            core_initialized["proposal_digest"],
+            "generic",
+        )
+        core_readme = (core_target / "README.md").read_text(encoding="utf-8")
+        self.assertIn("Core-only", core_readme)
+        self.assertNotIn("Codex", core_readme)
+        self.assertNotIn("Hermes", core_readme)
+        self.assertFalse((core_target / "AGENTS.md").exists())
+
+    def test_guided_legacy_yaml_and_schema_v1_migrate_transactionally(self) -> None:
+        legacy_target = self.root / "legacy-yaml-target"
+        legacy_target.mkdir()
+        (legacy_target / "workspace.yaml").write_text(
+            "state_dir: memory\nsessions_dir: handoffs\ntask_file: TASKS.md\n",
+            encoding="utf-8",
+        )
+        common = (
+            "--lock", str(self.candidate.lock_path),
+            "--source", str(self.candidate.root),
+            "--expect-sha256", self.candidate.digest,
+            "--agents", "none", "--profile", "full-template",
+            "--now", NOW.isoformat(),
+        )
+        initialized = self.guided_cli(
+            "workspace", "init", "--target", str(legacy_target), *common
+        )
+        self.assertIn(
+            "workspace.yaml",
+            [change["path"] for change in initialized["changes"]],
+        )
+        apply_proposal(
+            legacy_target,
+            legacy_target / initialized["proposal"],
+            initialized["proposal_digest"],
+            "generic",
+        )
+        migrated = json.loads(
+            (legacy_target / "contextos.workspace.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(2, migrated["schema_version"])
+        self.assertEqual("memory", migrated["paths"]["state_dir"])
+        self.assertFalse((legacy_target / "workspace.yaml").exists())
+
+        v1_target = self.root / "schema-v1-target"
+        shutil.copytree(self.candidate.root, v1_target)
+        v1_config = workspace(self.candidate.name, self.candidate.version)
+        v1_config["agents"] = []
+        (v1_target / "contextos.workspace.json").write_text(
+            json.dumps(v1_config, indent=2) + "\n", encoding="utf-8"
+        )
+        updated = self.guided_cli(
+            "workspace", "update", "--target", str(v1_target), *common
+        )
+        apply_proposal(
+            v1_target,
+            v1_target / updated["proposal"],
+            updated["proposal_digest"],
+            "generic",
+        )
+        migrated_v1 = json.loads(
+            (v1_target / "contextos.workspace.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(2, migrated_v1["schema_version"])
+        self.assertEqual(
+            self.candidate.digest, migrated_v1["template"]["bundle_sha256"]
+        )
 
     def test_marker_only_core_profile_can_materialize_verified_product_authority(self) -> None:
         target = self.root / "marker-only-target"
@@ -275,7 +585,10 @@ class MaterializerTest(unittest.TestCase):
                     "--confirm", compose_report["proposal_digest"],
                 ]),
             )
-        self.assertEqual("component-materialize", json.loads(apply_output.getvalue())["operation"])
+        apply_report = json.loads(apply_output.getvalue())
+        self.assertEqual("component-materialize", apply_report["operation"])
+        self.assertIn(apply_report["validation"]["status"], {"pass", "warn", "fail"})
+        self.assertEqual("profile", apply_report["validation"]["scope"])
         self.assertEqual(b"index line\n", (target / "managed.bin").read_bytes())
 
         propose_output = io.StringIO()

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -345,7 +345,7 @@ class MaterializerTest(unittest.TestCase):
             source,
             version="4.0.0",
             managed=b"entry\n",
-            addon=False,
+            addon=True,
             runtime_addon=False,
             entry_surfaces=True,
         )
@@ -385,6 +385,47 @@ class MaterializerTest(unittest.TestCase):
         self.assertIn("Codex", agents)
         self.assertNotIn("Hermes", readme)
         self.assertNotIn("Hermes", agents)
+        guide = (target / "GUIDE.md").read_text(encoding="utf-8")
+        self.assertIn("[managed payload](managed.bin)", guide)
+        self.assertIn("the optional add-on is omitted", guide)
+        self.assertNotIn("(addon.txt)", guide)
+        self.assertFalse((target / "addon.txt").exists())
+
+        upgrade_source = self.root / "entry-upgrade-source"
+        upgrade_source.mkdir()
+        upgrade_fixture = BundleFixture(
+            upgrade_source,
+            version="5.0.0",
+            managed=b"entry v5\n",
+            addon=True,
+            runtime_addon=False,
+            entry_surfaces=True,
+        )
+        upgrade = upgrade_fixture.verify()
+        upgraded = self.guided_cli(
+            "workspace", "update",
+            "--target", str(target),
+            "--lock", str(upgrade_fixture.lock_path),
+            "--source", str(upgrade_source),
+            "--expect-sha256", upgrade.digest,
+            "--current-lock", str(fixture.lock_path),
+            "--current-source", str(source),
+            "--expect-current-sha256", candidate.digest,
+            "--agents", "codex",
+            "--profile", "selected",
+            "--now", NOW.isoformat(),
+        )
+        apply_proposal(
+            target,
+            target / upgraded["proposal"],
+            upgraded["proposal_digest"],
+            "generic",
+        )
+        self.assertEqual(b"entry v5\n", (target / "managed.bin").read_bytes())
+        self.assertIn(
+            "[managed payload](managed.bin)",
+            (target / "GUIDE.md").read_text(encoding="utf-8"),
+        )
 
         core_target = self.root / "core-entry-target"
         core_target.mkdir()

--- a/tests/test_materializer.py
+++ b/tests/test_materializer.py
@@ -371,6 +371,18 @@ class MaterializerTest(unittest.TestCase):
             {"README.md": "core", "AGENTS.md": "agents-instructions"},
             generated_owners,
         )
+        initialized_proposal = json.loads(
+            (target / initialized["proposal"]).read_text(encoding="utf-8")
+        )
+        guide_plan = next(
+            action
+            for action in initialized_proposal["authorization"]["plan"]["actions"]
+            if action["path"] == "GUIDE.md"
+        )
+        self.assertNotEqual(
+            guide_plan["desired"]["sha256_raw"],
+            guide_plan["desired"]["sha256_text_lf"],
+        )
         apply_proposal(
             target,
             target / initialized["proposal"],

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -36,9 +36,9 @@ class ReleaseFixture:
             shutil.copyfile(source, root / "contextos" / source.name)
             contextos_paths.append((f"contextos/{source.name}", "managed"))
         workspace = {
-            "schema_version": 1,
-            "mode": "full-template",
+            "schema_version": 2,
             "agents": ["codex"],
+            "composition": {"profile": "full-template", "extras": []},
             "paths": {
                 "state_dir": "state",
                 "sessions_dir": "sessions",
@@ -47,6 +47,7 @@ class ReleaseFixture:
             "template": {
                 "version": self.version,
                 "source": "agent-context-os-template",
+                "bundle_sha256": "0" * 64,
             },
         }
         (root / "workspace/example.json").write_text(

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -366,6 +366,7 @@ class WorkspaceConfigTest(unittest.TestCase):
                     runtimes,
                     closure,
                     source_texts=source_texts,
+                    selected_paths=tuple(selected_paths),
                     available_paths=tuple(available_paths),
                 )
                 self.assertIn("README.md", generated)

--- a/tests/test_workspace_config.py
+++ b/tests/test_workspace_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import io
 import os
+import posixpath
 import re
 import subprocess
 import tempfile
@@ -21,12 +22,19 @@ from contextos.kernel import (
     workspace_resolution_report,
 )
 from contextos.cli import main as cli_main
+from contextos.component_schema import resolved_component_paths
+from contextos.workspace_composition import (
+    WorkspaceCompositionError,
+    desired_component_closure,
+)
+from contextos.workspace_projection import closure_aware_files
 from contextos.workspace_schema import (
     DEFAULT_PATHS,
     DEFAULT_TEMPLATE_VERSION,
     WorkspaceConfigError,
     analyze_legacy_workspace,
     load_workspace_config,
+    migrate_v1_workspace_config,
     parse_agent_selection,
     render_workspace_config,
     strict_json_loads,
@@ -37,6 +45,13 @@ from contextos.workspace_schema import (
 
 ROOT = Path(__file__).resolve().parents[1]
 KNOWN = set(runtime_ids(ROOT))
+KNOWN_COMPONENTS = {
+    item["id"]
+    for item in json.loads(
+        (ROOT / "components/manifest.json").read_text(encoding="utf-8")
+    )["components"]
+}
+FIXTURE_DIGEST = "a" * 64
 
 
 def make_directory_link(link: Path, target: Path) -> None:
@@ -62,6 +77,22 @@ def config(**overrides: object) -> dict[str, object]:
         "template": {
             "version": "0.12.0",
             "source": "agent-context-os-template",
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def v2_config(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": 2,
+        "agents": ["claude", "codex"],
+        "composition": {"profile": "selected", "extras": ["example-project"]},
+        "paths": dict(DEFAULT_PATHS),
+        "template": {
+            "version": "0.12.0",
+            "source": "agent-context-os-template",
+            "bundle_sha256": FIXTURE_DIGEST,
         },
     }
     value.update(overrides)
@@ -96,6 +127,7 @@ class WorkspaceConfigTest(unittest.TestCase):
             ROOT / "workspace/example.json",
             root=ROOT,
             known_runtime_ids=KNOWN,
+            known_component_ids=KNOWN_COMPONENTS,
         )
         self.assertTrue(canonical)
         self.assertEqual([], loaded["agents"])
@@ -105,7 +137,10 @@ class WorkspaceConfigTest(unittest.TestCase):
         if os.environ.get("CONTEXTOS_VALIDATION_PROFILE") == "workspace" \
                 and live_path.exists():
             live, _live_canonical = load_workspace_config(
-                live_path, root=ROOT, known_runtime_ids=KNOWN
+                live_path,
+                root=ROOT,
+                known_runtime_ids=KNOWN,
+                known_component_ids=KNOWN_COMPONENTS,
             )
             self.assertLessEqual(set(live["agents"]), KNOWN)
         else:
@@ -163,8 +198,8 @@ class WorkspaceConfigTest(unittest.TestCase):
         mutations.append((extra, "unknown unknown"))
         boolean = config(schema_version=True)
         mutations.append((boolean, "integer 1"))
-        future = config(schema_version=2)
-        mutations.append((future, "integer 1"))
+        malformed_v2 = config(schema_version=2)
+        mutations.append((malformed_v2, "missing composition"))
         mode = config(mode="composed")
         mutations.append((mode, "full-template"))
         missing_path = config(paths={"state_dir": "state", "sessions_dir": "sessions"})
@@ -200,6 +235,172 @@ class WorkspaceConfigTest(unittest.TestCase):
                 WorkspaceConfigError, "paths"
             ):
                 validate_workspace_config(config(paths=paths), known_runtime_ids=KNOWN)
+
+    def test_schema_v2_is_canonical_closed_and_bundle_pinned(self) -> None:
+        value = validate_workspace_config(
+            v2_config(
+                agents=["codex", "claude"],
+                composition={
+                    "profile": "selected",
+                    "extras": ["example-project", "agents-instructions"],
+                },
+            ),
+            known_runtime_ids=KNOWN,
+            known_component_ids=KNOWN_COMPONENTS,
+        )
+        self.assertEqual(["claude", "codex"], value["agents"])
+        self.assertEqual(
+            ["agents-instructions", "example-project"],
+            value["composition"]["extras"],
+        )
+        for mutation, message in (
+            (
+                v2_config(
+                    composition={"profile": "full-template", "extras": ["core"]}
+                ),
+                "must be empty",
+            ),
+            (
+                v2_config(
+                    composition={"profile": "selected", "extras": ["missing"]}
+                ),
+                "unknown id",
+            ),
+            (
+                v2_config(
+                    template={
+                        "version": "0.12.0",
+                        "source": "agent-context-os-template",
+                        "bundle_sha256": "A" * 64,
+                    }
+                ),
+                "lowercase SHA-256",
+            ),
+        ):
+            with self.subTest(message=message), self.assertRaisesRegex(
+                WorkspaceConfigError, message
+            ):
+                validate_workspace_config(
+                    mutation,
+                    known_runtime_ids=KNOWN,
+                    known_component_ids=KNOWN_COMPONENTS,
+                )
+
+    def test_v1_to_v2_migration_is_explicit_and_preserves_intent(self) -> None:
+        cases = json.loads(
+            (ROOT / "tests/fixtures/workspace-v2-migrations.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for case in cases:
+            with self.subTest(case=case["id"]):
+                if "error" in case:
+                    with self.assertRaisesRegex(
+                        WorkspaceConfigError, case["error"]
+                    ):
+                        migrate_v1_workspace_config(
+                            case["source"],
+                            known_runtime_ids=KNOWN,
+                            known_component_ids=KNOWN_COMPONENTS,
+                            bundle_sha256=FIXTURE_DIGEST,
+                        )
+                else:
+                    first = migrate_v1_workspace_config(
+                        case["source"],
+                        known_runtime_ids=KNOWN,
+                        known_component_ids=KNOWN_COMPONENTS,
+                        bundle_sha256=FIXTURE_DIGEST,
+                    )
+                    second = migrate_v1_workspace_config(
+                        case["source"],
+                        known_runtime_ids=KNOWN,
+                        known_component_ids=KNOWN_COMPONENTS,
+                        bundle_sha256=FIXTURE_DIGEST,
+                    )
+                    self.assertEqual(case["expected"], first)
+                    self.assertEqual(first, second)
+
+    def test_selected_core_and_single_runtime_entry_surfaces_match_closure(self) -> None:
+        manifest = json.loads(
+            (ROOT / "components/manifest.json").read_text(encoding="utf-8")
+        )
+        runtimes = {
+            runtime_id: json.loads(
+                (ROOT / "runtimes" / f"{runtime_id}.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            for runtime_id in KNOWN
+        }
+        display_names = {
+            runtime_id: runtime["display_name"]
+            for runtime_id, runtime in runtimes.items()
+        }
+        for agents in ([], ["codex"]):
+            with self.subTest(agents=agents):
+                desired_config = v2_config(
+                    agents=agents,
+                    composition={"profile": "selected", "extras": []},
+                )
+                closure = desired_component_closure(
+                    desired_config, manifest, runtimes
+                )
+                selected_paths = {
+                    item["path"]
+                    for item in resolved_component_paths(manifest, closure)
+                }
+                source_texts = {
+                    path: (ROOT / path).read_text(encoding="utf-8")
+                    for path in selected_paths
+                    if path.endswith(".md")
+                }
+                available_paths = {
+                    item["path"]
+                    for item in resolved_component_paths(
+                        manifest,
+                        [item["id"] for item in manifest["components"]],
+                    )
+                }
+                generated = closure_aware_files(
+                    desired_config,
+                    runtimes,
+                    closure,
+                    source_texts=source_texts,
+                    available_paths=tuple(available_paths),
+                )
+                self.assertIn("README.md", generated)
+                self.assertEqual(bool(agents), "AGENTS.md" in generated)
+                entry_surfaces = [generated["README.md"]]
+                if agents:
+                    entry_surfaces.append(generated["AGENTS.md"])
+                combined = "\n".join(entry_surfaces)
+                for runtime_id, display_name in display_names.items():
+                    if runtime_id in agents:
+                        self.assertIn(display_name, combined)
+                    else:
+                        self.assertNotIn(display_name, combined)
+                for source, original in source_texts.items():
+                    text = generated.get(source, original)
+                    for link in re.findall(
+                        r"\[[^\]]+\]\((?!https?://|#|mailto:)([^)#]+)", text
+                    ):
+                        target = posixpath.normpath(
+                            posixpath.join(posixpath.dirname(source), link)
+                        )
+                        if target in available_paths:
+                            self.assertIn(target, selected_paths)
+
+        with self.assertRaisesRegex(
+            WorkspaceCompositionError, "duplicates runtime-required"
+        ):
+            desired_component_closure(
+                v2_config(
+                    agents=["codex"],
+                    composition={"profile": "selected", "extras": ["core"]},
+                ),
+                manifest,
+                runtimes,
+            )
 
     def test_generated_path_pattern_rejects_dot_segments_not_dotfiles(self) -> None:
         pattern = workspace_schema_document()["properties"]["paths"]["properties"][
@@ -264,6 +465,17 @@ class WorkspaceConfigTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(ContextOSError, "duplicate JSON"):
             resolve_workspace(self.root)
+
+    def test_schema_v2_marker_only_root_remains_discoverable(self) -> None:
+        marker = v2_config(
+            agents=[],
+            composition={"profile": "selected", "extras": []},
+        )
+        self.write_json(marker)
+        resolution = resolve_workspace(self.root)
+        self.assertEqual("json", resolution.source)
+        self.assertEqual(2, resolution.config["schema_version"])
+        self.assertEqual([], list(resolution.agents or ()))
 
     def test_valid_json_ignores_but_reports_malformed_shadowed_yaml(self) -> None:
         self.write_json(config())

--- a/workspace/example.json
+++ b/workspace/example.json
@@ -1,7 +1,10 @@
 {
-  "schema_version": 1,
-  "mode": "full-template",
+  "schema_version": 2,
   "agents": [],
+  "composition": {
+    "profile": "full-template",
+    "extras": []
+  },
   "paths": {
     "state_dir": "state",
     "sessions_dir": "sessions",
@@ -9,6 +12,7 @@
   },
   "template": {
     "version": "0.12.0",
-    "source": "agent-context-os-template"
+    "source": "agent-context-os-template",
+    "bundle_sha256": "854373a7e3a46675a1d301401d49471485dfdd646efb6d5f73e12a3bfbc7c167"
   }
 }

--- a/workspace/example.json
+++ b/workspace/example.json
@@ -13,6 +13,6 @@
   "template": {
     "version": "0.12.0",
     "source": "agent-context-os-template",
-    "bundle_sha256": "854373a7e3a46675a1d301401d49471485dfdd646efb6d5f73e12a3bfbc7c167"
+    "bundle_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/workspace/schema.json
+++ b/workspace/schema.json
@@ -1,22 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$comment": "Generated structural subset. contextos.workspace_schema is authoritative for runtime-registry membership, portable path safety, semantic set uniqueness, role collisions, and canonical rendering.",
+  "$comment": "Generated structural subset. contextos.workspace_schema is authoritative for runtime/component-registry membership, portable path safety, semantic set uniqueness, role collisions, and canonical rendering. Schema-v1 documents are accepted only as migration inputs.",
   "title": "Context OS tracked workspace configuration",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schema_version",
-    "mode",
     "agents",
+    "composition",
     "paths",
     "template"
   ],
   "properties": {
     "schema_version": {
-      "const": 1
-    },
-    "mode": {
-      "const": "full-template"
+      "const": 2
     },
     "agents": {
       "type": "array",
@@ -25,6 +22,48 @@
         "type": "string",
         "pattern": "^[a-z][a-z0-9-]*$"
       }
+    },
+    "composition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile",
+        "extras"
+      ],
+      "properties": {
+        "profile": {
+          "enum": [
+            "full-template",
+            "selected"
+          ]
+        },
+        "extras": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "profile": {
+                "const": "full-template"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "extras": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ]
     },
     "paths": {
       "type": "object",
@@ -57,7 +96,8 @@
       "additionalProperties": false,
       "required": [
         "version",
-        "source"
+        "source",
+        "bundle_sha256"
       ],
       "properties": {
         "version": {
@@ -69,6 +109,10 @@
           "type": "string",
           "minLength": 1,
           "pattern": "^(?!\\s)(?:[^\\u0000-\\u001f\\u007f]*\\S)$"
+        },
+        "bundle_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
         }
       }
     }


### PR DESCRIPTION
## Summary

- introduce normative workspace schema v2 with tracked runtimes, selected/full-template composition, extras, and exact bundle digest
- add guided `workspace init`, `workspace update`, and `workspace reconcile` flows using the existing proposal/journal/rollback/receipt transaction
- track installed bundle state locally and report desired-vs-installed drift through doctor
- migrate schema v1 and safe legacy YAML transactionally
- generate closure-aware shared entry surfaces and preserve links to selected non-Markdown paths while degrading omitted links without deleting prose
- add clean-clone adoption, selected cross-bundle upgrade, Windows/Linux portability, release-artifact, and bounded-retention controls

Closes #118.

Follow-up: #158 records the cycle-capped medium finding that the resource report should model concurrent staged-write and projection-Markdown retention during selected apply. This affects reporting accuracy, not materialization correctness or transaction safety.

## Validation

- `scripts/validate-all.sh`
  - 635 tests passed, 47 skipped
  - portability and hook checks passed
  - link/reachability, generated schemas/catalogs, component ownership, runtime registry, JSON checks passed
- `python scripts/measure-bundle-materialization.py --check`
  - full-template compose/upgrade process counts: 48/96
  - selected compose/upgrade process counts: 72/144
  - zero per-blob Git processes in all four flows
- WSL targeted migration, init/reconcile/update/upgrade/move, selected projection, and closure-link checks passed

## Exact-SHA cross-model review

Reviewed commit: `21909c97440ee1637646a2935772d6b11e6ac9a5`

- authenticated Claude Opus, adversarial architecture/resource lens
- Hermes via OpenRouter `thinkingmachines/inkling:free` (live prompt/completion prices both zero), operational/CI lens

Three capped fix-and-reverify cycles closed proposal/apply projection divergence, selected-path link classification, release example self-reference, prose deletion, newline-normalized hashes, compatibility failures, exact projection retention, and selected resource-gate coverage. Hermes reported no material findings. Claude’s remaining medium reporting-model finding is filed as #158 per the stop rule.