### PR TITLE
fix(release): recover unpublished draft lookup

### DIFF
--- a/scripts/stage-release.py
+++ b/scripts/stage-release.py
@@ -80,10 +80,26 @@ def _lookup_by_tag(
         f"repos/{repository}/releases/tags/{tag}",
     ], check=False)
     status, value = _included_json(completed)
-    if status == 404:
-        return None
-    _require(isinstance(value, dict), "release lookup response must be an object")
-    return value
+    if status != 404:
+        _require(isinstance(value, dict), "release lookup response must be an object")
+        return value
+
+    # GitHub's tag endpoint can return 404 for an unpublished draft even to a
+    # token that can list that draft. The list endpoint is therefore a bounded
+    # recovery read, not permission to create or alter another release.
+    listed = runner.run([
+        "gh", "api", "--include", "-H", "X-GitHub-Api-Version: 2026-03-10",
+        f"repos/{repository}/releases?per_page=100",
+    ], check=False)
+    list_status, releases = _included_json(listed)
+    _require(200 <= list_status < 300, f"release list returned HTTP {list_status}")
+    _require(isinstance(releases, list), "release list response must be an array")
+    matches = [
+        release for release in releases
+        if isinstance(release, dict) and release.get("tag_name") == tag
+    ]
+    _require(len(matches) <= 1, "release list contains multiple entries for the tag")
+    return matches[0] if matches else None
 
 
 def _exact_draft(

--- a/scripts/stage-release.py
+++ b/scripts/stage-release.py
@@ -85,20 +85,27 @@ def _lookup_by_tag(
         return value
 
     # GitHub's tag endpoint can return 404 for an unpublished draft even to a
-    # token that can list that draft. The list endpoint is therefore a bounded
-    # recovery read, not permission to create or alter another release.
-    listed = runner.run([
-        "gh", "api", "--include", "-H", "X-GitHub-Api-Version: 2026-03-10",
-        f"repos/{repository}/releases?per_page=100",
-    ], check=False)
-    list_status, releases = _included_json(listed)
-    _require(200 <= list_status < 300, f"release list returned HTTP {list_status}")
-    _require(isinstance(releases, list), "release list response must be an array")
-    matches = [
-        release for release in releases
-        if isinstance(release, dict) and release.get("tag_name") == tag
-    ]
-    _require(len(matches) <= 1, "release list contains multiple entries for the tag")
+    # token that can list that draft. Walk every page, rather than assuming the
+    # desired draft is among the newest 100 releases: an incomplete recovery
+    # read could otherwise create a duplicate for an older draft.
+    matches: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        listed = runner.run([
+            "gh", "api", "--include", "-H", "X-GitHub-Api-Version: 2026-03-10",
+            f"repos/{repository}/releases?per_page=100&page={page}",
+        ], check=False)
+        list_status, releases = _included_json(listed)
+        _require(200 <= list_status < 300, f"release list returned HTTP {list_status}")
+        _require(isinstance(releases, list), "release list response must be an array")
+        matches.extend(
+            release for release in releases
+            if isinstance(release, dict) and release.get("tag_name") == tag
+        )
+        _require(len(matches) <= 1, "release list contains multiple entries for the tag")
+        if len(releases) < 100:
+            break
+        page += 1
     return matches[0] if matches else None
 
 

--- a/tests/test_stage_release.py
+++ b/tests/test_stage_release.py
@@ -27,16 +27,18 @@ class FakeRunner:
     def __init__(
         self, responses: list[tuple[int | None, dict[str, object] | None]], *,
         create_returncode: int = 0,
+        list_responses: list[list[dict[str, object]]] | None = None,
     ) -> None:
         self.responses = list(responses)
         self.create_returncode = create_returncode
+        self.list_responses = list(list_responses or [])
         self.create_count = 0
         self.calls: list[tuple[str, ...]] = []
 
     def run(self, arguments, *, check=True):
         args = tuple(str(value) for value in arguments)
         self.calls.append(args)
-        if args[:3] == ("gh", "api", "--include"):
+        if args[:3] == ("gh", "api", "--include") and "/releases/tags/" in args[-1]:
             if not self.responses:
                 raise AssertionError("unexpected lookup")
             status, value = self.responses.pop(0)
@@ -47,6 +49,14 @@ class FakeRunner:
             return subprocess.CompletedProcess(
                 args, 0 if 200 <= status < 300 else 1, output, f"HTTP {status}"
             )
+        if args[:3] == ("gh", "api", "--include") and "/releases?" in args[-1]:
+            releases = self.list_responses.pop(0) if self.list_responses else []
+            output = (
+                "HTTP/2.0 200 status\r\ncontent-type: application/json\r\n\r\n"
+                + json.dumps(releases)
+                + "\n"
+            )
+            return subprocess.CompletedProcess(args, 0, output, "")
         if args[:3] == ("gh", "release", "create"):
             self.create_count += 1
             return subprocess.CompletedProcess(
@@ -152,6 +162,25 @@ class StageReleaseTest(unittest.TestCase):
         result = self._stage(fake)
         self.assertEqual(result["release_id"], RELEASE_ID)
         self.assertEqual(fake.create_count, 1)
+
+    def test_tag_lookup_404_recovers_exact_draft_from_authenticated_list(self) -> None:
+        fake = FakeRunner(
+            [(404, None)],
+            list_responses=[[self._release()]],
+        )
+        result = self._stage(fake)
+        self.assertEqual(result["release_id"], RELEASE_ID)
+        self.assertFalse(result["created_by_this_run"])
+        self.assertEqual(fake.create_count, 0)
+
+    def test_tag_lookup_404_rejects_duplicate_drafts_from_authenticated_list(self) -> None:
+        fake = FakeRunner(
+            [(404, None)],
+            list_responses=[[self._release(), self._release(id=RELEASE_ID + 1)]],
+        )
+        with self.assertRaisesRegex(stage_release.StageReleaseError, "multiple entries"):
+            self._stage(fake)
+        self.assertEqual(fake.create_count, 0)
 
     def test_post_create_fatal_lookup_is_not_reclassified_as_absent(self) -> None:
         fake = FakeRunner([(404, None), (503, None)])

--- a/tests/test_stage_release.py
+++ b/tests/test_stage_release.py
@@ -173,6 +173,18 @@ class StageReleaseTest(unittest.TestCase):
         self.assertFalse(result["created_by_this_run"])
         self.assertEqual(fake.create_count, 0)
 
+    def test_tag_lookup_404_searches_later_list_pages_before_creating(self) -> None:
+        first_page = [{"tag_name": f"v0.0.{index}"} for index in range(100)]
+        fake = FakeRunner(
+            [(404, None)],
+            list_responses=[first_page, [self._release()]],
+        )
+        result = self._stage(fake)
+        self.assertEqual(result["release_id"], RELEASE_ID)
+        self.assertFalse(result["created_by_this_run"])
+        self.assertEqual(fake.create_count, 0)
+        self.assertTrue(any("page=2" in call[-1] for call in fake.calls))
+
     def test_tag_lookup_404_rejects_duplicate_drafts_from_authenticated_list(self) -> None:
         fake = FakeRunner(
             [(404, None)],


### PR DESCRIPTION
## Summary

- recover an exact unpublished draft through the authenticated releases-list endpoint when GitHub's tag endpoint returns 404
- preserve fail-closed handling for malformed, ambiguous, auth, rate-limit, and server responses
- add deterministic recovery and duplicate-draft regression tests

Fixes #165

## Verification

- `python -m unittest discover -s tests -p test_stage_release.py -v`
- `bash scripts/validate-all.sh`