### PR TITLE
Add integration evidence-freshness reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- A deterministic, read-only integration evidence-freshness report now marks
+  entries as current, due soon, or stale and gives maintainers evidence links,
+  review dates, and explicit human-review actions without changing claims (#162).
 - Integration catalog contributions now use one authoritative JSON file per
   entry. Deterministic aggregation generates the machine catalog, Markdown
   reference, and component ownership records, while the chooser and changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,12 @@ The task chooser and changelog are curated release-maintainer surfaces. A
 routine entry contribution does not edit them unless it also changes product
 guidance or records a release-level behavior change.
 
+Run `python3 scripts/integrations.py freshness` for the current evidence-health
+report, or add `--as-of YYYY-MM-DD` for reproducible local/CI output. Use
+`--format markdown` for a human-readable table. The report is read-only and
+offline: it never refreshes dates or treats link reachability as semantic
+verification.
+
 `maturity` is a claim about metadata, not about testing. `verified` means
 every submitted field is supported by current first-party evidence on the stated date.
 It does NOT mean that you created an account, installed the integration, authenticated,

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ uninstall behavior.
 
 Start with the task-based [integration chooser](docs/integrations-guide.md), add at most one new trust boundary at a time, then read the selected generated entry in full.
 
+Maintainers can run `python3 scripts/integrations.py freshness` to see which
+entries are approaching or past their human evidence-review date. Pass
+`--as-of YYYY-MM-DD` when reproducible output is required.
+
 The catalog spans portable skill collections, creator tools, CLIs, and MCP
 servers. Treat the generated catalog and task-based chooser as the current
 inventory rather than relying on a hand-maintained summary. `listed` and

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -624,6 +624,10 @@
                     "policy": "development"
                 },
                 {
+                    "path": "tests/fixtures/integration-freshness.json",
+                    "policy": "development"
+                },
+                {
                     "path": "tests/fixtures/workspace-conflicts.json",
                     "policy": "development"
                 },

--- a/docs/repo-maintenance.md
+++ b/docs/repo-maintenance.md
@@ -90,6 +90,27 @@ If upstream behavior changed since `last_verified`, update its
 `integrations/entries/<id>.json` source, run `scripts/integrations.py render`,
 add regression coverage when needed, and review every generated diff.
 
+### Evidence freshness policy
+
+Run `python3 scripts/integrations.py freshness` for JSON, or add
+`--format markdown` for a maintainer table. Pass `--as-of YYYY-MM-DD` in CI,
+saved evidence, or comparisons so the result is reproducible.
+
+Evidence has a 90-day review interval:
+
+- `current`: more than 30 days remain. No immediate action; review by the
+  suggested next-review date.
+- `due_soon`: 1–30 days remain. Schedule a human review of every catalog claim
+  against current first-party evidence before that date.
+- `stale`: the review is due today or overdue. Re-verify before relying on the
+  entry's safety, capability, maturity, or support claims.
+
+The report is offline and read-only. It reports entry ID, evidence URLs,
+`last_verified`, state, days remaining, suggested next-review date, and response.
+It never updates `last_verified`, maturity, capabilities, or support claims.
+A reachable link would not prove that upstream permissions, scopes, tools, or
+safety behavior are unchanged; any future network check must remain advisory.
+
 ## Changelog
 
 Whenever you add, remove, or significantly change a file, update `CHANGELOG.md`. Use each applicable `Added`, `Changed`, `Fixed`, or `Removed` heading at most once per release block, and list each public behavior change once.

--- a/scripts/integrations.py
+++ b/scripts/integrations.py
@@ -408,6 +408,10 @@ def validate_catalog(catalog: Any) -> None:
             raise CatalogError(f"{location}.uninstall: user-data removal requires delete and destructive capabilities")
         if not isinstance(item["maturity"], str) or item["maturity"] not in MATURITY:
             raise CatalogError(f"{location}.maturity: unsupported maturity")
+        if not isinstance(item["last_verified"], str) or not re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}", item["last_verified"]
+        ):
+            raise CatalogError(f"{location}.last_verified: expected YYYY-MM-DD")
         try:
             verified_on = dt.date.fromisoformat(item["last_verified"])
         except (TypeError, ValueError):
@@ -447,6 +451,12 @@ def freshness_report(catalog: dict[str, Any], as_of: dt.date) -> dict[str, Any]:
     entries = []
     summary = {state: 0 for state in FRESHNESS_STATES}
     for item in sorted(catalog["integrations"], key=lambda value: value["id"]):
+        if not isinstance(item["last_verified"], str) or not re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}", item["last_verified"]
+        ):
+            raise CatalogError(
+                f"{item['id']}.last_verified: expected YYYY-MM-DD"
+            )
         try:
             verified_on = dt.date.fromisoformat(item["last_verified"])
         except (TypeError, ValueError):

--- a/scripts/integrations.py
+++ b/scripts/integrations.py
@@ -447,7 +447,12 @@ def freshness_report(catalog: dict[str, Any], as_of: dt.date) -> dict[str, Any]:
     entries = []
     summary = {state: 0 for state in FRESHNESS_STATES}
     for item in sorted(catalog["integrations"], key=lambda value: value["id"]):
-        verified_on = dt.date.fromisoformat(item["last_verified"])
+        try:
+            verified_on = dt.date.fromisoformat(item["last_verified"])
+        except (TypeError, ValueError):
+            raise CatalogError(
+                f"{item['id']}.last_verified: expected YYYY-MM-DD"
+            ) from None
         if verified_on > as_of:
             raise CatalogError(
                 f"{item['id']}.last_verified: {verified_on.isoformat()} is after "
@@ -476,7 +481,7 @@ def freshness_report(catalog: dict[str, Any], as_of: dt.date) -> dict[str, Any]:
         entries.append(
             {
                 "id": item["id"],
-                "evidence_urls": item["evidence"],
+                "evidence_urls": list(item["evidence"]),
                 "last_verified": verified_on.isoformat(),
                 "freshness_state": state,
                 "suggested_next_review": suggested_next_review.isoformat(),
@@ -595,7 +600,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         catalog = load_catalog()
         if args.command == "freshness":
-            as_of = parse_report_date(args.as_of) if args.as_of else dt.date.today()
+            as_of = (
+                parse_report_date(args.as_of)
+                if args.as_of is not None
+                else dt.date.today()
+            )
             report = freshness_report(catalog, as_of)
             if args.format == "markdown":
                 sys.stdout.write(render_freshness_markdown(report))

--- a/scripts/integrations.py
+++ b/scripts/integrations.py
@@ -595,7 +595,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--as-of", help="freshness report date in YYYY-MM-DD")
     parser.add_argument("--format", choices=("json", "markdown"))
     args = parser.parse_args(argv)
-    if args.command != "freshness" and (args.as_of or args.format):
+    if args.command != "freshness" and (
+        args.as_of is not None or args.format is not None
+    ):
         parser.error("--as-of and --format apply only to the freshness command")
     try:
         catalog = load_catalog()

--- a/scripts/integrations.py
+++ b/scripts/integrations.py
@@ -19,6 +19,9 @@ CATALOG_PATH = ROOT / "integrations" / "catalog.json"
 ENTRY_DIR = ROOT / "integrations" / "entries"
 REFERENCE_PATH = ROOT / "references" / "integrations.md"
 COMPONENT_MANIFEST_PATH = ROOT / "components" / "manifest.json"
+FRESHNESS_REVIEW_DAYS = 90
+FRESHNESS_DUE_SOON_DAYS = 30
+FRESHNESS_STATES = ("current", "due_soon", "stale")
 
 KINDS = {
     "mcp_server",
@@ -431,6 +434,95 @@ def markdown_paragraph(value: str) -> str:
     return escaped
 
 
+def parse_report_date(value: str) -> dt.date:
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        raise CatalogError("--as-of: expected YYYY-MM-DD")
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError:
+        raise CatalogError("--as-of: expected YYYY-MM-DD") from None
+
+
+def freshness_report(catalog: dict[str, Any], as_of: dt.date) -> dict[str, Any]:
+    entries = []
+    summary = {state: 0 for state in FRESHNESS_STATES}
+    for item in sorted(catalog["integrations"], key=lambda value: value["id"]):
+        verified_on = dt.date.fromisoformat(item["last_verified"])
+        if verified_on > as_of:
+            raise CatalogError(
+                f"{item['id']}.last_verified: {verified_on.isoformat()} is after "
+                f"report date {as_of.isoformat()}"
+            )
+        suggested_next_review = verified_on + dt.timedelta(
+            days=FRESHNESS_REVIEW_DAYS
+        )
+        days_until_review = (suggested_next_review - as_of).days
+        if days_until_review <= 0:
+            state = "stale"
+            action = (
+                "Complete a human first-party-evidence review of every catalog claim "
+                "before relying on it; update metadata only after that review."
+            )
+        elif days_until_review <= FRESHNESS_DUE_SOON_DAYS:
+            state = "due_soon"
+            action = (
+                "Schedule a human first-party-evidence review before the suggested "
+                "next review date."
+            )
+        else:
+            state = "current"
+            action = "No immediate action; review by the suggested next review date."
+        summary[state] += 1
+        entries.append(
+            {
+                "id": item["id"],
+                "evidence_urls": item["evidence"],
+                "last_verified": verified_on.isoformat(),
+                "freshness_state": state,
+                "suggested_next_review": suggested_next_review.isoformat(),
+                "days_until_review": days_until_review,
+                "suggested_action": action,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "as_of": as_of.isoformat(),
+        "policy": {
+            "review_after_days": FRESHNESS_REVIEW_DAYS,
+            "due_soon_when_days_remaining_at_most": FRESHNESS_DUE_SOON_DAYS,
+            "states": list(FRESHNESS_STATES),
+        },
+        "summary": summary,
+        "entries": entries,
+    }
+
+
+def render_freshness_markdown(report: dict[str, Any]) -> str:
+    rows = []
+    for item in report["entries"]:
+        evidence = "<br>".join(
+            f"[{index + 1}]({url})"
+            for index, url in enumerate(item["evidence_urls"])
+        )
+        rows.append(
+            f"| `{item['id']}` | `{item['freshness_state']}` | "
+            f"{item['last_verified']} | {item['suggested_next_review']} | "
+            f"{item['days_until_review']} | {evidence} | "
+            f"{item['suggested_action']} |"
+        )
+    policy = report["policy"]
+    return (
+        "# Integration evidence freshness\n\n"
+        f"As of `{report['as_of']}`. Evidence becomes stale "
+        f"{policy['review_after_days']} days after `last_verified`; `due_soon` "
+        f"begins when {policy['due_soon_when_days_remaining_at_most']} days remain.\n\n"
+        "| Entry | State | Last verified | Suggested next review | Days remaining | Evidence | Maintainer response |\n"
+        "|---|---|---|---|---:|---|---|\n"
+        + "\n".join(rows)
+        + "\n"
+    )
+
+
 def render_reference(catalog: dict[str, Any]) -> str:
     rows = []
     sections = []
@@ -494,10 +586,22 @@ def render_reference(catalog: dict[str, Any]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", choices=("validate", "render", "check"))
+    parser.add_argument("command", choices=("validate", "render", "check", "freshness"))
+    parser.add_argument("--as-of", help="freshness report date in YYYY-MM-DD")
+    parser.add_argument("--format", choices=("json", "markdown"))
     args = parser.parse_args(argv)
+    if args.command != "freshness" and (args.as_of or args.format):
+        parser.error("--as-of and --format apply only to the freshness command")
     try:
         catalog = load_catalog()
+        if args.command == "freshness":
+            as_of = parse_report_date(args.as_of) if args.as_of else dt.date.today()
+            report = freshness_report(catalog, as_of)
+            if args.format == "markdown":
+                sys.stdout.write(render_freshness_markdown(report))
+            else:
+                sys.stdout.write(json.dumps(report, indent=2, ensure_ascii=False) + "\n")
+            return 0
         rendered_catalog = render_catalog(catalog)
         rendered_reference = render_reference(catalog)
         rendered_components = render_component_manifest(catalog)

--- a/tests/fixtures/integration-freshness.json
+++ b/tests/fixtures/integration-freshness.json
@@ -1,0 +1,40 @@
+{
+  "as_of": "2026-09-03",
+  "cases": [
+    {
+      "id": "current-boundary",
+      "last_verified": "2026-07-06",
+      "expected_state": "current",
+      "expected_next_review": "2026-10-04",
+      "expected_days_remaining": 31
+    },
+    {
+      "id": "due-soon-start",
+      "last_verified": "2026-07-05",
+      "expected_state": "due_soon",
+      "expected_next_review": "2026-10-03",
+      "expected_days_remaining": 30
+    },
+    {
+      "id": "due-soon-end",
+      "last_verified": "2026-06-06",
+      "expected_state": "due_soon",
+      "expected_next_review": "2026-09-04",
+      "expected_days_remaining": 1
+    },
+    {
+      "id": "stale-boundary",
+      "last_verified": "2026-06-05",
+      "expected_state": "stale",
+      "expected_next_review": "2026-09-03",
+      "expected_days_remaining": 0
+    },
+    {
+      "id": "stale-overdue",
+      "last_verified": "2026-06-04",
+      "expected_state": "stale",
+      "expected_next_review": "2026-09-02",
+      "expected_days_remaining": -1
+    }
+  ]
+}

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -564,22 +564,32 @@ class IntegrationCatalogTests(unittest.TestCase):
 
     def test_stale_freshness_output_is_actionable_and_read_only(self) -> None:
         before = copy.deepcopy(self.catalog)
-        as_of = MODULE.parse_report_date("2026-12-02")
+        latest_verified = max(
+            MODULE.parse_report_date(item["last_verified"])
+            for item in self.catalog["integrations"]
+        )
+        as_of = latest_verified + MODULE.dt.timedelta(
+            days=MODULE.FRESHNESS_REVIEW_DAYS
+        )
         report = MODULE.freshness_report(self.catalog, as_of)
         markdown = MODULE.render_freshness_markdown(report)
-        self.assertEqual(self.catalog, before)
         self.assertTrue(report["entries"])
         self.assertTrue(all(item["freshness_state"] == "stale" for item in report["entries"]))
         first = report["entries"][0]
         self.assertIn(first["id"], markdown)
         self.assertIn(first["evidence_urls"][0], markdown)
         self.assertIn("human first-party-evidence review", first["suggested_action"])
+        first["evidence_urls"].append("https://example.com/report-only")
+        self.assertEqual(self.catalog, before)
 
     def test_freshness_cli_uses_generated_entry_aggregation(self) -> None:
+        as_of = max(
+            item["last_verified"] for item in self.catalog["integrations"]
+        )
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             self.assertEqual(
-                MODULE.main(["freshness", "--as-of", "2026-09-03"]), 0
+                MODULE.main(["freshness", "--as-of", as_of]), 0
             )
         report = json.loads(output.getvalue())
         source_ids = sorted(path.stem for path in MODULE.ENTRY_DIR.glob("*.json"))
@@ -593,6 +603,23 @@ class IntegrationCatalogTests(unittest.TestCase):
     def test_freshness_rejects_invalid_or_preverification_report_dates(self) -> None:
         with self.assertRaises(MODULE.CatalogError):
             MODULE.parse_report_date("20260903")
+        errors = io.StringIO()
+        with contextlib.redirect_stderr(errors):
+            self.assertEqual(MODULE.main(["freshness", "--as-of", ""]), 1)
+        self.assertIn("--as-of: expected YYYY-MM-DD", errors.getvalue())
+        with self.assertRaisesRegex(MODULE.CatalogError, "expected YYYY-MM-DD"):
+            MODULE.freshness_report(
+                {
+                    "integrations": [
+                        {
+                            "id": "malformed-date",
+                            "evidence": ["https://example.com/evidence"],
+                            "last_verified": "not-a-date",
+                        }
+                    ]
+                },
+                MODULE.parse_report_date("2026-09-02"),
+            )
         with self.assertRaisesRegex(MODULE.CatalogError, "is after report date"):
             MODULE.freshness_report(
                 {

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -519,6 +519,11 @@ class IntegrationCatalogTests(unittest.TestCase):
 
     def test_future_verification_dates_are_rejected(self) -> None:
         self.assert_invalid(
+            lambda catalog: catalog["integrations"][0].update(
+                {"last_verified": "20260903"}
+            )
+        )
+        self.assert_invalid(
             lambda catalog: catalog["integrations"][0].update({"last_verified": "9999-12-31"})
         )
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -607,6 +607,11 @@ class IntegrationCatalogTests(unittest.TestCase):
         with contextlib.redirect_stderr(errors):
             self.assertEqual(MODULE.main(["freshness", "--as-of", ""]), 1)
         self.assertIn("--as-of: expected YYYY-MM-DD", errors.getvalue())
+        errors = io.StringIO()
+        with contextlib.redirect_stderr(errors), self.assertRaises(SystemExit) as exit_error:
+            MODULE.main(["validate", "--as-of", ""])
+        self.assertEqual(exit_error.exception.code, 2)
+        self.assertIn("apply only to the freshness command", errors.getvalue())
         with self.assertRaisesRegex(MODULE.CatalogError, "expected YYYY-MM-DD"):
             MODULE.freshness_report(
                 {

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,5 +1,7 @@
 import copy
+import contextlib
 import importlib.util
+import io
 import json
 import tempfile
 import unittest
@@ -519,6 +521,91 @@ class IntegrationCatalogTests(unittest.TestCase):
         self.assert_invalid(
             lambda catalog: catalog["integrations"][0].update({"last_verified": "9999-12-31"})
         )
+
+    def test_freshness_threshold_fixture_boundaries(self) -> None:
+        fixture = json.loads(
+            (ROOT / "tests" / "fixtures" / "integration-freshness.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        catalog = {
+            "integrations": [
+                {
+                    "id": case["id"],
+                    "evidence": [f"https://example.com/{case['id']}"],
+                    "last_verified": case["last_verified"],
+                }
+                for case in fixture["cases"]
+            ]
+        }
+        report = MODULE.freshness_report(
+            catalog, MODULE.parse_report_date(fixture["as_of"])
+        )
+        actual = {
+            item["id"]: (
+                item["freshness_state"],
+                item["suggested_next_review"],
+                item["days_until_review"],
+            )
+            for item in report["entries"]
+        }
+        expected = {
+            case["id"]: (
+                case["expected_state"],
+                case["expected_next_review"],
+                case["expected_days_remaining"],
+            )
+            for case in fixture["cases"]
+        }
+        self.assertEqual(actual, expected)
+        self.assertEqual(
+            report["summary"], {"current": 1, "due_soon": 2, "stale": 2}
+        )
+
+    def test_stale_freshness_output_is_actionable_and_read_only(self) -> None:
+        before = copy.deepcopy(self.catalog)
+        as_of = MODULE.parse_report_date("2026-12-02")
+        report = MODULE.freshness_report(self.catalog, as_of)
+        markdown = MODULE.render_freshness_markdown(report)
+        self.assertEqual(self.catalog, before)
+        self.assertTrue(report["entries"])
+        self.assertTrue(all(item["freshness_state"] == "stale" for item in report["entries"]))
+        first = report["entries"][0]
+        self.assertIn(first["id"], markdown)
+        self.assertIn(first["evidence_urls"][0], markdown)
+        self.assertIn("human first-party-evidence review", first["suggested_action"])
+
+    def test_freshness_cli_uses_generated_entry_aggregation(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.assertEqual(
+                MODULE.main(["freshness", "--as-of", "2026-09-03"]), 0
+            )
+        report = json.loads(output.getvalue())
+        source_ids = sorted(path.stem for path in MODULE.ENTRY_DIR.glob("*.json"))
+        self.assertEqual(
+            [item["id"] for item in report["entries"]], source_ids
+        )
+        by_id = {item["id"]: item for item in self.catalog["integrations"]}
+        for item in report["entries"]:
+            self.assertEqual(item["evidence_urls"], by_id[item["id"]]["evidence"])
+
+    def test_freshness_rejects_invalid_or_preverification_report_dates(self) -> None:
+        with self.assertRaises(MODULE.CatalogError):
+            MODULE.parse_report_date("20260903")
+        with self.assertRaisesRegex(MODULE.CatalogError, "is after report date"):
+            MODULE.freshness_report(
+                {
+                    "integrations": [
+                        {
+                            "id": "future-relative-to-report",
+                            "evidence": ["https://example.com/evidence"],
+                            "last_verified": "2026-09-03",
+                        }
+                    ]
+                },
+                MODULE.parse_report_date("2026-09-02"),
+            )
 
     def test_maturity_is_not_upgraded_by_rendering(self) -> None:
         item = self.entry("ai-tools-for-creators")


### PR DESCRIPTION
Adds an offline, read-only integration evidence report with current, due_soon, and stale states under a 90-day review policy. JSON and Markdown output include evidence links, review dates, days remaining, and maintainer actions. --as-of makes reports reproducible.

Closes #162. #177 is merged; this PR now targets main.

Validation: full validate-all.sh passes on 5360066aff5001f20b197e2ee590394fb188d7ef; the main-update commit 47041a6295f4033900de4ac5b7f137a33960ec5f has an identical Git tree, including 661 Python tests (47 skipped), hooks, portability, links, generators, and schemas. Fresh Claude Opus 5, Muse Spark 1.3 Free, and MiMo V2.5 Free reviews completed; findings were checked locally.
