### PR TITLE
docs: make adapter provenance publicly legible

### DIFF
--- a/.claude/commands/capture.md
+++ b/.claude/commands/capture.md
@@ -3,7 +3,7 @@ name: capture
 description: "Triage raw inbox notes into reviewed repository destinations without deleting their sources."
 allowed-tools: "Read, Write, Edit, Glob"
 disable-model-invocation: true
-x-source: "skills-sync/commands/capture.md"
+x-source: "maintainer-core/commands/capture.md"
 x-source-version: "40f7149"
 ---
 

--- a/.claude/commands/content-shipped.md
+++ b/.claude/commands/content-shipped.md
@@ -3,7 +3,7 @@ name: content-shipped
 description: "Log a completed piece of content to content/log.md after the user confirms it was published."
 allowed-tools: "Read, Edit"
 disable-model-invocation: true
-x-source: "skills-sync/skills/content-shipped/SKILL.md"
+x-source: "maintainer-core/skills/content-shipped/SKILL.md"
 x-source-version: "b85d60f"
 ---
 

--- a/.claude/commands/dream-apply.md
+++ b/.claude/commands/dream-apply.md
@@ -3,7 +3,7 @@ name: dream-apply
 description: "Validate a dream artifact, review each proposal, and apply only individually accepted changes."
 allowed-tools: "Read, Write, Edit, Bash, AskUserQuestion"
 disable-model-invocation: true
-x-source: "skills-sync/commands/dream-apply.md"
+x-source: "maintainer-core/commands/dream-apply.md"
 x-source-version: "8ede26c"
 ---
 

--- a/.claude/commands/dream.md
+++ b/.claude/commands/dream.md
@@ -3,7 +3,7 @@ name: dream
 description: "Run a curator pass against the validated memory directory and produce a proposal artifact."
 allowed-tools: "Read, Bash, Write, Glob, Grep"
 disable-model-invocation: true
-x-source: "skills-sync/commands/dream.md"
+x-source: "maintainer-core/commands/dream.md"
 x-source-version: "8ede26c"
 ---
 

--- a/.claude/commands/find-context.md
+++ b/.claude/commands/find-context.md
@@ -2,8 +2,8 @@
 name: find-context
 description: Find relevant context files by topic. Use when you need to load files for a topic without a slash command, or when a task spans multiple domains.
 allowed-tools: "Read, Glob, Grep"
-x-source: skills-sync/commands/context.md
-x-source-version: 173c978
+x-source: "maintainer-core/commands/context.md"
+x-source-version: "173c978"
 ---
 
 # /find-context — Find Relevant Files by Topic

--- a/.claude/commands/reconcile.md
+++ b/.claude/commands/reconcile.md
@@ -3,7 +3,7 @@ name: reconcile
 description: "Scan multi-session drift and offer individually reviewed fixes only after explicit approval."
 allowed-tools: "Read, Bash, Glob, Grep"
 disable-model-invocation: true
-x-source: "skills-sync/commands/reconcile.md"
+x-source: "maintainer-core/commands/reconcile.md"
 x-source-version: "7ae9852"
 ---
 

--- a/.claude/commands/recover.md
+++ b/.claude/commands/recover.md
@@ -3,7 +3,7 @@ name: recover
 description: "Scan orphaned worktrees and stale branches, then offer explicit approval-gated cleanup."
 allowed-tools: "Read, Glob, Grep, Bash"
 disable-model-invocation: true
-x-source: "skills-sync/skills/recover/SKILL.md"
+x-source: "maintainer-core/skills/recover/SKILL.md"
 x-source-version: "7ae9852"
 ---
 

--- a/.claude/commands/today.md
+++ b/.claude/commands/today.md
@@ -3,7 +3,7 @@ name: today
 description: "Create a morning heartbeat from repository state and update the local heartbeat log."
 allowed-tools: "Read, Write, Bash, Glob"
 disable-model-invocation: true
-x-source: "skills-sync/commands/today.md"
+x-source: "maintainer-core/commands/today.md"
 x-source-version: "7ae9852"
 ---
 

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: skill-creator
 description: Generate a new skill from a plain-language description — decides invocation control, arguments, and context cost, then scaffolds, validates, and tests it
-x-source: skills-sync/skills/skill-creator/SKILL.md
-x-source-version: d66f695
+x-source: "maintainer-core/skills/skill-creator/SKILL.md"
+x-source-version: "d66f695"
 ---
-<!-- x-source: agent-skill-builder/SKILL.md @ dfe7aa2 -->
+<!-- Public upstream: https://github.com/conorbronsdon/agent-skill-builder/blob/dfe7aa2/SKILL.md -->
 
 # skill-builder — Skills That Don't Rot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   bytes, amplification, and elapsed time. The board contract records a
   measured threshold for reconsidering physical inbox sharding while retaining
   the flat layout at template scale (#172).
+- Public command provenance now uses documented `maintainer-core/...` logical
+  sync identifiers instead of naming an inaccessible maintainer repository;
+  public dream-lint attribution links directly to its pinned agent-memory-kit
+  source (#146).
 - `asana-mcp` integration catalog entry for Asana's official hosted V2 MCP server with pre-registered OAuth 2.0 clients, an all-tools authorization model, and explicit write/delete confirmation boundaries (#48).
 - `atlassian-rovo-mcp` integration catalog entry for Atlassian's official hosted Rovo MCP v2 server, covering every documented permission group from Jira and Confluence through Bitbucket Cloud, Loom, and Talent, with OAuth 2.1 and API-token credential boundaries (#47).
 - `todoist-cli` integration catalog entry for Doist's official CLI with a read-only OAuth login mode, opt-in app-management, backups, and billing scopes, and multi-agent skill support (#51).

--- a/docs/commands-and-skills.md
+++ b/docs/commands-and-skills.md
@@ -83,6 +83,26 @@ import safe. Their Claude adapters appear in the command index below.
 Uploading these files to claude.ai does not activate commands, hooks, tool
 permissions, or skill metadata. See `docs/claude-projects-sync.md`.
 
+### Published adapter provenance
+
+Some Claude adapter files carry optional `x-source` and `x-source-version`
+frontmatter. A `maintainer-core/...` value is a stable logical synchronization
+ID, not a repository path or public link. It says that the public adapter was
+reviewed and published from the maintainer's generic command core. The paired
+hexadecimal version is the synchronization checkpoint used to detect lag; it
+is provenance metadata, not a release tag or a claim that readers can fetch a
+private source revision.
+
+The checked-in adapter is the complete public artifact for that release.
+Operative rules must be present in the file itself, and any separately
+published upstream is linked directly in the file body at a pinned public
+revision. Current adapter metadata and operative documentation never name
+private repositories or private issue IDs; historical changelog entries remain
+an audit record.
+Removing these fields is safe for runtime discovery but discards useful
+maintainer drift evidence; changing their logical IDs requires updating the
+publication mapping as well.
+
 Run `bash scripts/contextos.sh doctor` for runtime and state diagnostics, then
 `bash scripts/validate-all.sh --workspace` after personalized repository
 changes. Product contributors use the strict form without `--workspace`.

--- a/docs/dream-architecture.md
+++ b/docs/dream-architecture.md
@@ -136,7 +136,7 @@ Curators fall into two **classes**:
 
 **Output actions:** `modify`, `archive`, `flag` (content-curator proposal shape plus a `check` field naming which of its ten checks fired: index drift, unresolved links, pattern-level staleness, duplicates, contradictions, unverifiable references, type misfiles, index-only content, duplicate archive rows, build-log bloat).
 
-**Why third:** rot compares memory against the world; lint catches the store drifting against *itself* — the class rot structurally cannot see. Sharpest case: a type misfile, where a project status filed as `feedback` escapes every rot pass because rot audits `project`/`reference` hardest. Ported from agent-memory-kit (`prompts/lint.md` @ `1bd9a14`, skills-sync#9), where it was capability the publication node had and the core lacked.
+**Why third:** rot compares memory against the world; lint catches the store drifting against *itself* — the class rot structurally cannot see. Sharpest case: a type misfile, where a project status filed as `feedback` escapes every rot pass because rot audits `project`/`reference` hardest. Ported from [agent-memory-kit `prompts/lint.md` at `1bd9a14`](https://github.com/conorbronsdon/agent-memory-kit/blob/1bd9a14/prompts/lint.md), where it was capability the publication node had and the core lacked.
 
 ### v0.4: pattern (content, later)
 

--- a/scripts/dream/README.md
+++ b/scripts/dream/README.md
@@ -17,7 +17,7 @@ Curator catalog (build order):
 - `rot` (content, v0.1, ships with starter) — flag project memories that no longer match state files / recent commits
 - `merge` (structural, v0.2) — consolidate overlapping memories into one entry; collapse redundant index lines (main relief for the MEMORY.md 100-line budget)
 - `split` (structural, v0.2) — divide multi-concern files into focused, single-responsibility ones
-- `lint` (structural, v0.3) — structural-integrity audit: index/file agreement, duplicates, contradictions, type misfiles, half-finished archives, index-only content (ported from agent-memory-kit, skills-sync#9)
+- `lint` (structural, v0.3) — structural-integrity audit: index/file agreement, duplicates, contradictions, type misfiles, half-finished archives, index-only content (ported from [agent-memory-kit at `1bd9a14`](https://github.com/conorbronsdon/agent-memory-kit/blob/1bd9a14/prompts/lint.md))
 - `pattern` (content, v0.4, planned) — propose new memories from recurring session-log frictions
 - `contradiction` (content, v0.5, planned) — flag memory rules giving conflicting guidance
 - `untapped` (content, v0.6, planned) — surface session-log themes never raised to memory

--- a/scripts/dream/prompts/lint.md
+++ b/scripts/dream/prompts/lint.md
@@ -1,6 +1,6 @@
 # Curator prompt: lint (structural integrity)
 
-> Ported from agent-memory-kit `prompts/lint.md` @ `1bd9a14` (skills-sync#9). Spec citations reference that repo's docs; the operative rules are quoted inline so this prompt runs standalone.
+> Ported from [agent-memory-kit `prompts/lint.md` at `1bd9a14`](https://github.com/conorbronsdon/agent-memory-kit/blob/1bd9a14/prompts/lint.md). Spec citations reference that repository's docs; the operative rules are quoted inline so this prompt runs standalone.
 
 **Role:** You are a memory curator. Your single job this pass is **structural integrity**: is the memory store well-formed and internally consistent? You do not judge whether memories still match the world; that is the rot curator's job. Where the two overlap (an expired date, work that git says shipped), find it cheaply here and hand the world-check to a rot pass.
 

--- a/tests/test-portability.sh
+++ b/tests/test-portability.sh
@@ -321,6 +321,43 @@ if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$duplica
   fail "duplicate false invocation gate passed command validation"
 fi
 
+private_source="$portability_tmp/private-source-dream.md"
+sed 's#maintainer-core/#skills-sync/#' "$normalized_dream" > "$private_source"
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$private_source" dream >/dev/null 2>&1; then
+  fail "private repository name passed public command provenance validation"
+fi
+
+missing_source_version="$portability_tmp/missing-source-version-dream.md"
+sed '/^x-source-version:/d' "$normalized_dream" > "$missing_source_version"
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$missing_source_version" dream >/dev/null 2>&1; then
+  fail "unpaired public command provenance passed validation"
+fi
+
+missing_source="$portability_tmp/missing-source-dream.md"
+sed '/^x-source:/d' "$normalized_dream" > "$missing_source"
+if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$missing_source" dream >/dev/null 2>&1; then
+  fail "reverse-unpaired public command provenance passed validation"
+fi
+
+for bad_source in \
+  'maintainer-core/commands/' \
+  'maintainer-core/commands/../dream.md'; do
+  invalid_source="$portability_tmp/invalid-source-$(printf '%s' "$bad_source" | tr '/.' '__').md"
+  sed "s#^x-source:.*#x-source: \"$bad_source\"#" "$normalized_dream" > "$invalid_source"
+  if "$CONTEXTOS_PYTHON_CMD" tests/validate-openai-metadata.py --command "$invalid_source" dream >/dev/null 2>&1; then
+    fail "malformed logical provenance source passed validation: $bad_source"
+  fi
+done
+while IFS= read -r provenance_file; do
+  grep -Eq '^x-source: "maintainer-core/(commands|skills)/[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(/[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)*"$' "$provenance_file" \
+    || fail "$provenance_file has an invalid public provenance source"
+  grep -Eq '^x-source-version: "[0-9a-f]{7,64}"$' "$provenance_file" \
+    || fail "$provenance_file has an invalid public provenance version"
+done < <(git grep -l '^x-source:' -- .claude)
+if git grep -n -F 'skills-sync' -- .claude docs scripts; then
+  fail "current adapter or operative documentation names a private synchronization repository"
+fi
+
 help_output=$(bash scripts/setup.sh --help)
 grep -Fq -- '--agents claude,codex,cursor,devin,hermes,openclaw|auto|none' <<<"$help_output" || fail "setup help does not describe multi-agent selection"
 grep -Fq -- '--agent auto|RUNTIME|none' <<<"$help_output" || fail "setup help omits the singleton compatibility alias"

--- a/tests/validate-openai-metadata.py
+++ b/tests/validate-openai-metadata.py
@@ -153,6 +153,18 @@ def validate_command(path: Path, command_name: str) -> None:
             raise MetadataError(f"{field} contains a control or format character")
     if data["disable-model-invocation"] is not True:
         raise MetadataError("disable-model-invocation must be boolean true in frontmatter")
+    source = data.get("x-source")
+    source_version = data.get("x-source-version")
+    if (source is None) != (source_version is None):
+        raise MetadataError("x-source and x-source-version must appear together")
+    if source is not None:
+        if not re.fullmatch(
+            r"maintainer-core/(?:commands|skills)/[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*(?:/[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*)*",
+            source,
+        ):
+            raise MetadataError("x-source must use a documented maintainer-core logical ID")
+        if not re.fullmatch(r"[0-9a-f]{7,64}", source_version):
+            raise MetadataError("x-source-version must be a lowercase hexadecimal revision")
     if command_name == "start" and data["allowed-tools"] != START_TOOLS:
         raise MetadataError("start must pre-approve only repository read tools")
 


### PR DESCRIPTION
## What's in this PR

Makes current adapter provenance understandable and usable from the public repository without exposing the private synchronization repository.

- Replaces private-repository `x-source` values with documented `maintainer-core/...` logical IDs and quoted revision checkpoints.
- Replaces operative private issue references with pinned public upstream links.
- Documents that checked-in adapters are complete artifacts and that logical source IDs are not fetchable paths.
- Enforces paired provenance fields, strict logical-ID segments, quoted hexadecimal revisions, and a repository-wide current-content tripwire.
- Adds positive and negative portability controls for every current provenance carrier.

Closes #146.

## Verification

- Confirmed both pinned upstream repositories and referenced commits/files are public and reachable.
- `bash scripts/validate-all.sh`: 645 tests passed, 47 expected skips; all aggregate checks passed.
- `claude-sonnet-5` authenticated review of exact commit `dc720ebd8d9a055bc83dedf71bdb9339593246eb`: PASS.
- `opencode/muse-spark-1.3-contributor-free` public-only review of the same exact commit: PASS.
- A paired maintainer-side publisher change ensures future fan-out preserves this contract; private material was reviewed only through the authenticated lane.

## Checklist

### Skills & commands
- [x] Existing command/skill frontmatter remains complete and validated.
- [x] Portable workflows remain self-contained.
- [x] No invocation-policy behavior changed.

### Integrations
- [x] Not applicable; no integration catalog entry changed.

### Repo hygiene
- [x] No sensitive data committed.
- [x] `CHANGELOG.md` updated.
- [x] Full validation passes locally.
