### PR TITLE
Finish remaining OpenCode conformance follow-ups

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
 
 jobs:
+  opencode-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Check OpenCode fixture portability on macOS
+        run: python -m unittest discover -s tests -p "test_opencode_conformance.py" -v
+
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -89,6 +89,25 @@ Add `--model <provider/model>` plus all acknowledgement flags printed by
 a logged or training-enabled route for private repository material. The live
 run rejects dirty checkouts and is release evidence for the exact reviewed
 commit, not a required CI step.
+
+Fixture paths are checked using NFC Unicode normalization and case folding
+before any files are copied. Equivalent Unicode spellings, case collisions,
+and file/directory conflicts are rejected; distinct Unicode names retain their
+original spelling and bytes. Focused fixture tests run on macOS, Linux, and Windows.
+
+The denial control requires a completed read of the exact skill file. Additional
+reads are allowed, but every non-read tool event is rejected by the verifier.
+The runtime permission override denies bash and edit; the verifier also rejects
+skill loading. This checks tool behavior, not a filesystem read sandbox.
+
+OpenCode searches parent directories for [project configuration](https://opencode.ai/docs/config/).
+Before copying the fixture or asking it to load skills, the harness rejects any
+ancestor `opencode.json`, `opencode.jsonc`, or `.opencode` entry. This is a
+conservative setup check, not an attempt to reproduce the client's Git-boundary
+search rules. On rejection, select a clean temporary location using `TMPDIR`
+on POSIX or `TEMP`/`TMP` on Windows and rerun. The fixture's own configuration
+remains enabled; unrelated sibling directories do not affect this check.
+
 See the [first-class promotion note](../../docs/releases/opencode-first-class.md)
 for the shipped claim boundary.
 

--- a/adapters/opencode/live_conformance.py
+++ b/adapters/opencode/live_conformance.py
@@ -11,6 +11,7 @@ import re
 import stat
 import subprocess
 import tempfile
+import unicodedata
 from pathlib import Path, PurePosixPath
 
 
@@ -39,6 +40,20 @@ OPENCODE_GENERATED_PATHS = {
     ".opencode/package-lock.json",
 }
 OPENCODE_GENERATED_PREFIXES = (".opencode/node_modules",)
+
+
+def verify_no_ancestor_config(root: Path) -> None:
+    """Reject ambiguous setup; keep the fixture's own project config enabled."""
+    for parent in root.resolve().parents:
+        for name in ("opencode.json", "opencode.jsonc", ".opencode"):
+            candidate = parent / name
+            if candidate.exists() or candidate.is_symlink():
+                raise RuntimeError(
+                    f"ancestor OpenCode configuration detected: {candidate}. "
+                    "Choose a clean temporary location with TMPDIR (POSIX) or "
+                    "TEMP/TMP (Windows), outside directories containing OpenCode "
+                    "configuration. The harness does not disable project configuration."
+                )
 
 
 def run(
@@ -170,10 +185,11 @@ def copy_tracked_fixture(repo: Path, fixture: Path, commit: str) -> None:
         for depth in range(1, len(relative.parts) + 1):
             prefix = "/".join(relative.parts[:depth])
             is_file = depth == len(relative.parts)
-            prior = seen.get(prefix.casefold())
+            key = unicodedata.normalize("NFC", unicodedata.normalize("NFC", prefix).casefold())
+            prior = seen.get(key)
             if prior is not None and (prior[0] != prefix or prior[1] or is_file):
                 raise RuntimeError(f"colliding tracked path: {name!r}")
-            seen[prefix.casefold()] = (prefix, is_file)
+            seen[key] = (prefix, is_file)
         entries.append((relative, mode, object_id))
 
     # Validate the entire tree before fetching blobs or materializing any files.
@@ -297,8 +313,9 @@ def run_lifecycle_command(
 def verify_denial_output(output: str, fixture: Path) -> None:
     if not tool_loaded_exact_skill(output, fixture, "context-start"):
         raise RuntimeError("permission denial control produced no successful allowed read")
-    # This control permits only reading the skill file as data. In particular,
-    # loading it through the skill tool is denied and cannot satisfy the control.
+    # The runtime policy denies bash/edit. This verifier additionally rejects
+    # every non-read tool, including skill loading. Extra reads are permitted:
+    # this proves the required read plus absence of other tools, not a read sandbox.
     exposed = set(tool_names(output)) - {"read"}
     if exposed:
         raise RuntimeError(f"denied tools were exposed to model intent: {sorted(exposed)}")
@@ -343,6 +360,7 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="contextos-opencode-") as temporary:
         fixture = Path(temporary) / "public-fixture"
+        verify_no_ancestor_config(fixture)
         copy_tracked_fixture(repo, fixture, verified_commit)
         skills = parse_json_document(run(binary, fixture, "debug", "skill"), "debug skill")
         by_name: dict[str, dict[str, object]] = {}

--- a/tests/test_opencode_conformance.py
+++ b/tests/test_opencode_conformance.py
@@ -257,6 +257,9 @@ class OpenCodeAdapterTest(unittest.TestCase):
             ("File.md", "file.md"), ("same", "same"),
             ("Dir/a", "dir/b"), ("file", "file/child"),
             ("file/child", "file"),
+            ("caf\u00e9", "cafe\u0301"),
+            ("CAF\u00c9/a", "cafe\u0301/b"),
+            ("caf\u00e9/child", "cafe\u0301"),
         ):
             with self.subTest(names=names), tempfile.TemporaryDirectory() as temporary:
                 root = Path(temporary)
@@ -282,6 +285,49 @@ class OpenCodeAdapterTest(unittest.TestCase):
                     with self.assertRaisesRegex(RuntimeError, "unsafe tracked path"):
                         live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
                     self.assertEqual(1, mocked.call_count)
+
+    def test_fixture_preserves_distinct_unicode_names_and_bytes(self) -> None:
+        live = load_live_module()
+        names = ("caf\u00e9/a", "caf\u00e9/b", "\u6771\u4eac.txt", "cafe.txt")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            tree = b"".join(b"100644 blob " + b"0" * 40 + b"\t" + name.encode("utf-8") + b"\0"
+                            for name in names)
+            responses = [subprocess.CompletedProcess([], 0, tree, b"")] + [
+                subprocess.CompletedProcess([], 0, name.encode("utf-8"), b"") for name in names
+            ]
+            with patch.object(live.subprocess, "run", side_effect=responses):
+                live.copy_tracked_fixture(root, root / "fixture", "0" * 40)
+            for name in names:
+                self.assertEqual(name.encode("utf-8"), (root / "fixture" / name).read_bytes())
+
+    def test_ancestor_config_guard_rejects_each_source_without_reading_it(self) -> None:
+        live = load_live_module()
+        for name in ("opencode.json", "opencode.jsonc", ".opencode"):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                config = root / name
+                if name == ".opencode":
+                    config.mkdir()
+                else:
+                    config.write_text("not parsed: reject the location", encoding="utf-8")
+                with self.assertRaisesRegex(RuntimeError, "ancestor OpenCode configuration.*clean temporary"):
+                    live.verify_no_ancestor_config(root / "nested" / "fixture")
+
+    def test_ancestor_config_guard_allows_fixture_config_and_unrelated_sibling(self) -> None:
+        live = load_live_module()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = root / "fixture"
+            fixture.mkdir()
+            (fixture / ".opencode").mkdir()
+            config = fixture / "opencode.json"
+            config.write_text('{"permission":{"bash":"allow"}}', encoding="utf-8")
+            sibling = root / "unrelated"
+            sibling.mkdir()
+            (sibling / "opencode.jsonc").write_text("{}", encoding="utf-8")
+            live.verify_no_ancestor_config(fixture)
+            self.assertEqual('{"permission":{"bash":"allow"}}', config.read_text(encoding="utf-8"))
 
     def test_fixture_allows_shared_directory_and_distinct_files(self) -> None:
         live = load_live_module()
@@ -425,6 +471,10 @@ class OpenCodeAdapterTest(unittest.TestCase):
             }}
         }})
         live.verify_denial_output(allowed, ROOT)
+        extra_read = allowed.replace(".agents/skills/context-start/SKILL.md", "README.md")
+        live.verify_denial_output(allowed + "\n" + extra_read, ROOT)
+        with self.assertRaisesRegex(RuntimeError, "no successful allowed read"):
+            live.verify_denial_output(extra_read, ROOT)
         for output in ("", "I cannot do that", allowed.replace('"completed"', '"error"')):
             with self.assertRaisesRegex(RuntimeError, "no successful allowed read"):
                 live.verify_denial_output(output, ROOT)


### PR DESCRIPTION
Finish the three remaining OpenCode follow-ups:

- Reject Unicode-normalization collisions before fixture writes; preserve distinct Unicode names and bytes. Add focused macOS CI alongside existing Linux/Windows coverage.
- Specify and test the denial control: an exact completed skill-file read is required, additional reads are allowed, and every non-read tool event is rejected. Clarify runtime permissions versus verifier assertions.
- Detect ancestor OpenCode configuration before fixture copying or discovery, with an actionable temporary-directory error. Preserve the fixture's own configuration.

Closes #187.
Closes #188.
Closes #189.

Review evidence at ecce3f15fb7499c3484e07268423fdd061c0f742:
- Authenticated claude-sonnet-5, opencode/muse-spark-1.3-contributor-free, and opencode/nemotron-3-ultra-free completed independent reviews. Each confirmed all input packet end markers. No verified defects; zero repair cycles.
- Nemotron's mixed-case configuration concern was rejected: Path.exists follows filesystem case lookup, confirmed with a mixed-case file on Windows. Its superscript-device-name concern contradicts Microsoft's documented reserved names: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
- Unicode normalization before and after case folding is retained as a conservative canonical comparison policy.

Validation:
- Focused local suite: 29 tests, one POSIX-only skip on Windows.
- Three deliberate guard/contract regressions were detected by the tests.
- Installed OpenCode 1.18.28 rejects a contaminated temporary root with the specific ancestor-configuration diagnostic.
- All four hosted CI jobs passed: macOS ran all 29 focused tests; Windows ran 712 tests with 19 skips; Linux and Python 3.10 each ran 712 tests with 27 skips. Aggregate validation and materialization bounds passed. Evidence: https://github.com/conorbronsdon/agent-context-os/actions/runs/33951624677
- The clean installed-client run passed all discovery, lifecycle, permission, and digest controls on OpenCode 1.18.28 with opencode/muse-spark-1.3-contributor-free at the exact reviewed SHA.

No additional issues were created from this work.
