### PR TITLE
Finish OpenCode fixture and read-only conformance guards

### DIFF
--- a/adapters/opencode/live_conformance.py
+++ b/adapters/opencode/live_conformance.py
@@ -139,7 +139,8 @@ def copy_tracked_fixture(repo: Path, fixture: Path, commit: str) -> None:
     )
     if listed.returncode != 0:
         raise RuntimeError("could not enumerate the verified commit tree")
-    fixture.mkdir(parents=True)
+    entries: list[tuple[PurePosixPath, str, str]] = []
+    seen: dict[str, tuple[str, bool]] = {}
     for record in listed.stdout.split(b"\0"):
         if not record:
             continue
@@ -156,19 +157,41 @@ def copy_tracked_fixture(repo: Path, fixture: Path, commit: str) -> None:
             or ".." in relative.parts
             or not relative.parts
             or re.match(r"^[A-Za-z]:", relative.parts[0])
+            or any(
+                re.search(r'[<>:"|?*\x00-\x1f]', part)
+                or part.endswith((".", " "))
+                or re.fullmatch(r"(?i:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])", part.split(".")[0])
+                for part in relative.parts
+            )
         ):
             raise RuntimeError(f"unsafe tracked path: {name!r}")
         if object_type != "blob" or mode not in {"100644", "100755"}:
             raise RuntimeError(f"tracked fixture source must be a regular file: {name!r}")
+        for depth in range(1, len(relative.parts) + 1):
+            prefix = "/".join(relative.parts[:depth])
+            is_file = depth == len(relative.parts)
+            prior = seen.get(prefix.casefold())
+            if prior is not None and (prior[0] != prefix or prior[1] or is_file):
+                raise RuntimeError(f"colliding tracked path: {name!r}")
+            seen[prefix.casefold()] = (prefix, is_file)
+        entries.append((relative, mode, object_id))
+
+    # Validate the entire tree before fetching blobs or materializing any files.
+    fixture.mkdir(parents=True)
+    fixture_root = fixture.resolve()
+    for relative, mode, object_id in entries:
+        target = fixture.joinpath(*relative.parts)
+        if not target.resolve().is_relative_to(fixture_root):
+            raise RuntimeError(f"tracked target escapes fixture: {relative}")
         blob = subprocess.run(
             ["git", "cat-file", "blob", object_id], cwd=repo,
             capture_output=True, check=False,
         )
         if blob.returncode != 0:
-            raise RuntimeError(f"could not read verified blob for {name!r}")
-        target = fixture.joinpath(*relative.parts)
+            raise RuntimeError(f"could not read verified blob for {str(relative)!r}")
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(blob.stdout)
+        with target.open("xb") as output:
+            output.write(blob.stdout)
         if os.name != "nt":
             target.chmod(0o755 if mode == "100755" else 0o644)
 
@@ -212,6 +235,13 @@ def tool_names(output: str) -> list[str]:
         if event.get("type") == "tool_use" and isinstance(event.get("part"), dict):
             names.append(str(event["part"].get("tool", "")))
     return names
+
+
+def verify_lifecycle_output(output: str, fixture: Path, name: str) -> None:
+    if not tool_loaded_exact_skill(output, fixture, name):
+        raise RuntimeError(f"live {name} produced no exact-skill tool event")
+    if set(tool_names(output)) - {"skill", "read"}:
+        raise RuntimeError(f"live {name} used tools beyond skill loading")
 
 
 def bash_commands(output: str) -> list[str]:
@@ -395,10 +425,7 @@ def main() -> int:
                 result = run_lifecycle_command(binary, fixture, args.model, name)
                 if result.returncode != 0:
                     raise RuntimeError(f"live {name} failed: {result.stderr.strip()}")
-                if not tool_loaded_exact_skill(result.stdout, fixture, name):
-                    raise RuntimeError(f"live {name} produced no exact-skill tool event")
-                if set(tool_names(result.stdout)) - {"skill", "read"}:
-                    raise RuntimeError(f"live {name} used tools beyond skill loading")
+                verify_lifecycle_output(result.stdout, fixture, name)
             denial = run(
                 binary, fixture, "run", "--pure", "--format", "json", "-m", args.model,
                 "Conformance control: first use read to load "

--- a/adapters/opencode/live_conformance.py
+++ b/adapters/opencode/live_conformance.py
@@ -297,7 +297,9 @@ def run_lifecycle_command(
 def verify_denial_output(output: str, fixture: Path) -> None:
     if not tool_loaded_exact_skill(output, fixture, "context-start"):
         raise RuntimeError("permission denial control produced no successful allowed read")
-    exposed = {"bash", "edit"} & set(tool_names(output))
+    # This control permits only reading the skill file as data. In particular,
+    # loading it through the skill tool is denied and cannot satisfy the control.
+    exposed = set(tool_names(output)) - {"read"}
     if exposed:
         raise RuntimeError(f"denied tools were exposed to model intent: {sorted(exposed)}")
 

--- a/tests/test_opencode_conformance.py
+++ b/tests/test_opencode_conformance.py
@@ -428,7 +428,12 @@ class OpenCodeAdapterTest(unittest.TestCase):
         for output in ("", "I cannot do that", allowed.replace('"completed"', '"error"')):
             with self.assertRaisesRegex(RuntimeError, "no successful allowed read"):
                 live.verify_denial_output(output, ROOT)
-        for tool in ("bash", "edit"):
+        skill = json.dumps({"type": "tool_use", "part": {
+            "tool": "skill", "state": {"status": "completed", "input": {"name": "context-start"}}
+        }})
+        with self.assertRaisesRegex(RuntimeError, "denied tools were exposed"):
+            live.verify_denial_output(skill, ROOT)
+        for tool in ("bash", "edit", "skill", "write", "unknown_tool"):
             denied = json.dumps({"type": "tool_use", "part": {"tool": tool}})
             with self.assertRaisesRegex(RuntimeError, "denied tools were exposed"):
                 live.verify_denial_output(allowed + "\n" + denied, ROOT)

--- a/tests/test_opencode_conformance.py
+++ b/tests/test_opencode_conformance.py
@@ -251,6 +251,84 @@ class OpenCodeAdapterTest(unittest.TestCase):
                     live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
                 self.assertEqual(1, mocked.call_count)
 
+    def test_fixture_rejects_collisions_before_materializing_any_files(self) -> None:
+        live = load_live_module()
+        for names in (
+            ("File.md", "file.md"), ("same", "same"),
+            ("Dir/a", "dir/b"), ("file", "file/child"),
+            ("file/child", "file"),
+        ):
+            with self.subTest(names=names), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                tree = b"".join(
+                    b"100644 blob " + b"0" * 40 + b"\t" + name.encode() + b"\0"
+                    for name in names
+                )
+                with patch.object(live.subprocess, "run", return_value=
+                                  subprocess.CompletedProcess([], 0, tree, b"")) as mocked:
+                    with self.assertRaisesRegex(RuntimeError, "colliding tracked path"):
+                        live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
+                    self.assertEqual(1, mocked.call_count)
+                    self.assertFalse((root / "fixture").exists())
+
+    def test_fixture_rejects_windows_aliases_and_nested_drive_syntax(self) -> None:
+        live = load_live_module()
+        for name in ("dir/C:escape", "file:stream", "file.", "dir /file", "NUL.txt", "com1", "LPT¹.log"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                tree = b"100644 blob " + b"0" * 40 + b"\t" + name.encode() + b"\0"
+                with patch.object(live.subprocess, "run", return_value=
+                                  subprocess.CompletedProcess([], 0, tree, b"")) as mocked:
+                    with self.assertRaisesRegex(RuntimeError, "unsafe tracked path"):
+                        live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
+                    self.assertEqual(1, mocked.call_count)
+
+    def test_fixture_allows_shared_directory_and_distinct_files(self) -> None:
+        live = load_live_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            tree = b"".join(b"100644 blob " + b"0" * 40 + b"\t" + name + b"\0"
+                            for name in (b"dir/a", b"dir/b", b"other/a"))
+            responses = [subprocess.CompletedProcess([], 0, tree, b"")] + [
+                subprocess.CompletedProcess([], 0, content, b"")
+                for content in (b"first", b"second", b"third")
+            ]
+            with patch.object(live.subprocess, "run", side_effect=responses):
+                live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
+            for name, content in (("dir/a", b"first"), ("dir/b", b"second"), ("other/a", b"third")):
+                self.assertEqual(content, (root / "fixture" / name).read_bytes())
+
+    def test_fixture_rejects_resolved_target_outside_root(self) -> None:
+        live = load_live_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            tree = b"100644 blob " + b"0" * 40 + b"\tdir/file\0"
+            with patch.object(live.subprocess, "run", return_value=
+                              subprocess.CompletedProcess([], 0, tree, b"")) as mocked, \
+                    patch.object(Path, "resolve", side_effect=[root / "fixture", root / "outside"]):
+                with self.assertRaisesRegex(RuntimeError, "escapes fixture"):
+                    live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
+                self.assertEqual(1, mocked.call_count)
+            self.assertFalse((root / "outside").exists())
+
+    def test_fixture_never_overwrites_existing_target(self) -> None:
+        live = load_live_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = root / "fixture"
+            tree = b"100644 blob " + b"0" * 40 + b"\tfile\0"
+
+            def git_result(args, **kwargs):
+                if args[1] == "ls-tree":
+                    return subprocess.CompletedProcess([], 0, tree, b"")
+                (fixture / "file").write_bytes(b"existing")
+                return subprocess.CompletedProcess([], 0, b"replacement", b"")
+
+            with patch.object(live.subprocess, "run", side_effect=git_result):
+                with self.assertRaises(FileExistsError):
+                    live.copy_tracked_fixture(root, fixture, "0" * 40)
+            self.assertEqual(b"existing", (fixture / "file").read_bytes())
+
     def test_exact_skill_read_resolves_relative_to_fixture(self) -> None:
         live = load_live_module()
         with tempfile.TemporaryDirectory() as temporary:
@@ -271,6 +349,15 @@ class OpenCodeAdapterTest(unittest.TestCase):
                 }
             )
             self.assertTrue(live.tool_loaded_exact_skill(event, root, skill_name))
+            for wrong_path in (
+                ".agents/skills/context-end/SKILL.md",
+                "other/.agents/skills/context-start/SKILL.md",
+                ".agents/skills/context-start/SKILL.md.bak",
+                str(root.parent / ".agents/skills/context-start/SKILL.md"),
+            ):
+                wrong_event = json.loads(event)
+                wrong_event["part"]["state"]["input"]["filePath"] = wrong_path
+                self.assertFalse(live.tool_loaded_exact_skill(json.dumps(wrong_event), root, skill_name))
             for status in ("pending", "running", "error"):
                 self.assertFalse(live.tool_loaded_exact_skill(
                     event.replace('"completed"', json.dumps(status)), root, skill_name
@@ -287,6 +374,28 @@ class OpenCodeAdapterTest(unittest.TestCase):
             self.assertEqual(status == "completed", live.tool_loaded_exact_skill(
                 event, ROOT, "context-start"
             ))
+
+    def test_lifecycle_allows_exact_skill_and_read_but_rejects_other_tools(self) -> None:
+        live = load_live_module()
+        for item in LIFECYCLE:
+            name = f"context-{item}"
+            skill = json.dumps({"type": "tool_use", "part": {
+                "tool": "skill", "state": {"status": "completed", "input": {"name": name}}
+            }})
+            read = json.dumps({"type": "tool_use", "part": {
+                "tool": "read", "state": {"status": "completed", "input": {"filePath": "README.md"}}
+            }})
+            live.verify_lifecycle_output(skill + "\n" + read, ROOT, name)
+            with self.assertRaisesRegex(RuntimeError, "no exact-skill"):
+                live.verify_lifecycle_output(read, ROOT, name)
+            for tool in ("bash", "edit", "write", "unknown_tool"):
+                for status in ("pending", "error", "completed"):
+                    with self.subTest(name=name, tool=tool, status=status):
+                        forbidden = json.dumps({"type": "tool_use", "part": {
+                            "tool": tool, "state": {"status": status, "input": {}}
+                        }})
+                        with self.assertRaisesRegex(RuntimeError, "beyond skill loading"):
+                            live.verify_lifecycle_output(skill + "\n" + forbidden, ROOT, name)
 
     def test_lifecycle_run_dispatches_registered_command(self) -> None:
         live = load_live_module()


### PR DESCRIPTION
OpenCode fixture copies now reject case-colliding paths, file/directory conflicts, Windows filename aliases, and targets that resolve outside the fixture. The full Git tree is checked before copying files, and exclusive creation prevents overwrites.

All four lifecycle commands have direct regression coverage for wrong skill reads and unexpected tools. The permission-denial control now requires an exact completed read and rejects every non-read tool event, including a skill-only bypass found during review. The existing portable digest fix is retained: OpenCode-generated dependencies are excluded, while context-state writes remain detectable.

Closes #179.
Closes #180.
Closes #181.

Validation at 7f1400fef2dd2e1b79e8c429c6cf1c2416918b8f:
- Focused suite: 26 tests, one Windows/POSIX skip.
- Full local validation passed: 709 tests, 48 platform/environment skips. Six deliberate guard regressions were detected by their tests.
- All hosted CI passed: Linux and Python 3.10 each ran 709 tests with 27 skips; Windows ran 709 with 19 skips. Full-bundle materialization bounds passed. Evidence: https://github.com/conorbronsdon/agent-context-os/actions/runs/33950967619
- Installed-client conformance passed for OpenCode 1.18.28 with opencode/muse-spark-1.3-contributor-free at the exact final SHA, including positive control, all four lifecycle runs, denial control, and unchanged fixture digest.

Independent reviews:
- Authenticated claude-sonnet-5; opencode/muse-spark-1.3-contributor-free; opencode/nemotron-3-ultra-free.
- Each reviewed cf0f0a0a8ba7526c8dab816220b218d1bea9dd3c and re-reviewed the affected files at final SHA 7f1400fef2dd2e1b79e8c429c6cf1c2416918b8f; all confirmed complete packets. One repair cycle used.
- Verified and fixed Claude's skill-only denial bypass and Muse's broader non-read-tool gap in commit 7f1400f.
- Rejected Nemotron's proposed .context-os digest exclusion: it would hide forbidden writes. Initial Claude packet mojibake was a review-input decoding issue; the source contains the intended Unicode code points, confirmed in the UTF-8 re-review.
- No unresolved verified merge blockers. Unicode portability and denial-control scope clarification are tracked in #187 and #188.
- Live attempts under an ancestor deny-all configuration failed the positive control; reproduced on unmodified main and tracked in #189. The final live run passed using a clean temporary root. This setup failure does not count as conformance evidence.
