### PR TITLE
feat(coordination): measure sync read amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Added
+- Coordination `board sync` receipts now report content-free scan counts,
+  bytes, amplification, and elapsed time. The board contract records a
+  measured threshold for reconsidering physical inbox sharding while retaining
+  the flat layout at template scale (#172).
 - `asana-mcp` integration catalog entry for Asana's official hosted V2 MCP server with pre-registered OAuth 2.0 clients, an all-tools authorization model, and explicit write/delete confirmation boundaries (#48).
 - `atlassian-rovo-mcp` integration catalog entry for Atlassian's official hosted Rovo MCP v2 server, covering every documented permission group from Jira and Confluence through Bitbucket Cloud, Loom, and Talent, with OAuth 2.1 and API-token credential boundaries (#47).
 - `todoist-cli` integration catalog entry for Doist's official CLI with a read-only OAuth login mode, opt-in app-management, backups, and billing scopes, and multi-agent skill support (#51).

--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -6,6 +6,7 @@ import re
 import secrets
 import subprocess
 import tempfile
+import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
@@ -1115,11 +1116,18 @@ def _current_claims(
     head: str,
     now: datetime,
     notices: list[str],
+    scan_metrics: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     current_paths = set(_tree_paths(root, head, _CLAIMS_PREFIX))
     current_paths.discard(f"{_CLAIMS_PREFIX}.gitkeep")
+    if scan_metrics is not None:
+        scan_metrics["active_claim_files"] = len(current_paths)
+    if not current_paths:
+        return []
     latest_addition: dict[str, tuple[int, str]] = {}
     commits = _commit_sequence(root, head)
+    if scan_metrics is not None:
+        scan_metrics["claim_history_commits_scanned"] = len(commits)
     for index, (commit, path) in enumerate(
         _added_paths_for_commits(root, commits, _CLAIMS_PREFIX)
     ):
@@ -1136,7 +1144,11 @@ def _current_claims(
     claims: list[dict[str, Any]] = []
     for path in ordered_paths:
         try:
-            fields, body = _parse_frontmatter(_read_tree_text(root, head, path))
+            text = _read_tree_text(root, head, path)
+            if scan_metrics is not None:
+                scan_metrics["claim_files_read"] += 1
+                scan_metrics["claim_bytes_read"] += len(text.encode("utf-8"))
+            fields, body = _parse_frontmatter(text)
             for required in ("task", "owner", "lease-expires"):
                 if required not in fields:
                     raise ContextOSError(f"missing required key '{required}'")
@@ -1189,11 +1201,11 @@ def _commits_after_cursor(
     head: str,
     cursor: str | None,
     notices: list[str],
-) -> list[str]:
+) -> tuple[list[str], str]:
     if cursor is None:
-        return _commit_sequence(root, head)
+        return _commit_sequence(root, head), "cold"
     if cursor == head:
-        return []
+        return [], "current"
     ancestor = _git(
         root,
         ["merge-base", "--is-ancestor", cursor, head],
@@ -1204,9 +1216,9 @@ def _commits_after_cursor(
             "The coordination cursor is not an ancestor of the current ref; "
             "scanning the current board"
         )
-        return _commit_sequence(root, head)
+        return _commit_sequence(root, head), "recovery"
     result = _git(root, ["rev-list", "--reverse", f"{cursor}..{head}"])
-    return result.stdout.splitlines()
+    return result.stdout.splitlines(), "incremental"
 
 
 def _audience_notice(
@@ -1250,6 +1262,7 @@ def sync_board(
     roles: list[str] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
+    started_at = time.perf_counter()
     root = Path(root)
     current = _coerce_now(now)
     runtime_value = _scalar(runtime, "runtime")
@@ -1257,23 +1270,102 @@ def sync_board(
     run_value = _scalar(run_id, "run_id")
     full_run_id = run_value if "/" in run_value else f"{runtime_value}/{run_value}"
     notices: list[str] = []
+    scan_metrics: dict[str, Any] = {
+        "cursor_mode": "unavailable",
+        "message_commits_after_cursor_scanned": 0,
+        "claim_history_commits_scanned": 0,
+        "active_message_files": 0,
+        "active_claim_files": 0,
+        "candidate_message_files": 0,
+        "message_files_read": 0,
+        "claim_files_read": 0,
+        "message_bytes_read": 0,
+        "claim_bytes_read": 0,
+        "fetch_elapsed_ms": 0.0,
+        "message_scan_elapsed_ms": 0.0,
+        "claim_scan_elapsed_ms": 0.0,
+    }
+
+    def finish_metrics(
+        messages: list[dict[str, Any]],
+        claims: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        bytes_read = (
+            scan_metrics["message_bytes_read"]
+            + scan_metrics["claim_bytes_read"]
+        )
+        message_surfaced_bytes = len(
+            json.dumps(
+                messages,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        claim_surfaced_bytes = len(
+            json.dumps(
+                claims,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        surfaced_bytes = message_surfaced_bytes + claim_surfaced_bytes
+        ratio = round(bytes_read / surfaced_bytes, 3)
+        message_ratio = round(
+            scan_metrics["message_bytes_read"] / message_surfaced_bytes,
+            3,
+        )
+        claim_ratio = round(
+            scan_metrics["claim_bytes_read"] / claim_surfaced_bytes,
+            3,
+        )
+        return {
+            **scan_metrics,
+            "files_read": (
+                scan_metrics["message_files_read"]
+                + scan_metrics["claim_files_read"]
+            ),
+            "bytes_read": bytes_read,
+            "messages_surfaced": len(messages),
+            "claims_surfaced": len(claims),
+            "message_surfaced_bytes": message_surfaced_bytes,
+            "claim_surfaced_bytes": claim_surfaced_bytes,
+            "surfaced_bytes": surfaced_bytes,
+            "message_read_amplification_ratio": message_ratio,
+            "claim_read_amplification_ratio": claim_ratio,
+            "read_amplification_ratio": ratio,
+            "elapsed_ms": round(
+                max(0.0, time.perf_counter() - started_at) * 1000,
+                3,
+            ),
+        }
 
     head = _fetch_coordination(root)
+    scan_metrics["fetch_elapsed_ms"] = round(
+        max(0.0, time.perf_counter() - started_at) * 1000,
+        3,
+    )
     if head is None:
+        messages: list[dict[str, Any]] = []
+        claims: list[dict[str, Any]] = []
         return {
             "commit": None,
             "previous_cursor": None,
-            "messages": [],
-            "claims": [],
+            "messages": messages,
+            "claims": claims,
             "claim_order": {},
+            "scan": finish_metrics(messages, claims),
             "notices": ["The coordination board has not been bootstrapped"],
         }
 
     cursor_path = Path(cursor_file)
     previous = _cursor_value(cursor_path, notices)
-    commits = _commits_after_cursor(root, head, previous, notices)
+    message_scan_started = time.perf_counter()
+    commits, cursor_mode = _commits_after_cursor(root, head, previous, notices)
+    scan_metrics["cursor_mode"] = cursor_mode
+    scan_metrics["message_commits_after_cursor_scanned"] = len(commits)
     current_paths = set(_tree_paths(root, head, _BOARD_PREFIX))
     current_paths.discard(f"{_BOARD_PREFIX}.gitkeep")
+    scan_metrics["active_message_files"] = len(current_paths)
 
     messages: list[dict[str, Any]] = []
     seen_paths: set[str] = set()
@@ -1281,8 +1373,12 @@ def sync_board(
         if path in seen_paths or path not in current_paths:
             continue
         seen_paths.add(path)
+        scan_metrics["candidate_message_files"] += 1
         try:
-            fields, body = _parse_frontmatter(_read_tree_text(root, head, path))
+            text = _read_tree_text(root, head, path)
+            scan_metrics["message_files_read"] += 1
+            scan_metrics["message_bytes_read"] += len(text.encode("utf-8"))
+            fields, body = _parse_frontmatter(text)
             for required in ("from", "audience", "kind", "expires"):
                 if required not in fields:
                     raise ContextOSError(f"missing required key '{required}'")
@@ -1314,7 +1410,23 @@ def sync_board(
             }
         )
 
-    claims = _current_claims(root, head, current, notices)
+    scan_metrics["message_scan_elapsed_ms"] = round(
+        max(0.0, time.perf_counter() - message_scan_started) * 1000,
+        3,
+    )
+
+    claim_scan_started = time.perf_counter()
+    claims = _current_claims(
+        root,
+        head,
+        current,
+        notices,
+        scan_metrics=scan_metrics,
+    )
+    scan_metrics["claim_scan_elapsed_ms"] = round(
+        max(0.0, time.perf_counter() - claim_scan_started) * 1000,
+        3,
+    )
     _write_cursor(cursor_path, head)
     return {
         "commit": head,
@@ -1322,6 +1434,7 @@ def sync_board(
         "messages": messages,
         "claims": claims,
         "claim_order": _claim_order(claims),
+        "scan": finish_metrics(messages, claims),
         "notices": notices,
     }
 

--- a/coordination/README.md
+++ b/coordination/README.md
@@ -89,6 +89,48 @@ run-id audiences are surfaced but not validated — run ids are ephemeral.
   undelivered receipt; a post is delivered only when its commit is confirmed
   on the remote. Fetch-only runs cannot acquire claims.
 
+### Read-amplification telemetry and inbox threshold
+
+Every `board sync` receipt includes a `scan` object with counts only: history
+commits scanned, active and candidate files, files and UTF-8 bytes read,
+messages and claims surfaced, compact-JSON surfaced bytes, the read-to-surfaced
+byte ratio, cursor mode (`cold`, `incremental`, `current`, `recovery`, or
+`unavailable`), and fetch, message-scan, claim-scan, and total elapsed
+milliseconds. Message commit counts cover only commits after the cursor;
+claim-history counts cover the full coordination history when live claims exist
+because publish-order arbitration requires it. With no live claims, that
+history walk is skipped. The telemetry never includes message content,
+frontmatter values, paths, or identifiers.
+
+Keep the flat board layout unless **three consecutive representative cold or
+cursor-recovery syncs on the same host** each read at least 256 KiB and also
+cross either threshold:
+
+- at least 2,000 ms in `message_scan_elapsed_ms`; or
+- at least 20:1 `message_read_amplification_ratio`.
+
+A cold/recovery sample has no usable cursor and scans the current board. The
+byte floor prevents host startup noise from triggering a layout migration for
+a small board; the repeated-sample rule prevents one slow process launch from
+doing the same. Apply the 256 KiB floor to `message_bytes_read`, not combined
+message-and-claim work: inbox directories do not change claim arbitration. If
+`message_surfaced_bytes` itself exceeds 64 KiB, improve addressing, expiry, or
+compaction first: physical inboxes cannot reduce content genuinely addressed
+to the recipient.
+
+Calibration on 2026-09-03 used a Windows local bare remote and near-limit
+synthetic messages, seeded in one fixture commit, with `all`, role, run-id, and
+unrelated audiences. A
+16-message cold sync read 55,943 message bytes in 647 ms at 7.583:1; an
+80-message cold sync read 279,783 message bytes in 2,414 ms at 37.926:1. Both surfaced two
+messages. The larger fixture crossed every gate; the smaller fixture crossed
+none after the byte floor. This evidence supports retaining the flat layout at
+template scale and revisiting physical inboxes only when observed receipts
+meet the gate above.
+
+`scan` is additive receipt metadata. Consumers must ignore unknown receipt and
+report keys; adding this object does not change the board-file schema version.
+
 ## Commands
 
 ```text

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -675,15 +675,28 @@ class CoordinationTests(unittest.TestCase):
         )
 
         cursor = self.base / "cursors" / "codex.json"
-        first = sync_board(
-            self.repo_a,
-            runtime="codex",
-            role="publisher",
-            run_id="run-7",
-            cursor_file=cursor,
-            roles=["researcher", "publisher"],
-            now=NOW + timedelta(minutes=1),
-        )
+        with mock.patch.object(
+            coordination.time,
+            "perf_counter",
+            side_effect=[
+                100.0,
+                100.010,
+                100.020,
+                100.040,
+                100.050,
+                100.055,
+                100.125,
+            ],
+        ):
+            first = sync_board(
+                self.repo_a,
+                runtime="codex",
+                role="publisher",
+                run_id="run-7",
+                cursor_file=cursor,
+                roles=["researcher", "publisher"],
+                now=NOW + timedelta(minutes=1),
+            )
         self.assertEqual(
             [message["body"] for message in first["messages"]],
             ["All body", "Role body", "Run body"],
@@ -704,6 +717,57 @@ class CoordinationTests(unittest.TestCase):
             json.loads(cursor.read_text(encoding="utf-8")),
             {"last_seen": first["commit"]},
         )
+        self.assertEqual(
+            {
+                key: first["scan"][key]
+                for key in (
+                    "message_commits_after_cursor_scanned",
+                    "active_message_files",
+                    "candidate_message_files",
+                    "message_files_read",
+                    "active_claim_files",
+                    "claim_files_read",
+                    "messages_surfaced",
+                    "claims_surfaced",
+                )
+            },
+            {
+                "message_commits_after_cursor_scanned": 7,
+                "active_message_files": 6,
+                "candidate_message_files": 6,
+                "message_files_read": 6,
+                "active_claim_files": 0,
+                "claim_files_read": 0,
+                "messages_surfaced": 3,
+                "claims_surfaced": 0,
+            },
+        )
+        self.assertEqual(first["scan"]["cursor_mode"], "cold")
+        self.assertEqual(first["scan"]["fetch_elapsed_ms"], 10.0)
+        self.assertEqual(first["scan"]["message_scan_elapsed_ms"], 20.0)
+        self.assertEqual(first["scan"]["claim_scan_elapsed_ms"], 5.0)
+        self.assertEqual(first["scan"]["elapsed_ms"], 125.0)
+        self.assertGreater(first["scan"]["message_bytes_read"], 0)
+        self.assertEqual(
+            first["scan"]["bytes_read"],
+            first["scan"]["message_bytes_read"],
+        )
+        self.assertGreater(first["scan"]["surfaced_bytes"], 0)
+        self.assertEqual(
+            first["scan"]["surfaced_bytes"],
+            first["scan"]["message_surfaced_bytes"]
+            + first["scan"]["claim_surfaced_bytes"],
+        )
+        self.assertIsInstance(first["scan"]["read_amplification_ratio"], float)
+        metrics_text = json.dumps(first["scan"], sort_keys=True)
+        for private_value in (
+            "All body",
+            "Role body",
+            "Run body",
+            "Other role body",
+            "Typo audience body",
+        ):
+            self.assertNotIn(private_value, metrics_text)
 
         post_message(
             self.repo_a,
@@ -728,6 +792,87 @@ class CoordinationTests(unittest.TestCase):
             ["Newer body"],
         )
         self.assertEqual(second["previous_cursor"], first["commit"])
+        self.assertEqual(second["scan"]["cursor_mode"], "incremental")
+        self.assertEqual(second["scan"]["message_commits_after_cursor_scanned"], 1)
+        self.assertEqual(second["scan"]["active_message_files"], 7)
+        self.assertEqual(second["scan"]["candidate_message_files"], 1)
+        self.assertEqual(second["scan"]["message_files_read"], 1)
+        self.assertEqual(second["scan"]["messages_surfaced"], 1)
+        self.assertEqual(second["scan"]["claim_history_commits_scanned"], 0)
+
+        current = sync_board(
+            self.repo_a,
+            runtime="codex",
+            role="publisher",
+            run_id="run-7",
+            cursor_file=cursor,
+            roles=["researcher", "publisher"],
+            now=NOW + timedelta(minutes=4),
+        )
+        self.assertEqual(current["previous_cursor"], second["commit"])
+        self.assertEqual(current["scan"]["cursor_mode"], "current")
+        self.assertEqual(current["scan"]["message_commits_after_cursor_scanned"], 0)
+        self.assertEqual(current["scan"]["candidate_message_files"], 0)
+        self.assertEqual(current["scan"]["message_files_read"], 0)
+        self.assertEqual(current["messages"], [])
+
+    def test_sync_metrics_cover_unavailable_recovery_and_malformed_data(self) -> None:
+        cursor = self.base / "metrics-cursor.json"
+        with mock.patch.object(
+            coordination.time,
+            "perf_counter",
+            side_effect=[1.0, 1.010, 1.020],
+        ):
+            unavailable = sync_board(
+                self.repo_a,
+                runtime="codex",
+                role="publisher",
+                run_id="run-7",
+                cursor_file=cursor,
+                roles=["publisher"],
+                now=NOW,
+            )
+        self.assertEqual(unavailable["scan"]["cursor_mode"], "unavailable")
+        self.assertEqual(unavailable["scan"]["files_read"], 0)
+        self.assertEqual(unavailable["scan"]["fetch_elapsed_ms"], 10.0)
+        self.assertEqual(unavailable["scan"]["elapsed_ms"], 20.0)
+
+        bootstrap_board(self.repo_a, now=NOW)
+        malformed_path = (
+            "coordination/board/"
+            "20260831T143001Z-acde-claude-malformed.md"
+        )
+        self._plant_files(
+            {malformed_path: "not frontmatter\nCONTEXTOS_PRIVATE_METRIC_CANARY\n"},
+            "Plant malformed sync fixture",
+        )
+        unrelated_main_commit = git(self.repo_a, "rev-parse", "HEAD").stdout.strip()
+        cursor.write_text(
+            json.dumps({"last_seen": unrelated_main_commit}) + "\n",
+            encoding="utf-8",
+        )
+        recovered = sync_board(
+            self.repo_a,
+            runtime="codex",
+            role="publisher",
+            run_id="run-7",
+            cursor_file=cursor,
+            roles=["publisher"],
+            now=NOW,
+        )
+        self.assertEqual(recovered["scan"]["cursor_mode"], "recovery")
+        self.assertEqual(recovered["scan"]["active_message_files"], 1)
+        self.assertEqual(recovered["scan"]["candidate_message_files"], 1)
+        self.assertEqual(recovered["scan"]["message_files_read"], 1)
+        self.assertEqual(recovered["scan"]["messages_surfaced"], 0)
+        self.assertIn(
+            "missing opening frontmatter fence",
+            "\n".join(recovered["notices"]),
+        )
+        self.assertNotIn(
+            "CONTEXTOS_PRIVATE_METRIC_CANARY",
+            json.dumps(recovered["scan"], sort_keys=True),
+        )
 
     def test_compact_dry_run_and_apply(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)
@@ -805,6 +950,16 @@ class CoordinationTests(unittest.TestCase):
         self.assertNotIn(
             "Expired operational note",
             [message["body"] for message in synced["messages"]],
+        )
+        self.assertEqual(synced["scan"]["active_message_files"], 1)
+        self.assertEqual(synced["scan"]["message_files_read"], 1)
+        self.assertEqual(synced["scan"]["active_claim_files"], 1)
+        self.assertEqual(synced["scan"]["claim_files_read"], 1)
+        self.assertGreater(synced["scan"]["claim_history_commits_scanned"], 0)
+        self.assertEqual(
+            synced["scan"]["bytes_read"],
+            synced["scan"]["message_bytes_read"]
+            + synced["scan"]["claim_bytes_read"],
         )
 
     def test_validate_clean_and_reports_malformed_and_imperative_files(self) -> None:


### PR DESCRIPTION
## What's in this PR

Adds content-free scan telemetry to `board sync` receipts so coordination read amplification can be measured before changing the flat inbox layout.

- Reports cursor mode, message/claim commit and file counts, bytes read and surfaced, amplification ratios, and phase timings.
- Preserves publish-order claim arbitration while skipping claim-history walks when no live claims exist.
- Documents a conservative, repeated-sample migration threshold calibrated against small and larger synthetic boards.
- Covers cold, current, incremental, recovery, unavailable, malformed-message, claim-history, timing, byte-reconciliation, and content-leak cases.

Closes #172.

## Verification

- `bash scripts/validate-all.sh`: 646 tests passed, 47 expected skips; all aggregate checks passed.
- `claude-sonnet-5` authenticated review of exact commit `5390ded193da6a0841e5444aafb055708317d1c6`: PASS.
- `opencode/muse-spark-1.3-contributor-free` public-only review of the same exact commit: PASS.

## Checklist

### Skills & commands
- [x] No new skill or command metadata was introduced.
- [x] Portable/provider-specific boundaries are unchanged.

### Integrations
- [x] Not applicable; no integration catalog entry changed.

### Repo hygiene
- [x] No sensitive data committed.
- [x] `CHANGELOG.md` updated.
- [x] Full validation passes locally.
