### PR TITLE
fix: account for concurrent selected apply buffers

### DIFF
--- a/docs/bundle-locks.md
+++ b/docs/bundle-locks.md
@@ -158,11 +158,12 @@ this raw-buffer metric. Full-template proposal planning requests no bundle
 payload retention. Selected-profile planning performs a separate streaming
 verification that retains only Markdown paths in the selected component closure
 while it computes closure-aware projections. Its bound uses the same formula
-with those selected Markdown paths as the requested set. The projection pass is
-sequential with ordinary candidate/current verification, so candidate write
-payloads are not retained again unless they are themselves selected Markdown.
-Apply retains only candidate bundle payloads referenced by write changes; those
-verified bytes are released when transaction staging completes.
+with those selected Markdown paths as the requested set. During selected apply,
+the outer verified candidate still holds bundle-backed write payloads while the
+separate projection verification runs. The concurrent logical peak and bound
+therefore add those outer retained bytes to the larger candidate/current
+projection verification metric; overlapping paths may occupy both buffers.
+Candidate write payloads are released when transaction staging completes.
 
 Maintainers can report the current full-template and selected-profile compose
 and upgrade bounds on Linux or Windows with:
@@ -178,8 +179,9 @@ change one managed bundle path so their retained-payload observations are
 nonzero. CI checks process batching and exact subprocess counts for all four
 flows on both platforms, but records time and memory without platform-sensitive
 thresholds because shared-runner measurements are not stable correctness
-signals. Exact subset-retention tests enforce the payload policy separately,
-including exclusion of omitted-component Markdown.
+signals. Selected metrics also report the concurrent apply peak and bound.
+Exact subset-retention tests enforce the payload policy separately, including
+exclusion of omitted-component Markdown.
 
 ## Low-level materializer interface
 

--- a/scripts/measure-bundle-materialization.py
+++ b/scripts/measure-bundle-materialization.py
@@ -212,8 +212,42 @@ def _metric(
     observed_retained_payload_bytes: int,
     traced_python_peak_bytes: int,
     projection_paths: set[str] | None = None,
+    current_projection_lock: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     projection_paths = set() if projection_paths is None else projection_paths
+    records = {item["path"]: item["size"] for item in lock["bundle"]["files"]}
+    retained_payload_bytes = sum(records[path] for path in retained_paths)
+    projection_locks = (
+        (lock, current_projection_lock)
+        if current_projection_lock is not None
+        else (lock,)
+    )
+    projection_peak = max(
+        _logical_verification_peak(
+            projection_lock,
+            role="candidate",
+            retain_paths=projection_paths,
+        )
+        for projection_lock in projection_locks
+    )
+    projection_bound = max(
+        _logical_verification_bound(
+            projection_lock,
+            role="candidate",
+            retain_paths=projection_paths,
+        )
+        for projection_lock in projection_locks
+    )
+    concurrent_peak = (
+        retained_payload_bytes + projection_peak
+        if projection_paths
+        else None
+    )
+    concurrent_bound = (
+        retained_payload_bytes + projection_bound
+        if projection_paths
+        else None
+    )
     batch_commands = [
         command for command in commands if "cat-file" in command and "--batch" in command
     ]
@@ -230,6 +264,7 @@ def _metric(
         _logical_verification_peak(
             lock, role="candidate", retain_paths=projection_paths
         ),
+        concurrent_peak or 0,
     )
     logical_bound = max(
         _logical_verification_bound(lock, role="candidate", retain_paths=set()),
@@ -239,6 +274,7 @@ def _metric(
         _logical_verification_bound(
             lock, role="candidate", retain_paths=projection_paths
         ),
+        concurrent_bound or 0,
     )
     return {
         "git_subprocess_count": len(commands),
@@ -247,6 +283,8 @@ def _metric(
         "wall_seconds": round(time.perf_counter() - started, 6),
         "logical_peak_retained_payload_bytes": logical_peak,
         "logical_retained_payload_bound_bytes": logical_bound,
+        "logical_concurrent_apply_peak_bytes": concurrent_peak,
+        "logical_concurrent_apply_bound_bytes": concurrent_bound,
         "observed_staging_payload_bytes": observed_retained_payload_bytes,
         "tracemalloc_peak_bytes": traced_python_peak_bytes,
         "retained_bundle_path_count": len(retained_paths),
@@ -492,6 +530,7 @@ def measure() -> dict[str, Any]:
             max(selected_upgrade_retained, default=0),
             selected_upgrade_python_peak[0],
             selected_projection_paths,
+            current_lock,
         )
 
         return {

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -495,13 +495,30 @@ class BundleLockTest(unittest.TestCase):
             item["path"]: item["size"]
             for item in fixture.lock["bundle"]["files"]
         }
+        current_lock = copy.deepcopy(fixture.lock)
+        current_guide = next(
+            item
+            for item in current_lock["bundle"]["files"]
+            if item["path"] == "GUIDE.md"
+        )
+        current_guide["size"] += 10_000
         outer_bytes = sum(sizes[path] for path in retained)
-        expected_peak = outer_bytes + bundle_measurement._logical_verification_peak(
+        candidate_projection_peak = bundle_measurement._logical_verification_peak(
             fixture.lock, role="candidate", retain_paths=projection
         )
-        expected_bound = outer_bytes + bundle_measurement._logical_verification_bound(
+        current_projection_peak = bundle_measurement._logical_verification_peak(
+            current_lock, role="candidate", retain_paths=projection
+        )
+        candidate_projection_bound = bundle_measurement._logical_verification_bound(
             fixture.lock, role="candidate", retain_paths=projection
         )
+        current_projection_bound = bundle_measurement._logical_verification_bound(
+            current_lock, role="candidate", retain_paths=projection
+        )
+        self.assertGreater(current_projection_peak, candidate_projection_peak)
+        self.assertGreater(current_projection_bound, candidate_projection_bound)
+        expected_peak = outer_bytes + current_projection_peak
+        expected_bound = outer_bytes + current_projection_bound
         metric = bundle_measurement._metric(
             "selected_upgrade",
             time.perf_counter(),
@@ -511,6 +528,7 @@ class BundleLockTest(unittest.TestCase):
             observed_retained_payload_bytes=outer_bytes,
             traced_python_peak_bytes=0,
             projection_paths=projection,
+            current_projection_lock=current_lock,
         )
         union_peak = bundle_measurement._logical_verification_peak(
             fixture.lock,

--- a/tests/test_bundle_lock.py
+++ b/tests/test_bundle_lock.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import importlib.util
 import io
 import json
 import os
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -36,6 +38,12 @@ from contextos.primitives import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+MEASURE_SPEC = importlib.util.spec_from_file_location(
+    "bundle_measurement", ROOT / "scripts/measure-bundle-materialization.py"
+)
+assert MEASURE_SPEC is not None and MEASURE_SPEC.loader is not None
+bundle_measurement = importlib.util.module_from_spec(MEASURE_SPEC)
+MEASURE_SPEC.loader.exec_module(bundle_measurement)
 
 
 def digest(path: Path) -> str:
@@ -469,6 +477,53 @@ class BundleLockTest(unittest.TestCase):
             [{"AGENTS.md", "GUIDE.md", "README.md"}], retained_sets
         )
         self.assertNotIn("addon.md", retained_sets[0])
+
+    def test_selected_apply_metric_adds_outer_and_projection_buffers(self) -> None:
+        source = self.root / "concurrent-metric-source"
+        source.mkdir()
+        fixture = BundleFixture(
+            source,
+            version="2.0.0",
+            managed=b"selected\n",
+            addon=True,
+            runtime_addon=False,
+            entry_surfaces=True,
+        )
+        retained = {"managed.bin", "GUIDE.md"}
+        projection = {"AGENTS.md", "GUIDE.md", "README.md"}
+        sizes = {
+            item["path"]: item["size"]
+            for item in fixture.lock["bundle"]["files"]
+        }
+        outer_bytes = sum(sizes[path] for path in retained)
+        expected_peak = outer_bytes + bundle_measurement._logical_verification_peak(
+            fixture.lock, role="candidate", retain_paths=projection
+        )
+        expected_bound = outer_bytes + bundle_measurement._logical_verification_bound(
+            fixture.lock, role="candidate", retain_paths=projection
+        )
+        metric = bundle_measurement._metric(
+            "selected_upgrade",
+            time.perf_counter(),
+            [],
+            fixture.lock,
+            retained,
+            observed_retained_payload_bytes=outer_bytes,
+            traced_python_peak_bytes=0,
+            projection_paths=projection,
+        )
+        union_peak = bundle_measurement._logical_verification_peak(
+            fixture.lock,
+            role="candidate",
+            retain_paths=retained | projection,
+        )
+        self.assertEqual(expected_peak, metric["logical_concurrent_apply_peak_bytes"])
+        self.assertEqual(
+            expected_bound, metric["logical_concurrent_apply_bound_bytes"]
+        )
+        self.assertEqual(expected_peak, metric["logical_peak_retained_payload_bytes"])
+        self.assertEqual(expected_bound, metric["logical_retained_payload_bound_bytes"])
+        self.assertGreater(expected_peak, union_peak)
 
     def test_git_batch_reader_rejects_malformed_and_truncated_records(self) -> None:
         class BatchProcess:


### PR DESCRIPTION
## Summary

- model the selected-apply resource bound as outer retained candidate write payloads plus the larger candidate/current Markdown projection verification
- expose distinct logical concurrent apply peak and bound metrics
- document why overlapping paths can occupy both live buffers
- add a regression test covering a distinct, larger current projection

Closes #158

## Validation

- `python scripts/measure-bundle-materialization.py --check`
- `python -m unittest tests.test_bundle_lock`
- `bash scripts/validate-all.sh` (636 passed, 47 skipped)
- exact process gates preserved: full compose 48, upgrade 96, selected compose 72, selected upgrade 144
- omitted-addon.md control preserved

## Exact-SHA review

Reviewed commit: `3b44b5248fe83533957c4372dca6585ddd73ad49`

- Claude Sonnet (`claude-sonnet-5`): no material findings
- Hermes / OpenRouter (`thinkingmachines/inkling:free`, live zero-priced): no material findings
- repair cycle 1 addressed the initial Claude finding by exercising a distinct larger current projection and proving dropped-current/max-to-min regressions fail