### PR TITLE
feat: add proposal-gated board promotion

### DIFF
--- a/.agents/skills/context-end/SKILL.md
+++ b/.agents/skills/context-end/SKILL.md
@@ -99,7 +99,12 @@ hand off any claims this run holds (`board release`, optionally with
 sensitive personal data ever (git history keeps every message), durable facts
 stay canonical elsewhere and are referenced with `commit:path`, and publishing
 pushes to the ContextRoot remote, so it happens only with the user's approval at
-the host permission boundary.
+the host permission boundary. If compaction surfaces a promotion candidate,
+ask the user to classify it as a durable decision, a session handoff, or neither.
+Only an explicit choice may create a separate `board promote` proposal with a
+reviewed JSON payload and exact canonical target; the message's age, kind, or
+wording never supplies approval. Present that proposal's full diff and use the
+normal exact-digest apply path only after separate approval.
 
 ### 6. Confirm the handoff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Added
+- Coordination messages can now become source-bound kernel proposals for an
+  explicit decision-log or session-handoff target. Apply requires the normal
+  exact digest and rejects changed, missing, or expired source messages while
+  tolerating unrelated board updates (#171).
 - Coordination `board sync` receipts now report content-free scan counts,
   bytes, amplification, and elapsed time. The board contract records a
   measured threshold for reconsidering physical inbox sharding while retaining

--- a/contextos/cli.py
+++ b/contextos/cli.py
@@ -45,6 +45,7 @@ from .coordination import (
     compact_board,
     create_claim,
     post_message,
+    propose_promotion,
     release_claim,
     sync_board,
     validate_board,
@@ -303,6 +304,18 @@ def parser() -> argparse.ArgumentParser:
     )
     board_compact.add_argument("--apply", action="store_true")
     board_compact.add_argument("--now")
+    board_promote = board_commands.add_parser(
+        "promote", help="Create a source-bound proposal for one live message"
+    )
+    board_promote.add_argument("--message", required=True, help="exact message id")
+    board_promote.add_argument(
+        "--target", required=True,
+        help="explicit decisions.md or today's session path",
+    )
+    board_promote.add_argument(
+        "--input", type=Path, required=True, help="reviewed promotion JSON payload"
+    )
+    board_promote.add_argument("--now")
     board_validate = board_commands.add_parser("validate", help="Validate the fetched coordination tree")
     board_validate.add_argument("--now")
 
@@ -1053,6 +1066,24 @@ def main(argv: list[str] | None = None) -> int:
                 ))
             elif args.board_command == "compact":
                 emit(compact_board(root, apply=args.apply, now=now))
+            elif args.board_command == "promote":
+                path, document = propose_promotion(
+                    root,
+                    message_id=args.message,
+                    target=args.target,
+                    payload=read_json(args.input),
+                    now=now,
+                )
+                emit({
+                    "proposal": path.relative_to(root).as_posix(),
+                    "proposal_id": document["proposal_id"],
+                    "proposal_digest": document["proposal_digest"],
+                    "source": document["source"],
+                    "changes": [
+                        {"path": item["path"], "diff": item["diff"]}
+                        for item in document["changes"]
+                    ],
+                })
             elif args.board_command == "validate":
                 emit(validate_board(root, roles=_board_roles(root), now=now))
         elif args.command == "hook":

--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -1494,6 +1494,8 @@ def _promotion_source_snapshot(
             raise ContextOSError(
                 f"coordination source message is missing required key '{required}'"
             )
+    if fields["kind"] not in _KINDS:
+        raise ContextOSError("coordination source message has an unsupported kind")
     expires_at = _parse_utc(fields["expires"], "expires")
     if expires_at <= current:
         raise ContextOSError(f"coordination source message has expired: {message_id}")

--- a/contextos/coordination.py
+++ b/contextos/coordination.py
@@ -1471,6 +1471,109 @@ def _message_documents(
     return documents
 
 
+def _promotion_source_snapshot(
+    root: Path,
+    message_id: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, str]:
+    current = _coerce_now(now)
+    filename = f"{message_id}.md"
+    if not _FILE_RE.fullmatch(filename):
+        raise ContextOSError("message id has an invalid coordination format")
+    path = f"{_BOARD_PREFIX}{filename}"
+    head = _fetch_coordination(root)
+    if head is None:
+        raise ContextOSError("The coordination board has not been bootstrapped")
+    if path not in set(_tree_paths(root, head, _BOARD_PREFIX)):
+        raise ContextOSError(f"coordination source message does not exist: {message_id}")
+    text = _read_tree_text(root, head, path)
+    fields, _ = _parse_frontmatter(text)
+    for required in ("from", "kind", "expires"):
+        if required not in fields:
+            raise ContextOSError(
+                f"coordination source message is missing required key '{required}'"
+            )
+    expires_at = _parse_utc(fields["expires"], "expires")
+    if expires_at <= current:
+        raise ContextOSError(f"coordination source message has expired: {message_id}")
+    return {
+        "type": "coordination-message",
+        "id": message_id,
+        "path": path,
+        "content_sha256": sha256_text(text),
+        "expires": _iso(expires_at),
+        "from": fields["from"],
+        "kind": fields["kind"],
+        "observed_commit": head,
+    }
+
+
+def validate_promotion_source(
+    root: Path,
+    source: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> None:
+    message_id = source.get("id")
+    if not isinstance(message_id, str):
+        raise ContextOSError("promotion source id must be a string")
+    current = _promotion_source_snapshot(root, message_id, now=now)
+    observed = source.get("observed_commit")
+    if not isinstance(observed, str) or not re.fullmatch(r"[0-9a-f]{40,64}", observed):
+        raise ContextOSError("promotion source observed_commit is invalid")
+    ancestry = _git(
+        root,
+        ["merge-base", "--is-ancestor", observed, current["observed_commit"]],
+        check=False,
+    )
+    if ancestry.returncode != 0:
+        raise ContextOSError(
+            "refusing promotion proposal; observed coordination commit is not "
+            "an ancestor of the current board"
+        )
+    try:
+        observed_text = _read_tree_text(root, observed, source.get("path", ""))
+    except ContextOSError as exc:
+        raise ContextOSError(
+            "refusing promotion proposal; source is absent from its observed commit"
+        ) from exc
+    if sha256_text(observed_text) != source.get("content_sha256"):
+        raise ContextOSError(
+            "refusing promotion proposal; observed source content does not match"
+        )
+    for field in ("type", "id", "path", "content_sha256", "expires", "from", "kind"):
+        if source.get(field) != current[field]:
+            raise ContextOSError(
+                f"refusing stale promotion proposal; source changed: {message_id}"
+            )
+
+
+def propose_promotion(
+    root: Path,
+    *,
+    message_id: str,
+    target: str,
+    payload: dict[str, Any],
+    now: datetime | None = None,
+) -> tuple[Path, dict[str, Any]]:
+    proposal_now: Any = utc_now() if now is None else now
+    if not isinstance(proposal_now, datetime):
+        proposal_now = parse_now(str(proposal_now))
+    if proposal_now.tzinfo is None:
+        raise ContextOSError("Promotion timestamps must be timezone-aware")
+    source = _promotion_source_snapshot(root, message_id, now=proposal_now)
+    from .kernel import create_coordination_promotion_proposal
+
+    return create_coordination_promotion_proposal(
+        root,
+        target=target,
+        payload=payload,
+        source=source,
+        now=proposal_now,
+    )
+
+
 def compact_board(
     root: Path,
     *,

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -103,7 +103,7 @@ LOCAL_ARTIFACT_MODE = 0o600
 NEW_CONTENT_MODE = 0o666 if os.name == "nt" else 0o644
 LOCAL_BINDING_MODE = NEW_CONTENT_MODE if os.name == "nt" else LOCAL_ARTIFACT_MODE
 PROPOSAL_ID_RE = re.compile(
-    r"^\d{8}T\d{6}-(?:setup|update|end|agent-config)-[0-9a-f]{10}$"
+    r"^\d{8}T\d{6}-(?:setup|update|end|promotion|agent-config)-[0-9a-f]{10}$"
 )
 AGENT_MIGRATION_INVARIANTS = [
     "agent-workflow-path-policy",
@@ -129,6 +129,7 @@ CONTENT_BASE_INVARIANTS = [
     "exact-proposal-integrity",
 ]
 CONTENT_FRESHNESS_INVARIANTS = ["single-last-updated", "same-day-history"]
+PROMOTION_INVARIANT = "coordination-source-id-content-expiry-target"
 PLACEHOLDER_DATE = "[DATE]"
 LAST_UPDATED_RE = re.compile(r"^\*\*Last Updated:\*\*\s*(.+?)\s*$", re.MULTILINE)
 REAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -1338,6 +1339,64 @@ def render_end(workspace: Workspace, payload: dict[str, Any], now: datetime) -> 
     return pending
 
 
+def render_promotion(
+    workspace: Workspace,
+    target: str,
+    payload: dict[str, Any],
+    source: dict[str, Any],
+    now: datetime,
+) -> dict[Path, str]:
+    target_path = safe_repo_path(workspace.root, target)
+    target_relative = relative_path(workspace.root, target_path)
+    decision_relative = relative_path(
+        workspace.root, workspace.state_dir / "decisions.md"
+    )
+    session_relative = relative_path(
+        workspace.root,
+        workspace.sessions_dir / f"{now.strftime('%Y-%m-%d')}.md",
+    )
+    source_id = ensure_text(source.get("id"), "source.id")
+    today, clock = now.strftime("%Y-%m-%d"), now.strftime("%H:%M")
+
+    if target_relative == decision_relative:
+        allowed = {"decision", "rationale", "rejected_alternatives"}
+        if set(payload) - allowed:
+            raise ContextOSError("decision promotion input has unknown fields")
+        decision = ensure_text(payload.get("decision"), "decision").strip()
+        if not decision:
+            raise ContextOSError("decision must not be empty")
+        rationale = ensure_text(payload.get("rationale", ""), "rationale").strip()
+        rejected = ensure_text(
+            payload.get("rejected_alternatives", ""), "rejected_alternatives"
+        ).strip()
+        if not target_path.is_file():
+            raise ContextOSError(f"decision log does not exist: {target_relative}")
+        before = target_path.read_text(encoding="utf-8").rstrip()
+        provenance = f"coordination message {source_id}"
+        context = f"{rationale}; source: {provenance}" if rationale else f"source: {provenance}"
+        after = (
+            f"{before}\n| {today} | {_escape_table(decision)} | "
+            f"{_escape_table(context)} | {_escape_table(rejected)} |\n"
+        )
+        return {target_path: after}
+
+    if target_relative == session_relative:
+        if set(payload) != {"summary"}:
+            raise ContextOSError("handoff promotion input must contain only summary")
+        summary = ensure_string_list(payload.get("summary"), "summary", required=True)
+        block = (
+            f"## Coordination handoff: {clock}\n"
+            f"Source: coordination message `{source_id}`\n\n"
+            f"{_bullets(summary)}"
+        )
+        return {target_path: _session_append(target_path, block, today)}
+
+    raise ContextOSError(
+        "promotion target must be the decision log or today's session handoff: "
+        f"{target_relative}"
+    )
+
+
 def _is_populated(content: str) -> bool:
     stripped = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
     for raw_line in stripped.splitlines():
@@ -1414,6 +1473,8 @@ def build_changes(
 
 def _content_invariants(workflow: str, changes: Sequence[dict[str, Any]]) -> list[str]:
     invariants = list(CONTENT_BASE_INVARIANTS)
+    if workflow == "promotion":
+        invariants.append(PROMOTION_INVARIANT)
     if workflow in {"update", "end"} and any(
         isinstance(change, dict)
         and isinstance(change.get("path"), str)
@@ -1422,6 +1483,44 @@ def _content_invariants(workflow: str, changes: Sequence[dict[str, Any]]) -> lis
     ):
         invariants.extend(CONTENT_FRESHNESS_INVARIANTS)
     return invariants
+
+
+def create_coordination_promotion_proposal(
+    root: Path,
+    *,
+    target: str,
+    payload: dict[str, Any],
+    source: dict[str, Any],
+    now: datetime,
+) -> tuple[Path, dict[str, Any]]:
+    workspace = load_workspace(root)
+    changes = build_changes(
+        root, render_promotion(workspace, target, payload, source, now)
+    )
+    if len(changes) != 1:
+        raise ContextOSError("promotion proposal must contain exactly one change")
+    _validate_change_path(workspace, "promotion", now, changes[0]["path"])
+    bound_source = dict(source)
+    bound_source["target_path"] = changes[0]["path"]
+    document: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": "promotion",
+        "created_at": now.isoformat(),
+        "proposal_id": proposal_id("promotion", now, changes, binding=bound_source),
+        "source": bound_source,
+        "changes": changes,
+        "invariants": _content_invariants("promotion", changes),
+    }
+    document["proposal_digest"] = sha256_text(canonical_json(document))
+    proposal_path = (
+        root / ".context-os" / "proposals" / f"{document['proposal_id']}.json"
+    )
+    _write_exclusive_text(
+        proposal_path,
+        json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+        root=root,
+    )
+    return proposal_path, document
 
 
 def _content_change_diff(root: Path, relative: str, after_text: str) -> str:
@@ -1497,8 +1596,21 @@ def _validate_content_semantics(
         raise ContextOSError("same-day-history invariant failed")
 
 
-def proposal_id(workflow: str, now: datetime, changes: list[dict[str, Any]]) -> str:
-    seed = canonical_json({"workflow": workflow, "now": now.isoformat(), "changes": changes})
+def proposal_id(
+    workflow: str,
+    now: datetime,
+    changes: list[dict[str, Any]],
+    *,
+    binding: dict[str, Any] | None = None,
+) -> str:
+    identity: dict[str, Any] = {
+        "workflow": workflow,
+        "now": now.isoformat(),
+        "changes": changes,
+    }
+    if binding is not None:
+        identity["binding"] = binding
+    seed = canonical_json(identity)
     return f"{now.strftime('%Y%m%dT%H%M%S')}-{workflow}-{sha256_text(seed)[:10]}"
 
 
@@ -1904,14 +2016,20 @@ def _validate_change_path(workspace: Workspace, workflow: str, created_at: datet
             or (len(parts) >= 3 and parts[:2] == SETUP_SKILL_PREFIX)
         )
     else:
-        state_paths = {
-            relative_path(workspace.root, workspace.state_dir / name)
-            for name in ("current.md", "current-log.md")
-        }
+        state_paths: set[str] = set()
+        if workflow != "promotion":
+            state_paths.update(
+                relative_path(workspace.root, workspace.state_dir / name)
+                for name in ("current.md", "current-log.md")
+            )
         if workflow == "end":
             state_paths.update(
                 relative_path(workspace.root, workspace.state_dir / name)
                 for name in ("decisions.md", "blockers.md", "weekly-priorities.md")
+            )
+        elif workflow == "promotion":
+            state_paths.add(
+                relative_path(workspace.root, workspace.state_dir / "decisions.md")
             )
         session_path = relative_path(
             workspace.root, workspace.sessions_dir / f"{created_at.strftime('%Y-%m-%d')}.md"
@@ -2275,6 +2393,8 @@ def _validate_proposal_shape(
         "schema_version", "workflow", "created_at", "proposal_id",
         "changes", "invariants", "proposal_digest",
     }
+    if workflow == "promotion":
+        required.add("source")
     if workflow != AGENT_LIFECYCLE_WORKFLOW and (
         set(document) != required or document.get("schema_version") != SCHEMA_VERSION
     ):
@@ -2284,7 +2404,9 @@ def _validate_proposal_shape(
         or document.get("schema_version") != SCHEMA_VERSION
     ):
         raise ContextOSError("proposal has an unsupported schema version")
-    if workflow not in {"setup", "update", "end", AGENT_LIFECYCLE_WORKFLOW}:
+    if workflow not in {
+        "setup", "update", "end", "promotion", AGENT_LIFECYCLE_WORKFLOW
+    }:
         raise ContextOSError(f"unsupported proposal workflow: {workflow}")
     proposal_id_value = ensure_text(document.get("proposal_id"), "proposal_id")
     if not PROPOSAL_ID_RE.fullmatch(proposal_id_value):
@@ -2301,6 +2423,26 @@ def _validate_proposal_shape(
     changes = document.get("changes")
     if not isinstance(changes, list) or not changes:
         raise ContextOSError("proposal changes must be a non-empty list")
+    if workflow == "promotion":
+        source = document.get("source")
+        source_keys = {
+            "type", "id", "path", "content_sha256", "expires",
+            "from", "kind", "observed_commit", "target_path",
+        }
+        if not isinstance(source, dict) or set(source) != source_keys:
+            raise ContextOSError("promotion source binding has an invalid shape")
+        if source.get("type") != "coordination-message":
+            raise ContextOSError("promotion source has an invalid type")
+        for field in (
+            "id", "path", "expires", "from", "kind", "observed_commit", "target_path"
+        ):
+            ensure_text(source.get(field), f"source.{field}")
+        if not isinstance(source.get("content_sha256"), str) or not re.fullmatch(
+            r"[0-9a-f]{64}", source["content_sha256"]
+        ):
+            raise ContextOSError("source.content_sha256 is invalid")
+        if len(changes) != 1 or source["target_path"] != changes[0].get("path"):
+            raise ContextOSError("promotion source target does not match its change")
     if workflow != AGENT_LIFECYCLE_WORKFLOW and document.get(
         "invariants"
     ) != _content_invariants(workflow, changes):
@@ -3875,6 +4017,10 @@ def apply_proposal(
                 created_at,
                 document["changes"],
             )
+            if workflow == "promotion":
+                from .coordination import validate_promotion_source
+
+                validate_promotion_source(root, document["source"])
         head_before = git_head(root)
         applied = []
         backups: dict[Path, bytes | None] = {}
@@ -3970,6 +4116,12 @@ def apply_proposal(
                 # long enough for an uncoordinated source edit. Rebind every
                 # source and target immediately before the first mutation.
                 _validate_agent_preflight(root, document)
+            elif workflow == "promotion":
+                # Re-fetch immediately before the first canonical mutation so
+                # staging time cannot hide a changed or newly expired source.
+                from .coordination import validate_promotion_source
+
+                validate_promotion_source(root, document["source"])
             for change in document["changes"]:
                 path = _transaction_target(
                     root, change["path"], document.get("operation")
@@ -4108,6 +4260,15 @@ def apply_proposal(
                             {"path": path, "sha256_raw": digest}
                             for path, digest in document["source_hashes"].items()
                         ],
+                    },
+                })
+            elif workflow == "promotion":
+                receipt.update({
+                    "workflow": workflow,
+                    "source": document["source"],
+                    "confirmation": {
+                        "method": "exact-digest-echo",
+                        "human_authenticated": False,
                     },
                 })
             receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -130,6 +130,10 @@ CONTENT_BASE_INVARIANTS = [
 ]
 CONTENT_FRESHNESS_INVARIANTS = ["single-last-updated", "same-day-history"]
 PROMOTION_INVARIANT = "coordination-source-id-content-expiry-target"
+PROMOTION_SOURCE_KEYS = {
+    "type", "id", "path", "content_sha256", "expires",
+    "from", "kind", "observed_commit", "target_path",
+}
 PLACEHOLDER_DATE = "[DATE]"
 LAST_UPDATED_RE = re.compile(r"^\*\*Last Updated:\*\*\s*(.+?)\s*$", re.MULTILINE)
 REAL_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -2427,11 +2431,7 @@ def _validate_proposal_shape(
         raise ContextOSError("proposal changes must be a non-empty list")
     if workflow == "promotion":
         source = document.get("source")
-        source_keys = {
-            "type", "id", "path", "content_sha256", "expires",
-            "from", "kind", "observed_commit", "target_path",
-        }
-        if not isinstance(source, dict) or set(source) != source_keys:
+        if not isinstance(source, dict) or set(source) != PROMOTION_SOURCE_KEYS:
             raise ContextOSError("promotion source binding has an invalid shape")
         if source.get("type") != "coordination-message":
             raise ContextOSError("promotion source has an invalid type")
@@ -2948,6 +2948,8 @@ def _create_agent_journal(
                 "source_hashes": document["source_hashes"],
             }
             if workflow == AGENT_LIFECYCLE_WORKFLOW
+            else document["source"]
+            if workflow == "promotion"
             else None
         ),
     }
@@ -2995,7 +2997,9 @@ def _recover_agent_journal(
         or manifest.get("journal_version") != TRANSACTION_JOURNAL_VERSION
         or type(manifest.get("schema_version")) is not int
         or manifest.get("schema_version") != SCHEMA_VERSION
-        or workflow not in {"setup", "update", "end", AGENT_LIFECYCLE_WORKFLOW}
+        or workflow not in {
+            "setup", "update", "end", "promotion", AGENT_LIFECYCLE_WORKFLOW
+        }
         or manifest.get("proposal_id") != journal.name
         or not isinstance(manifest.get("proposal_id"), str)
         or PROPOSAL_ID_RE.fullmatch(manifest["proposal_id"]) is None
@@ -3040,6 +3044,23 @@ def _recover_agent_journal(
                 )
         elif manifest.get("invariants") != AGENT_MIGRATION_INVARIANTS:
             raise ContextOSError(f"invalid agent transaction evidence: {journal}")
+    elif workflow == "promotion":
+        evidence = manifest.get("agent_evidence")
+        if (
+            manifest.get("operation") != "content-lifecycle"
+            or not isinstance(evidence, dict)
+            or set(evidence) != PROMOTION_SOURCE_KEYS
+            or evidence.get("type") != "coordination-message"
+        ):
+            raise ContextOSError(f"invalid promotion transaction evidence: {journal}")
+        for field in (
+            "id", "path", "expires", "from", "kind", "observed_commit", "target_path"
+        ):
+            ensure_text(evidence.get(field), f"promotion source {field}")
+        if not isinstance(evidence.get("content_sha256"), str) or not re.fullmatch(
+            r"[0-9a-f]{64}", evidence["content_sha256"]
+        ):
+            raise ContextOSError(f"invalid promotion transaction evidence: {journal}")
     else:
         if (
             manifest.get("operation") != "content-lifecycle"
@@ -3064,6 +3085,11 @@ def _recover_agent_journal(
     }
     if not isinstance(entries, list) or not entries:
         raise ContextOSError(f"transaction journal has no entries: {journal}")
+    if workflow == "promotion" and (
+        len(entries) != 1
+        or manifest["agent_evidence"]["target_path"] != entries[0].get("path")
+    ):
+        raise ContextOSError(f"promotion journal target binding is invalid: {journal}")
     workspace = load_workspace(root) if workflow != AGENT_LIFECYCLE_WORKFLOW else None
     seen_paths: set[str] = set()
     seen_slots: set[str] = set()
@@ -3328,6 +3354,8 @@ def _recover_agent_journal(
             expected_receipt_keys.update(
                 {"workflow", "operation", "confirmation", "authorization"}
             )
+        elif workflow == "promotion":
+            expected_receipt_keys.update({"workflow", "source", "confirmation"})
         expected_files = [entry["receipt_entry"] for entry in entries]
         if (
             set(value) != expected_receipt_keys
@@ -3368,6 +3396,16 @@ def _recover_agent_journal(
             ):
                 raise ContextOSError(
                     f"journal receipt is not a valid agent commit marker: {receipt}"
+                )
+        elif workflow == "promotion":
+            if (
+                value.get("workflow") != "promotion"
+                or value.get("source") != manifest.get("agent_evidence")
+                or value.get("confirmation")
+                != {"method": "exact-digest-echo", "human_authenticated": False}
+            ):
+                raise ContextOSError(
+                    f"journal receipt is not a valid promotion commit marker: {receipt}"
                 )
         for entry, target, _content, _mode in recovered:
             if entry["action"] == "delete":

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1388,6 +1388,8 @@ def render_promotion(
         if set(payload) != {"summary"}:
             raise ContextOSError("handoff promotion input must contain only summary")
         summary = ensure_string_list(payload.get("summary"), "summary", required=True)
+        if not summary:
+            raise ContextOSError("summary must contain at least one item")
         block = (
             f"## Coordination handoff: {clock}\n"
             f"Source: coordination message `{source_id}`\n\n"

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -1493,6 +1493,8 @@ def create_coordination_promotion_proposal(
     source: dict[str, Any],
     now: datetime,
 ) -> tuple[Path, dict[str, Any]]:
+    if now.tzinfo is None:
+        raise ContextOSError("Promotion timestamps must be timezone-aware")
     workspace = load_workspace(root)
     changes = build_changes(
         root, render_promotion(workspace, target, payload, source, now)

--- a/coordination/README.md
+++ b/coordination/README.md
@@ -85,8 +85,8 @@ run-id audiences are surfaced but not validated — run ids are ephemeral.
   deletes expired messages only (mechanical); promotion of durable content
   is proposal-gated. A maintainer chooses whether a live message represents a
   user-ratified durable outcome for `state/decisions.md`, a useful session
-  handoff for today's dated session file, or neither. Kind and age can surface
-  candidates but never choose the target or imply approval.
+  handoff for the proposal-creation date's session file, or neither. Kind and
+  age can surface candidates but never choose the target or imply approval.
 - `board promote` requires an explicit message id, canonical target path, and
   reviewed JSON content. It never copies or interprets board prose as an
   instruction. The proposal binds the source id, path, exact content hash,

--- a/coordination/README.md
+++ b/coordination/README.md
@@ -83,8 +83,17 @@ run-id audiences are surfaced but not validated — run ids are ephemeral.
 - Session end: offer to post a message and release or renew claims.
 - Maintenance: `compact` reports expired messages and stale claims; applying
   deletes expired messages only (mechanical); promotion of durable content
-  into `state/decisions.md` is proposal-gated, and the proposal binds the
-  source message's identity (id, content hash, expiry).
+  is proposal-gated. A maintainer chooses whether a live message represents a
+  user-ratified durable outcome for `state/decisions.md`, a useful session
+  handoff for today's dated session file, or neither. Kind and age can surface
+  candidates but never choose the target or imply approval.
+- `board promote` requires an explicit message id, canonical target path, and
+  reviewed JSON content. It never copies or interprets board prose as an
+  instruction. The proposal binds the source id, path, exact content hash,
+  expiry, author, kind, observed coordination commit, and target. Apply
+  re-fetches that message immediately before mutation and fails closed if it
+  changed, disappeared, or expired. Unrelated coordination-ref updates do not
+  stale the proposal. Promotion never rewrites or deletes the source message.
 - Degraded hosts (fetch-only): posts queue in a local outbox with an
   undelivered receipt; a post is delivered only when its commit is confirmed
   on the remote. Fetch-only runs cannot acquire claims.
@@ -140,8 +149,17 @@ bash scripts/contextos.sh board claim --runtime <r> --task <ref> --owner <r>/<ru
 bash scripts/contextos.sh board release --runtime <r> --claim <id> [--then-claim-task <ref> --then-claim-owner <r>/<run-id>]
 bash scripts/contextos.sh board sync --runtime <r> --role <role> --run-id <id>
 bash scripts/contextos.sh board compact [--apply]
+bash scripts/contextos.sh board promote --message <id> --target state/decisions.md --input <reviewed.json>
+bash scripts/contextos.sh board promote --message <id> --target sessions/YYYY-MM-DD.md --input <reviewed.json>
 bash scripts/contextos.sh board validate
 ```
+
+Decision input contains `decision` and may include `rationale` and
+`rejected_alternatives`. Session-handoff input contains only a non-empty
+`summary` string array. `promote` creates a local proposal and changes no
+canonical file. Review its complete diff, then use the normal `apply` command
+with the exact printed digest and an explicit runtime. Board text, message kind,
+candidate age, and proposal creation are never approval evidence.
 
 Every command validates before publishing and returns a JSON receipt or
 report. Publishing pushes to the workspace remote — the host permission

--- a/docs/cross-runtime-architecture.md
+++ b/docs/cross-runtime-architecture.md
@@ -64,9 +64,11 @@ SHA-256 values. Their proposal digest covers the entire unsigned proposal. It
 binds integrity; the host permission prompt supplies the human approval boundary.
 Apply requires that exact digest, re-hashes every target, takes an exclusive
 `O_EXCL` lock, writes using UTF-8/LF, and emits a receipt inside a durable,
-path-bound journal. The journal gives `setup`, `update`, `end`, and
-`agent-config` resumable multi-file rollback across process death. New tracked
-content is non-executable; existing targets preserve their approved mode.
+path-bound journal. The journal gives `setup`, `update`, `end`, `promotion`, and
+`agent-config` resumable rollback across process death. Promotion additionally
+binds its coordination source and canonical target into the journal and receipt,
+so recovery validates the same provenance as apply. New tracked content is
+non-executable; existing targets preserve their approved mode.
 
 The `agent-config` workspace-migration workflow additionally binds raw-byte
 target and source hashes, proposal-bound before/after modes,

--- a/docs/root-contract.md
+++ b/docs/root-contract.md
@@ -199,7 +199,7 @@ instead scoped to one exact ContextRoot and project identity.
 
 ## Write and evidence boundaries
 
-Lifecycle setup/update/end obey these invariants:
+Journal-backed lifecycle and promotion workflows obey these invariants:
 
 1. Proposal, lock, staging, journal, receipt, and every target path are owned by
    ContextRoot. Host skills conventionally place reviewed input beneath

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -24,7 +24,11 @@ from contextos.coordination import (
     sync_board,
     validate_board,
 )
-from contextos.kernel import ContextOSError, apply_proposal
+from contextos.kernel import (
+    ContextOSError,
+    apply_proposal,
+    create_coordination_promotion_proposal,
+)
 from contextos.cli import main as cli_main
 
 
@@ -1161,6 +1165,16 @@ class CoordinationTests(unittest.TestCase):
         )
         self.assertEqual(2, status)
         self.assertIn("promotion target must be", stderr)
+
+    def test_promotion_kernel_rejects_naive_creation_time(self) -> None:
+        with self.assertRaisesRegex(ContextOSError, "timezone-aware"):
+            create_coordination_promotion_proposal(
+                self.repo_a,
+                target="state/decisions.md",
+                payload={"decision": "Must not be proposed"},
+                source={},
+                now=NOW.replace(tzinfo=None),
+            )
 
     def test_validate_clean_and_reports_malformed_and_imperative_files(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -26,6 +26,7 @@ from contextos.coordination import (
 )
 from contextos.kernel import (
     ContextOSError,
+    _recover_pending_agent_journals,
     apply_proposal,
     create_coordination_promotion_proposal,
 )
@@ -1088,6 +1089,84 @@ class CoordinationTests(unittest.TestCase):
                 self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
             )
         self.assertEqual(before, decisions.read_text(encoding="utf-8"))
+
+    def test_promotion_rolls_back_second_source_validation_failure(self) -> None:
+        self._prepare_workspace()
+        message = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="note",
+            body="Candidate whose second validation fails.",
+            runtime="claude",
+            now=NOW,
+        )
+        proposal_path, proposal = propose_promotion(
+            self.repo_a,
+            message_id=message["id"],
+            target="state/decisions.md",
+            payload={"decision": "Do not wedge transaction recovery"},
+            now=NOW + timedelta(hours=1),
+        )
+        decisions = self.repo_a / "state" / "decisions.md"
+        before = decisions.read_bytes()
+        original_validate = coordination.validate_promotion_source
+        calls = 0
+
+        def fail_second_validation(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise ContextOSError("injected promotion revalidation failure")
+            return original_validate(*args, **kwargs)
+
+        with mock.patch.object(
+            coordination,
+            "validate_promotion_source",
+            side_effect=fail_second_validation,
+        ), self.assertRaisesRegex(ContextOSError, "injected promotion revalidation failure"):
+            apply_proposal(
+                self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
+            )
+        self.assertEqual(2, calls)
+        self.assertEqual(before, decisions.read_bytes())
+        journals = self.repo_a / ".context-os" / "journals"
+        self.assertEqual([], list(journals.iterdir()))
+
+    def test_promotion_retires_committed_journal_during_recovery(self) -> None:
+        self._prepare_workspace()
+        message = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="note",
+            body="Candidate with a retained committed journal.",
+            runtime="claude",
+            now=NOW,
+        )
+        proposal_path, proposal = propose_promotion(
+            self.repo_a,
+            message_id=message["id"],
+            target="state/decisions.md",
+            payload={"decision": "Recover the committed promotion"},
+            now=NOW + timedelta(hours=1),
+        )
+        with mock.patch("contextos.kernel._discard_agent_journal", return_value=None):
+            receipt_path, _ = apply_proposal(
+                self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
+            )
+        journal = self.repo_a / ".context-os" / "journals" / proposal["proposal_id"]
+        self.assertTrue(journal.is_dir())
+        self.assertTrue(receipt_path.is_file())
+
+        _recover_pending_agent_journals(self.repo_a)
+
+        self.assertFalse(journal.exists())
+        self.assertTrue(receipt_path.is_file())
+        self.assertIn(
+            "Recover the committed promotion",
+            (self.repo_a / "state" / "decisions.md").read_text(encoding="utf-8"),
+        )
 
     def test_promotion_tolerates_unrelated_update_and_writes_handoff(self) -> None:
         self._prepare_workspace()

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1180,6 +1180,14 @@ class CoordinationTests(unittest.TestCase):
             now=NOW,
         )
         target = "sessions/2026-08-31.md"
+        with self.assertRaisesRegex(ContextOSError, "at least one item"):
+            propose_promotion(
+                self.repo_a,
+                message_id=source["id"],
+                target=target,
+                payload={"summary": []},
+                now=NOW + timedelta(hours=1),
+            )
         proposal_path, proposal = propose_promotion(
             self.repo_a,
             message_id=source["id"],

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -19,15 +19,17 @@ from contextos.coordination import (
     compact_board,
     create_claim,
     post_message,
+    propose_promotion,
     release_claim,
     sync_board,
     validate_board,
 )
-from contextos.kernel import ContextOSError
+from contextos.kernel import ContextOSError, apply_proposal
 from contextos.cli import main as cli_main
 
 
 NOW = datetime.fromisoformat("2026-08-31T14:30:00+00:00")
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def git(
@@ -169,6 +171,25 @@ class CoordinationTests(unittest.TestCase):
         with mock.patch.object(sys, "stdin", io.StringIO(stdin)), redirect_stdout(stdout), redirect_stderr(stderr):
             status = cli_main(["--root", str(self.repo_a), *args])
         return status, stdout.getvalue(), stderr.getvalue()
+
+    def _prepare_workspace(self) -> None:
+        (self.repo_a / "AGENTS.md").write_text("# Fixture\n", encoding="utf-8")
+        (self.repo_a / "state").mkdir(exist_ok=True)
+        (self.repo_a / "sessions").mkdir(exist_ok=True)
+        (self.repo_a / "runtimes").mkdir(exist_ok=True)
+        (self.repo_a / "components").mkdir(exist_ok=True)
+        (self.repo_a / "state" / "decisions.md").write_text(
+            "# Decisions Log\n\n"
+            "| Date | Decision | Context / rationale | Rejected alternatives |\n"
+            "|---|---|---|---|\n",
+            encoding="utf-8",
+        )
+        (self.repo_a / "runtimes" / "codex.json").write_bytes(
+            (ROOT / "runtimes" / "codex.json").read_bytes()
+        )
+        (self.repo_a / "components" / "manifest.json").write_bytes(
+            (ROOT / "components" / "manifest.json").read_bytes()
+        )
 
     def test_bootstrap_creates_ref_and_second_bootstrap_is_noop(self) -> None:
         before_branch = git(
@@ -961,6 +982,185 @@ class CoordinationTests(unittest.TestCase):
             synced["scan"]["message_bytes_read"]
             + synced["scan"]["claim_bytes_read"],
         )
+
+    def test_promotion_requires_exact_digest_and_preserves_source(self) -> None:
+        self._prepare_workspace()
+        message = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="note",
+            body="A candidate outcome for human review.",
+            runtime="claude",
+            now=NOW,
+        )
+        decisions = self.repo_a / "state" / "decisions.md"
+        before = decisions.read_text(encoding="utf-8")
+        proposal_path, proposal = propose_promotion(
+            self.repo_a,
+            message_id=message["id"],
+            target="state/decisions.md",
+            payload={
+                "decision": "Adopt the reviewed outcome",
+                "rationale": "The maintainer ratified it",
+                "rejected_alternatives": "Leave it ephemeral",
+            },
+            now=NOW + timedelta(hours=1),
+        )
+        self.assertEqual(before, decisions.read_text(encoding="utf-8"))
+        self.assertEqual(message["id"], proposal["source"]["id"])
+        self.assertEqual("state/decisions.md", proposal["source"]["target_path"])
+        with self.assertRaisesRegex(ContextOSError, "--confirm must exactly match"):
+            apply_proposal(self.repo_a, proposal_path, "0" * 64, "codex")
+        self.assertEqual(before, decisions.read_text(encoding="utf-8"))
+
+        receipt_path, receipt = apply_proposal(
+            self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
+        )
+        self.assertTrue(receipt_path.is_file())
+        self.assertEqual(proposal["source"], receipt["source"])
+        self.assertIn("Adopt the reviewed outcome", decisions.read_text(encoding="utf-8"))
+        self.assertIn(message["path"], self._paths("coordination/board"))
+
+    def test_promotion_rejects_changed_source_without_mutating_target(self) -> None:
+        self._prepare_workspace()
+        message = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="alert",
+            body="Candidate that will change.",
+            expires=iso(NOW + timedelta(days=2)),
+            runtime="claude",
+            now=NOW,
+        )
+        proposal_path, proposal = propose_promotion(
+            self.repo_a,
+            message_id=message["id"],
+            target="state/decisions.md",
+            payload={"decision": "Never apply a changed source"},
+            now=NOW + timedelta(hours=1),
+        )
+        decisions = self.repo_a / "state" / "decisions.md"
+        before = decisions.read_text(encoding="utf-8")
+        original = self._show(message["path"])
+        self._plant_files(
+            {message["path"]: original.replace("Candidate", "Altered")},
+            "Alter promotion source",
+        )
+        with mock.patch.object(
+            coordination, "utc_now", return_value=NOW + timedelta(hours=1)
+        ), self.assertRaisesRegex(ContextOSError, "source changed"):
+            apply_proposal(
+                self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
+            )
+        self.assertEqual(before, decisions.read_text(encoding="utf-8"))
+
+    def test_promotion_rejects_source_that_expired_after_proposal(self) -> None:
+        self._prepare_workspace()
+        message = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="alert",
+            body="Candidate that will expire.",
+            expires=iso(NOW + timedelta(days=2)),
+            runtime="claude",
+            now=NOW,
+        )
+        proposal_path, proposal = propose_promotion(
+            self.repo_a,
+            message_id=message["id"],
+            target="state/decisions.md",
+            payload={"decision": "Never apply an expired source"},
+            now=NOW + timedelta(hours=1),
+        )
+        decisions = self.repo_a / "state" / "decisions.md"
+        before = decisions.read_text(encoding="utf-8")
+        with mock.patch.object(
+            coordination, "utc_now", return_value=NOW + timedelta(days=3)
+        ), self.assertRaisesRegex(ContextOSError, "has expired"):
+            apply_proposal(
+                self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
+            )
+        self.assertEqual(before, decisions.read_text(encoding="utf-8"))
+
+    def test_promotion_tolerates_unrelated_update_and_writes_handoff(self) -> None:
+        self._prepare_workspace()
+        source = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="handoff",
+            body="Candidate handoff.",
+            runtime="claude",
+            now=NOW,
+        )
+        target = "sessions/2026-08-31.md"
+        proposal_path, proposal = propose_promotion(
+            self.repo_a,
+            message_id=source["id"],
+            target=target,
+            payload={"summary": ["Continue from the reviewed checkpoint"]},
+            now=NOW + timedelta(hours=1),
+        )
+        post_message(
+            self.repo_b,
+            sender="codex/researcher",
+            audience="all",
+            kind="note",
+            body="An unrelated board update.",
+            runtime="codex",
+            now=NOW + timedelta(minutes=30),
+        )
+        _, receipt = apply_proposal(
+            self.repo_a, proposal_path, proposal["proposal_digest"], "codex"
+        )
+        self.assertEqual(source["id"], receipt["source"]["id"])
+        handoff = (self.repo_a / target).read_text(encoding="utf-8")
+        self.assertIn("Continue from the reviewed checkpoint", handoff)
+        self.assertIn(source["id"], handoff)
+
+    def test_promotion_cli_requires_explicit_allowed_target(self) -> None:
+        self._prepare_workspace()
+        source = post_message(
+            self.repo_a,
+            sender="claude/researcher",
+            audience="all",
+            kind="note",
+            body="Candidate for explicit selection.",
+            runtime="claude",
+            now=NOW,
+        )
+        payload = self.base / "promotion.json"
+        payload.write_text(
+            json.dumps({"decision": "A reviewed CLI decision"}),
+            encoding="utf-8",
+        )
+        status, stdout, stderr = self._run_cli(
+            "board", "promote",
+            "--message", source["id"],
+            "--target", "state/decisions.md",
+            "--input", str(payload),
+            "--now", iso(NOW + timedelta(hours=1)),
+        )
+        self.assertEqual(0, status, stderr)
+        report = json.loads(stdout)
+        self.assertEqual(source["id"], report["source"]["id"])
+        self.assertFalse(
+            "A reviewed CLI decision"
+            in (self.repo_a / "state" / "decisions.md").read_text(encoding="utf-8")
+        )
+
+        status, _, stderr = self._run_cli(
+            "board", "promote",
+            "--message", source["id"],
+            "--target", "state/current.md",
+            "--input", str(payload),
+            "--now", iso(NOW + timedelta(hours=1)),
+        )
+        self.assertEqual(2, status)
+        self.assertIn("promotion target must be", stderr)
 
     def test_validate_clean_and_reports_malformed_and_imperative_files(self) -> None:
         bootstrap_board(self.repo_a, now=NOW)


### PR DESCRIPTION
## What is in this PR

Adds a human-selected, proposal-only workflow for promoting live coordination messages into either the decisions log or the proposal-creation date session handoff.

The proposal binds source identity, path, content hash, expiry, provenance commit, and explicit target. Apply re-fetches immediately before mutation, rejects changed, missing, expired, or history-rewritten sources, tolerates unrelated board updates, and never modifies the source message.

Closes #171.

## Checklist

### Skills & commands
- [x] Portable workflows keep provider-specific tools and paths in thin host adapters
- [x] Existing context-end skill retains explicit invocation and approval policy

### Integrations
- [x] Not applicable
- [x] CHANGELOG.md updated
- [x] Full validation passes locally

### Repo hygiene
- [x] No sensitive data committed
- [x] CHANGELOG.md updated
- [ ] CI passes

## Verification

- Full validation: 651 tests passed, 47 skipped; all catalog, component, bundle, runtime, workspace, and JSON checks passed.
- Coordination suite: 24 tests passed.
- Promotion-focused suite after review repair: 6 tests passed.
- Free review: opencode/muse-spark-1.3-contributor-free at f612ea0; one low timestamp-hardening finding fixed.
- Final free review: opencode/mimo-v2.5-free at 5b474c2; no merge-blocking findings.
- Authenticated Claude review is pending until the available review window; PR remains draft until that exact-SHA gate completes.