### PR TITLE
fix(coordination): harden board dispatch and secret checks

### DIFF
--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -1511,6 +1511,7 @@ def validate_board(
                 fields, body = {}, ""
 
             if document_type == "message":
+                message_warnings: list[str] = []
                 required = ("from", "audience", "kind", "expires")
                 for key in required:
                     if key not in fields:
@@ -1531,7 +1532,7 @@ def validate_board(
                     else:
                         valid_reference, reason = _reference_status(root, fields["re"])
                         if not valid_reference:
-                            warnings.append(
+                            message_warnings.append(
                                 f"{path}: reference degraded to summary-only: {reason}"
                             )
 
@@ -1539,14 +1540,14 @@ def validate_board(
                 if audience is not None:
                     warning = _audience_notice(audience, roles, path)
                     if warning is not None:
-                        warnings.append(warning)
+                        message_warnings.append(warning)
                 matched = [
                     label
                     for label, pattern in _SUSPICIOUS_PATTERNS
                     if pattern.search(body)
                 ]
                 if matched:
-                    warnings.append(
+                    message_warnings.append(
                         f"{path}: suspicious imperative or authorization language: "
                         + ", ".join(matched)
                     )
@@ -1566,6 +1567,15 @@ def validate_board(
                 if secret_labels:
                     for key in ("from", "audience", "kind", "expires", "body"):
                         report[key] = _REDACTED_BOARD_VALUE
+                    # Some diagnostics interpolate metadata. Suppress every
+                    # per-message diagnostic once raw-text detection fires so
+                    # a warning cannot reintroduce the value just redacted.
+                    if message_warnings:
+                        warnings.append(
+                            f"{path}: diagnostics withheld for suspected credential material"
+                        )
+                else:
+                    warnings.extend(message_warnings)
                 message_reports.append(report)
             else:
                 required = ("task", "owner", "lease-expires")

--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -67,6 +67,7 @@ _SECRET_PATTERNS = (
     ("AWS access key ID", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
     ("private key block", re.compile(r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----")),
 )
+_REDACTED_BOARD_VALUE = "[redacted: suspected credential material]"
 
 
 def _secret_labels(value: str) -> list[str]:
@@ -1557,12 +1558,14 @@ def validate_board(
                     "audience": fields.get("audience"),
                     "kind": fields.get("kind"),
                     "expires": fields.get("expires"),
-                    "body": (
-                        "[redacted: suspected credential material]"
-                        if secret_labels
-                        else body
-                    ),
+                    "body": body,
                 }
+                # Detection scans the raw frontmatter and body.  If it fires,
+                # redact every user-controlled field that this report exposes,
+                # not only the body that is commonly the source of a match.
+                if secret_labels:
+                    for key in ("from", "audience", "kind", "expires", "body"):
+                        report[key] = _REDACTED_BOARD_VALUE
                 message_reports.append(report)
             else:
                 required = ("task", "owner", "lease-expires")

--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -54,6 +54,29 @@ _SUSPICIOUS_PATTERNS = (
     ("urgent", re.compile(r"\burgent\b", re.IGNORECASE)),
 )
 
+# These are intentionally narrow tripwires, not a claim of comprehensive secret
+# detection. Labels, rather than matched text, are returned to callers so a
+# validation report does not become another place that leaks a credential.
+_SECRET_PATTERNS = (
+    ("Context OS test canary", re.compile(r"\bCONTEXTOS_TEST_SECRET_[A-Z0-9_]+\b")),
+    (
+        "GitHub token",
+        re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"),
+    ),
+    ("OpenAI-style API key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b")),
+    ("AWS access key ID", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("private key block", re.compile(r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----")),
+)
+
+
+def _secret_labels(value: str) -> list[str]:
+    """Return detector labels only; never return credential-like matches."""
+    return [label for label, pattern in _SECRET_PATTERNS if pattern.search(value)]
+
+
+def _secret_error(labels: list[str]) -> str:
+    return "board content contains suspected credential material: " + ", ".join(labels)
+
 
 def _git(
     root: Path,
@@ -793,6 +816,16 @@ def post_message(
     if not isinstance(body, str) or not body.strip():
         raise ContextOSError("body must not be empty")
 
+    secret_labels = _secret_labels(
+        "\n".join(
+            value
+            for value in (sender_value, audience_value, kind_value, body, re_ref, expires, runtime_value)
+            if value is not None
+        )
+    )
+    if secret_labels:
+        raise ContextOSError(_secret_error(secret_labels))
+
     expiry_value = _expiry(expires, now=current, field="expires")
     normalized_ref, notices = _prepare_reference(root, re_ref)
 
@@ -1462,6 +1495,9 @@ def validate_board(
             except ContextOSError as exc:
                 errors.append(f"{path}: {exc}")
                 continue
+            secret_labels = _secret_labels(text) if document_type == "message" else []
+            if secret_labels:
+                file_errors.append(_secret_error(secret_labels))
             if document_type == "message" and len(text.encode("utf-8")) > MAX_MESSAGE_BYTES:
                 file_errors.append(
                     f"message exceeds the {MAX_MESSAGE_BYTES}-byte whole-file limit"
@@ -1521,7 +1557,11 @@ def validate_board(
                     "audience": fields.get("audience"),
                     "kind": fields.get("kind"),
                     "expires": fields.get("expires"),
-                    "body": body,
+                    "body": (
+                        "[redacted: suspected credential material]"
+                        if secret_labels
+                        else body
+                    ),
                 }
                 message_reports.append(report)
             else:

--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -1483,6 +1483,11 @@ def validate_board(
                 continue
             filename = PurePosixPath(path).name
             identifier = PurePosixPath(path).stem
+            reported_path = (
+                _REDACTED_BOARD_VALUE
+                if document_type == "message" and _secret_labels(path)
+                else path
+            )
             file_errors = _filename_errors(path)
             if identifier in seen_ids:
                 file_errors.append(
@@ -1494,9 +1499,15 @@ def validate_board(
             try:
                 text = _read_tree_text(root, head, path)
             except ContextOSError as exc:
-                errors.append(f"{path}: {exc}")
+                errors.append(f"{reported_path}: {exc}")
                 continue
-            secret_labels = _secret_labels(text) if document_type == "message" else []
+            secret_labels = (
+                _secret_labels(f"{path}\n{text}")
+                if document_type == "message"
+                else []
+            )
+            if secret_labels:
+                reported_path = _REDACTED_BOARD_VALUE
             if secret_labels:
                 file_errors.append(_secret_error(secret_labels))
             if document_type == "message" and len(text.encode("utf-8")) > MAX_MESSAGE_BYTES:
@@ -1553,8 +1564,8 @@ def validate_board(
                     )
 
                 report = {
-                    "id": identifier,
-                    "path": path,
+                    "id": _REDACTED_BOARD_VALUE if secret_labels else identifier,
+                    "path": reported_path,
                     "from": fields.get("from"),
                     "audience": fields.get("audience"),
                     "kind": fields.get("kind"),
@@ -1572,7 +1583,7 @@ def validate_board(
                     # a warning cannot reintroduce the value just redacted.
                     if message_warnings:
                         warnings.append(
-                            f"{path}: diagnostics withheld for suspected credential material"
+                            f"{reported_path}: diagnostics withheld for suspected credential material"
                         )
                 else:
                     warnings.extend(message_warnings)
@@ -1619,7 +1630,16 @@ def validate_board(
                     }
                 )
 
-            errors.extend(f"{path}: {finding}" for finding in file_errors)
+            if document_type == "message" and secret_labels:
+                # Filename and parser diagnostics can interpolate raw metadata.
+                # Preserve the actionable detector label, but withhold all
+                # other per-message diagnostics from a report that is meant
+                # not to echo suspected credential material.
+                file_errors = [
+                    _secret_error(secret_labels),
+                    "message diagnostics withheld for suspected credential material",
+                ]
+            errors.extend(f"{reported_path}: {finding}" for finding in file_errors)
 
     order_notices: list[str] = []
     ordered_claims = _current_claims(root, head, current, order_notices)

--- a/coordination/README.md
+++ b/coordination/README.md
@@ -29,7 +29,11 @@ exist on the `coordination` branch.
    overlap justifies reporting only — never deleting or rewriting another
    run's work.
 3. **No secrets, credentials, or sensitive personal data, ever.** Expiry
-   removes a message from the active view; git history keeps it forever.
+   removes a message from the active view; git history keeps it forever. `post`
+   rejects a narrow set of high-confidence credential shapes before it writes or
+   queues a message, and `validate` flags and redacts matching messages in its
+   report. This is a tripwire, not proof that content is safe; never rely on it
+   to approve a credential for the board.
 4. **The board is user-visible by design.** Plain files, git history, surfaced
    at session start.
 5. **Human-paced.** No always-on agents poll this board. The only sanctioned

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -901,6 +901,27 @@ class CoordinationTests(unittest.TestCase):
         self.assertNotIn(canary, json.dumps(report))
         self.assertEqual("[redacted: suspected credential material]", report["messages"][0]["body"])
 
+    def test_validate_redacts_frontmatter_when_it_contains_a_secret(self) -> None:
+        bootstrap_board(self.repo_a, now=NOW)
+        path = "coordination/board/20260831T143001Z-acde-claude-frontmatter.md"
+        canary = "CONTEXTOS_TEST_SECRET_FRONTMATTER"
+        self._plant_files(
+            {
+                path: (
+                    f"---\nfrom: {canary}\naudience: all\nkind: note\n"
+                    "expires: 2026-09-07T14:30:01Z\n---\n\n"
+                    "A manually planted invalid board message.\n"
+                )
+            },
+            "Plant frontmatter secret validation fixture",
+        )
+        report = validate_board(self.repo_a, now=NOW)
+        self.assertFalse(report["valid"])
+        self.assertNotIn(canary, json.dumps(report))
+        message = report["messages"][0]
+        for key in ("from", "audience", "kind", "expires", "body"):
+            self.assertEqual("[redacted: suspected credential material]", message[key])
+
     def test_claim_succession_after_release_and_lease_ttl_bound(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)
         with mock.patch.object(coordination.secrets, "token_hex", return_value="aaaa"):

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import io
 import json
 import subprocess
+import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
@@ -21,6 +24,7 @@ from contextos.coordination import (
     validate_board,
 )
 from contextos.kernel import ContextOSError
+from contextos.cli import main as cli_main
 
 
 NOW = datetime.fromisoformat("2026-08-31T14:30:00+00:00")
@@ -156,6 +160,15 @@ class CoordinationTests(unittest.TestCase):
         git(self.repo_b, "commit", "-m", message)
         git(self.repo_b, "push", "origin", "coordination:coordination")
         return self._remote_head(self.repo_b)
+
+    def _run_cli(self, *args: str, stdin: str = "") -> tuple[int, str, str]:
+        (self.repo_a / "AGENTS.md").write_text("# Fixture\n", encoding="utf-8")
+        (self.repo_a / "state").mkdir(exist_ok=True)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(sys, "stdin", io.StringIO(stdin)), redirect_stdout(stdout), redirect_stderr(stderr):
+            status = cli_main(["--root", str(self.repo_a), *args])
+        return status, stdout.getvalue(), stderr.getvalue()
 
     def test_bootstrap_creates_ref_and_second_bootstrap_is_noop(self) -> None:
         before_branch = git(
@@ -305,6 +318,65 @@ class CoordinationTests(unittest.TestCase):
         )
         self.assertNotIn(":", Path(receipt["path"]).name)
         self.assertTrue(receipt["delivered"])
+
+    def test_post_rejects_secret_before_bootstrap_queue_or_primary_mutation(self) -> None:
+        primary_before = git(self.repo_a, "rev-parse", "HEAD").stdout.strip()
+        with self.assertRaisesRegex(ContextOSError, "Context OS test canary") as caught:
+            post_message(
+                self.repo_a,
+                sender="claude/researcher",
+                audience="all",
+                kind="note",
+                body="CONTEXTOS_TEST_SECRET_BOARD_POST",
+                runtime="claude",
+                now=NOW,
+            )
+        self.assertNotIn("CONTEXTOS_TEST_SECRET_BOARD_POST", str(caught.exception))
+        self.assertEqual("", git(self.repo_a, "ls-remote", "origin", "refs/heads/coordination").stdout)
+        self.assertFalse((self.repo_a / ".contextos-outbox").exists())
+        self.assertEqual(primary_before, git(self.repo_a, "rev-parse", "HEAD").stdout.strip())
+
+    def test_post_allows_a_near_miss_to_keep_detection_narrow(self) -> None:
+        bootstrap_board(self.repo_a, now=NOW)
+        receipt = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="note",
+            body="CONTEXTOS_TEST_SECRETS is a documentation heading, not a canary.",
+            runtime="claude",
+            now=NOW,
+        )
+        self.assertTrue(receipt["delivered"])
+
+    def test_board_cli_dispatches_bootstrap_stdin_post_validate_and_rejection(self) -> None:
+        status, stdout, stderr = self._run_cli("board", "bootstrap", "--now", "2026-08-31T14:30:00Z")
+        self.assertEqual(0, status, stderr)
+        self.assertTrue(json.loads(stdout)["delivered"])
+
+        status, stdout, stderr = self._run_cli(
+            "board", "post", "--runtime", "claude", "--from", "claude/researcher",
+            "--audience", "all", "--kind", "note", "--body", "-",
+            "--now", "2026-08-31T14:30:01Z", stdin="CLI body from stdin\n",
+        )
+        self.assertEqual(0, status, stderr)
+        self.assertTrue(json.loads(stdout)["delivered"])
+
+        status, stdout, stderr = self._run_cli("board", "validate", "--now", "2026-08-31T14:30:02Z")
+        self.assertEqual(0, status, stderr)
+        self.assertTrue(json.loads(stdout)["valid"])
+
+        primary_before = git(self.repo_a, "rev-parse", "HEAD").stdout.strip()
+        status, stdout, stderr = self._run_cli(
+            "board", "post", "--runtime", "claude", "--from", "claude/researcher",
+            "--audience", "all", "--kind", "note", "--body", "CONTEXTOS_TEST_SECRET_CLI",
+            "--now", "2026-08-31T14:30:03Z",
+        )
+        self.assertEqual(2, status)
+        self.assertEqual("", stdout)
+        self.assertIn("Context OS test canary", stderr)
+        self.assertNotIn("CONTEXTOS_TEST_SECRET_CLI", stderr)
+        self.assertEqual(primary_before, git(self.repo_a, "rev-parse", "HEAD").stdout.strip())
 
     def test_non_fast_forward_race_retries_and_keeps_both_messages(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)
@@ -807,6 +879,27 @@ class CoordinationTests(unittest.TestCase):
         self.assertIn("user approved", joined_warnings)
         self.assertIn("run this now", joined_warnings)
         self.assertEqual(report["notices"], report["warnings"])
+
+    def test_validate_reports_secret_finding_without_echoing_the_message(self) -> None:
+        bootstrap_board(self.repo_a, now=NOW)
+        path = "coordination/board/20260831T143001Z-acde-claude-secret.md"
+        canary = "CONTEXTOS_TEST_SECRET_VALIDATE"
+        self._plant_files(
+            {
+                path: (
+                    "---\nfrom: claude/researcher\naudience: all\nkind: note\n"
+                    "expires: 2026-09-07T14:30:01Z\n---\n\n"
+                    f"Do not retain {canary}.\n"
+                )
+            },
+            "Plant secret validation fixture",
+        )
+        report = validate_board(self.repo_a, now=NOW)
+        self.assertFalse(report["valid"])
+        self.assertIn(path, "\n".join(report["errors"]))
+        self.assertIn("Context OS test canary", "\n".join(report["errors"]))
+        self.assertNotIn(canary, json.dumps(report))
+        self.assertEqual("[redacted: suspected credential material]", report["messages"][0]["body"])
 
     def test_claim_succession_after_release_and_lease_ttl_bound(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -896,7 +896,7 @@ class CoordinationTests(unittest.TestCase):
         )
         report = validate_board(self.repo_a, now=NOW)
         self.assertFalse(report["valid"])
-        self.assertIn(path, "\n".join(report["errors"]))
+        self.assertNotIn(path, json.dumps(report))
         self.assertIn("Context OS test canary", "\n".join(report["errors"]))
         self.assertNotIn(canary, json.dumps(report))
         self.assertEqual("[redacted: suspected credential material]", report["messages"][0]["body"])
@@ -922,6 +922,26 @@ class CoordinationTests(unittest.TestCase):
         message = report["messages"][0]
         for key in ("from", "audience", "kind", "expires", "body"):
             self.assertEqual("[redacted: suspected credential material]", message[key])
+
+    def test_validate_redacts_matching_message_path_and_id(self) -> None:
+        bootstrap_board(self.repo_a, now=NOW)
+        canary = "CONTEXTOS_TEST_SECRET_PATH"
+        path = f"coordination/board/20260831T143001Z-acde-{canary}.md"
+        self._plant_files(
+            {
+                path: (
+                    "---\nfrom: claude/researcher\naudience: all\nkind: note\n"
+                    "expires: 2026-09-07T14:30:01Z\n---\n\n"
+                    "A manually named invalid board message.\n"
+                )
+            },
+            "Plant path secret validation fixture",
+        )
+        report = validate_board(self.repo_a, now=NOW)
+        self.assertFalse(report["valid"])
+        self.assertNotIn(canary, json.dumps(report))
+        self.assertEqual("[redacted: suspected credential material]", report["messages"][0]["path"])
+        self.assertEqual("[redacted: suspected credential material]", report["messages"][0]["id"])
 
     def test_claim_succession_after_release_and_lease_ttl_bound(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -908,16 +908,17 @@ class CoordinationTests(unittest.TestCase):
         self._plant_files(
             {
                 path: (
-                    f"---\nfrom: {canary}\naudience: all\nkind: note\n"
+                    f"---\nfrom: claude/researcher\naudience: {canary}\nkind: note\n"
                     "expires: 2026-09-07T14:30:01Z\n---\n\n"
                     "A manually planted invalid board message.\n"
                 )
             },
             "Plant frontmatter secret validation fixture",
         )
-        report = validate_board(self.repo_a, now=NOW)
+        report = validate_board(self.repo_a, roles=["publisher"], now=NOW)
         self.assertFalse(report["valid"])
         self.assertNotIn(canary, json.dumps(report))
+        self.assertIn("diagnostics withheld", "\n".join(report["warnings"]))
         message = report["messages"][0]
         for key in ("from", "audience", "kind", "expires", "body"):
             self.assertEqual("[redacted: suspected credential material]", message[key])


### PR DESCRIPTION
## Summary

- reject narrow high-confidence credential tripwires before a board post can bootstrap, queue, commit, or push
- flag and redact matching existing board messages during validation
- add end-to-end CLI dispatch coverage for bootstrap, stdin posting, validation, and rejected input
- document the guardrail without treating it as comprehensive secret detection

Fixes #154

## Verification

- `python -m unittest discover -s tests -p test_coordination.py -k board_cli -v`
- `python -m unittest discover -s tests -p test_coordination.py -k secret -v`
- `bash scripts/validate-all.sh`