### PR TITLE
Connect the first reviewed handoff to the COT context resource

### DIFF
--- a/docs/first-handoff.md
+++ b/docs/first-handoff.md
@@ -75,6 +75,11 @@ and whether you could explain what was saved. If the answer is wrong, inspect
 the source and proposal first: was the fact saved, replaced, omitted, or simply
 not used? Run `bash scripts/contextos.sh doctor` for setup problems.
 
+To test what happens when a decision changes, see
+[how to spot stale context and test your next session](https://chainofthought.show/context-engineering/?utm_source=github&utm_medium=referral&utm_campaign=repo-first-handoff&utm_content=agent-context-os)
+on Chain of Thought. The resource includes a separate, downloadable exercise
+with repaired and conflicting handoffs, plus the conversations behind the practice.
+
 For controlled comparisons with a plain handoff note, use the
 [continuity benchmark](continuity-benchmark.md). For your own project, continue
 with [getting started](getting-started.md); select additional agents and imports


### PR DESCRIPTION
After completing the first reviewed handoff, readers now get one optional link to Chain of Thought's practical context-maintenance resource. It points to a separate repaired/conflicting-handoff exercise and supporting conversations, without interrupting installation or the CSV example.

Tracking contract: source `github`, medium `referral`, campaign `repo-first-handoff`, content `agent-context-os`. The distinct campaign identifies this guide placement separately from the Website field (`repo-website`) and README credit (`repo-readme`). Filter those campaigns separately; do not combine them into one placement metric.

Review SHA: `b22c6583693c52b2542d3e7a7bf83c71dd15ad08`.
- Authenticated `claude-sonnet-5` completed. Its two conditional checks were resolved: the live resource and ZIP contain the described separate exercise; the campaign is intentionally distinct and documented here. GA4 receives campaign values from URL parameters without campaign pre-registration (https://support.google.com/analytics/answer/10917952).
- `opencode/muse-spark-1.3-contributor-free`: PASS, no actionable issues.
- No code changes after review and no repair cycles.

Validation: aggregate validator reached `All validation passed`; 712 Python tests completed with 48 platform skips, plus portability/hook, catalog, manifest, schema, and JSON checks. Windows PowerShell reported Git CRLF warnings as native stderr records; the validator itself completed all stages. Exact live link returns 200 with all four expected UTM values and the described content. No runtime or starter-branch changes. This change does not claim GA4 ingestion is verified.

Coordination: conorbronsdon/personal-context#323. Resource: conorbronsdon/cot-site#294.
