### PR TITLE
Fix setup on Windows-backed WSL mounts

### DIFF
--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -933,7 +933,17 @@ def _post_write_mode_matches(
     actual_mode = path.stat().st_mode & 0o7777
     if actual_mode == expected_mode:
         return True
-    if expected_mode != 0o644 or not _same_file(path, publication_anchor):
+    permission_bits = actual_mode & 0o777
+    uniform_projection = (
+        actual_mode & 0o7000 == 0
+        and permission_bits >> 6 == permission_bits >> 3 & 0o7
+        and permission_bits >> 6 == permission_bits & 0o7
+    )
+    if (
+        expected_mode != 0o644
+        or not uniform_projection
+        or not _same_file(path, publication_anchor)
+    ):
         return False
     projected = _wsl_windows_mount_does_not_preserve_modes(path)
     return projected and _same_file(path, publication_anchor)

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -878,7 +878,7 @@ def _mount_projects_windows_modes(
         try:
             separator = fields.index("-")
             if separator < 6 or len(fields) < separator + 4:
-                return False
+                continue
             mount_point = PurePosixPath(_decode_mountinfo_path(fields[4]))
             target.relative_to(mount_point)
             filesystem = fields[separator + 1]
@@ -892,7 +892,7 @@ def _mount_projects_windows_modes(
             for option in re.split("[,;]", field)
         }
         candidate = (len(mount_point.parts), filesystem, source, options)
-        if best_mount is None or candidate[0] > best_mount[0]:
+        if best_mount is None or candidate[0] >= best_mount[0]:
             best_mount = candidate
     if best_mount is None:
         return False

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -908,7 +908,8 @@ def _mount_projects_windows_modes(
         and source[1:3] == ":\\"
     )
     windows_backed = source.lower().startswith("drvfs") or windows_drive_source
-    return filesystem in {"9p", "drvfs"} and windows_backed and "metadata" not in options
+    metadata_enabled = any(option.split("=", 1)[0] == "metadata" for option in options)
+    return filesystem in {"9p", "drvfs"} and windows_backed and not metadata_enabled
 
 
 def _wsl_windows_mount_does_not_preserve_modes(path: Path) -> bool:

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -877,15 +877,18 @@ def _mount_projects_windows_modes(
         fields = line.split()
         try:
             separator = fields.index("-")
-            if separator < 6 or len(fields) < separator + 4:
-                return False
-            mount_point = PurePosixPath(_decode_mountinfo_path(fields[4]))
+        except ValueError:
+            return False
+        if separator < 6 or len(fields) < separator + 4:
+            return False
+        mount_point = PurePosixPath(_decode_mountinfo_path(fields[4]))
+        try:
             target.relative_to(mount_point)
-            filesystem = fields[separator + 1]
-            source = _decode_mountinfo_path(fields[separator + 2])
-            option_fields = fields[5:separator] + fields[separator + 3 :]
-        except (IndexError, ValueError):
+        except ValueError:
             continue
+        filesystem = fields[separator + 1]
+        source = _decode_mountinfo_path(fields[separator + 2])
+        option_fields = fields[5:separator] + fields[separator + 3 :]
         options = {
             option.lower()
             for field in option_fields

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -925,12 +925,18 @@ def _wsl_windows_mount_does_not_preserve_modes(path: Path) -> bool:
         return False
 
 
-def _post_write_mode_matches(path: Path, expected_mode: int) -> bool:
+def _post_write_mode_matches(
+    path: Path,
+    expected_mode: int,
+    publication_anchor: Path,
+) -> bool:
     actual_mode = path.stat().st_mode & 0o7777
-    return (
-        actual_mode == expected_mode
-        or _wsl_windows_mount_does_not_preserve_modes(path)
-    )
+    if actual_mode == expected_mode:
+        return True
+    if expected_mode != 0o644 or not _same_file(path, publication_anchor):
+        return False
+    projected = _wsl_windows_mount_does_not_preserve_modes(path)
+    return projected and _same_file(path, publication_anchor)
 
 
 def _workspace_component_ids(root: Path) -> list[str] | None:
@@ -4301,7 +4307,9 @@ def apply_proposal(
                     expected_mode = change["after_mode"]
                     if (
                         change["action"] == "write"
-                        and not _post_write_mode_matches(path, expected_mode)
+                        and not _post_write_mode_matches(
+                            path, expected_mode, publication_anchors[path]
+                        )
                     ):
                         raise ContextOSError(
                             f"agent-config post-write mode is invalid: {change['path']}"
@@ -4331,7 +4339,9 @@ def apply_proposal(
                         if backup_modes[path] is not None
                         else NEW_CONTENT_MODE
                     )
-                    if not _post_write_mode_matches(path, expected_mode):
+                    if not _post_write_mode_matches(
+                        path, expected_mode, publication_anchors[path]
+                    ):
                         raise ContextOSError(
                             f"content post-write mode is invalid: {change['path']}"
                         )

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -851,6 +851,82 @@ def _selection_components(root: Path, agents: Sequence[str]) -> list[str]:
         ) from exc
 
 
+def _decode_mountinfo_path(value: str) -> str:
+    """Decode the octal escapes used for path fields in proc mountinfo."""
+    escapes = (
+        ("\\040", " "),
+        ("\\011", "\t"),
+        ("\\012", "\n"),
+        ("\\134", "\\"),
+    )
+    for escaped, decoded in escapes:
+        value = value.replace(escaped, decoded)
+    return value
+
+
+def _mount_projects_windows_modes(
+    target: PurePosixPath,
+    release: str,
+    mountinfo: str,
+) -> bool:
+    """Classify only WSL Windows mounts that lack POSIX metadata support."""
+    if "microsoft" not in release.lower():
+        return False
+    best_mount: tuple[int, str, str, set[str]] | None = None
+    for line in mountinfo.splitlines():
+        fields = line.split()
+        try:
+            separator = fields.index("-")
+            if separator < 6 or len(fields) < separator + 4:
+                return False
+            mount_point = PurePosixPath(_decode_mountinfo_path(fields[4]))
+            target.relative_to(mount_point)
+            filesystem = fields[separator + 1]
+            source = _decode_mountinfo_path(fields[separator + 2])
+            option_fields = fields[5:separator] + fields[separator + 3 :]
+        except (IndexError, ValueError):
+            continue
+        options = {
+            option.lower()
+            for field in option_fields
+            for option in re.split("[,;]", field)
+        }
+        candidate = (len(mount_point.parts), filesystem, source, options)
+        if best_mount is None or candidate[0] > best_mount[0]:
+            best_mount = candidate
+    if best_mount is None:
+        return False
+    _depth, filesystem, source, options = best_mount
+    windows_drive_source = (
+        len(source) >= 3
+        and source[0].isalpha()
+        and source[1:3] == ":\\"
+    )
+    windows_backed = source.lower().startswith("drvfs") or windows_drive_source
+    return filesystem in {"9p", "drvfs"} and windows_backed and "metadata" not in options
+
+
+def _wsl_windows_mount_does_not_preserve_modes(path: Path) -> bool:
+    """Detect a Windows-backed WSL mount that projects rather than stores modes."""
+    if os.name != "posix":
+        return False
+    try:
+        release = Path("/proc/sys/kernel/osrelease").read_text(encoding="utf-8")
+        mountinfo = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
+        target = PurePosixPath(path.resolve(strict=False).as_posix())
+        return _mount_projects_windows_modes(target, release, mountinfo)
+    except (OSError, UnicodeError, ValueError):
+        return False
+
+
+def _post_write_mode_matches(path: Path, expected_mode: int) -> bool:
+    actual_mode = path.stat().st_mode & 0o7777
+    return (
+        actual_mode == expected_mode
+        or _wsl_windows_mount_does_not_preserve_modes(path)
+    )
+
+
 def _workspace_component_ids(root: Path) -> list[str] | None:
     component_path = safe_repo_path(root, "components/manifest.json")
     if not component_path.exists():
@@ -4219,7 +4295,7 @@ def apply_proposal(
                     expected_mode = change["after_mode"]
                     if (
                         change["action"] == "write"
-                        and path.stat().st_mode & 0o7777 != expected_mode
+                        and not _post_write_mode_matches(path, expected_mode)
                     ):
                         raise ContextOSError(
                             f"agent-config post-write mode is invalid: {change['path']}"
@@ -4249,7 +4325,7 @@ def apply_proposal(
                         if backup_modes[path] is not None
                         else NEW_CONTENT_MODE
                     )
-                    if path.stat().st_mode & 0o7777 != expected_mode:
+                    if not _post_write_mode_matches(path, expected_mode):
                         raise ContextOSError(
                             f"content post-write mode is invalid: {change['path']}"
                         )

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -878,7 +878,7 @@ def _mount_projects_windows_modes(
         try:
             separator = fields.index("-")
             if separator < 6 or len(fields) < separator + 4:
-                continue
+                return False
             mount_point = PurePosixPath(_decode_mountinfo_path(fields[4]))
             target.relative_to(mount_point)
             filesystem = fields[separator + 1]
@@ -892,8 +892,10 @@ def _mount_projects_windows_modes(
             for option in re.split("[,;]", field)
         }
         candidate = (len(mount_point.parts), filesystem, source, options)
-        if best_mount is None or candidate[0] >= best_mount[0]:
+        if best_mount is None or candidate[0] > best_mount[0]:
             best_mount = candidate
+        elif candidate[0] == best_mount[0] and candidate[1:] != best_mount[1:]:
+            return False
     if best_mount is None:
         return False
     _depth, filesystem, source, options = best_mount

--- a/contextos/kernel.py
+++ b/contextos/kernel.py
@@ -868,11 +868,12 @@ def _mount_projects_windows_modes(
     target: PurePosixPath,
     release: str,
     mountinfo: str,
+    expected_device: str | None = None,
 ) -> bool:
     """Classify only WSL Windows mounts that lack POSIX metadata support."""
     if "microsoft" not in release.lower():
         return False
-    best_mount: tuple[int, str, str, set[str]] | None = None
+    best_mount: tuple[int, str, str, set[str], str] | None = None
     for line in mountinfo.splitlines():
         fields = line.split()
         try:
@@ -894,14 +895,14 @@ def _mount_projects_windows_modes(
             for field in option_fields
             for option in re.split("[,;]", field)
         }
-        candidate = (len(mount_point.parts), filesystem, source, options)
+        candidate = (len(mount_point.parts), filesystem, source, options, fields[2])
         if best_mount is None or candidate[0] > best_mount[0]:
             best_mount = candidate
         elif candidate[0] == best_mount[0] and candidate[1:] != best_mount[1:]:
             return False
     if best_mount is None:
         return False
-    _depth, filesystem, source, options = best_mount
+    _depth, filesystem, source, options, device = best_mount
     windows_drive_source = (
         len(source) >= 3
         and source[0].isalpha()
@@ -909,10 +910,18 @@ def _mount_projects_windows_modes(
     )
     windows_backed = source.lower().startswith("drvfs") or windows_drive_source
     metadata_enabled = any(option.split("=", 1)[0] == "metadata" for option in options)
-    return filesystem in {"9p", "drvfs"} and windows_backed and not metadata_enabled
+    return (
+        filesystem in {"9p", "drvfs"}
+        and windows_backed
+        and not metadata_enabled
+        and (expected_device is None or device == expected_device)
+    )
 
 
-def _wsl_windows_mount_does_not_preserve_modes(path: Path) -> bool:
+def _wsl_windows_mount_does_not_preserve_modes(
+    path: Path,
+    expected_st_dev: int,
+) -> bool:
     """Detect a Windows-backed WSL mount that projects rather than stores modes."""
     if os.name != "posix":
         return False
@@ -920,7 +929,10 @@ def _wsl_windows_mount_does_not_preserve_modes(path: Path) -> bool:
         release = Path("/proc/sys/kernel/osrelease").read_text(encoding="utf-8")
         mountinfo = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
         target = PurePosixPath(path.resolve(strict=False).as_posix())
-        return _mount_projects_windows_modes(target, release, mountinfo)
+        expected_device = f"{os.major(expected_st_dev)}:{os.minor(expected_st_dev)}"
+        return _mount_projects_windows_modes(
+            target, release, mountinfo, expected_device=expected_device
+        )
     except (OSError, UnicodeError, ValueError):
         return False
 
@@ -930,7 +942,8 @@ def _post_write_mode_matches(
     expected_mode: int,
     publication_anchor: Path,
 ) -> bool:
-    actual_mode = path.stat().st_mode & 0o7777
+    observed_stat = path.stat()
+    actual_mode = observed_stat.st_mode & 0o7777
     if actual_mode == expected_mode:
         return True
     permission_bits = actual_mode & 0o777
@@ -942,10 +955,13 @@ def _post_write_mode_matches(
     if (
         expected_mode != 0o644
         or not uniform_projection
+        or not os.path.samestat(observed_stat, publication_anchor.stat())
         or not _same_file(path, publication_anchor)
     ):
         return False
-    projected = _wsl_windows_mount_does_not_preserve_modes(path)
+    projected = _wsl_windows_mount_does_not_preserve_modes(
+        path, observed_stat.st_dev
+    )
     return projected and _same_file(path, publication_anchor)
 
 

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -125,18 +125,33 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         ):
             self.assertFalse(_post_write_mode_matches(target, mismatched_mode))
 
+    def test_agent_config_apply_rolls_back_when_mode_guard_rejects(self) -> None:
+        path, proposal = self.propose()
+        with mock.patch(
+            "contextos.kernel._post_write_mode_matches",
+            return_value=False,
+        ), self.assertRaisesRegex(ContextOSError, "post-write mode is invalid"):
+            self.apply(path, proposal)
+        self.assertTrue((self.root / "workspace.yaml").exists())
+        self.assertFalse((self.root / "contextos.workspace.json").exists())
+        self.assert_no_transaction_artifacts()
+
     def test_wsl_metadata_mount_remains_strict(self) -> None:
-        mountinfo = (
+        metadata_mountinfo = (
             "132 82 0:70 / /mnt/c rw,noatime - 9p C:\\134 "
             "rw,aname=drvfs;path=C:\\;metadata\n"
         )
-        self.assertFalse(
-            _mount_projects_windows_modes(
-                PurePosixPath("/mnt/c/work/file"),
-                "microsoft-standard-WSL2",
-                mountinfo,
+        for mountinfo in (
+            metadata_mountinfo,
+            metadata_mountinfo.replace(";metadata", ";metadata=1"),
+        ):
+            self.assertFalse(
+                _mount_projects_windows_modes(
+                    PurePosixPath("/mnt/c/work/file"),
+                    "microsoft-standard-WSL2",
+                    mountinfo,
+                )
             )
-        )
 
     def test_wsl_projected_mount_parser_is_narrow_and_defensive(self) -> None:
         projected = (

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -14,7 +14,7 @@ import unittest
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import redirect_stdout
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest import mock
 
 from contextos.cli import main as cli_main
@@ -25,7 +25,9 @@ from contextos.kernel import (
     _create_agent_journal,
     _discard_agent_journal,
     _fsync_directory,
+    _mount_projects_windows_modes,
     _prepare_publication_anchor,
+    _post_write_mode_matches,
     _publish_exclusive,
     _recover_pending_agent_journals,
     _rmtree_readonly_artifacts,
@@ -102,6 +104,85 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             if path.exists():
                 self.assertEqual([], list(path.iterdir()), folder)
         self.assertFalse((self.root / ".context-os/apply.lock").exists())
+
+    def test_wsl_windows_mount_accepts_projected_post_write_mode(self) -> None:
+        target = self.root / "projected.txt"
+        target.write_text("fixture\n", encoding="utf-8")
+        with mock.patch(
+            "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
+            return_value=True,
+        ):
+            self.assertTrue(_post_write_mode_matches(target, 0o600))
+
+    def test_posix_mode_mismatch_still_fails(self) -> None:
+        target = self.root / "strict.txt"
+        target.write_text("fixture\n", encoding="utf-8")
+        actual_mode = target.stat().st_mode & 0o7777
+        mismatched_mode = actual_mode ^ 0o100
+        with mock.patch(
+            "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
+            return_value=False,
+        ):
+            self.assertFalse(_post_write_mode_matches(target, mismatched_mode))
+
+    def test_wsl_metadata_mount_remains_strict(self) -> None:
+        mountinfo = (
+            "132 82 0:70 / /mnt/c rw,noatime - 9p C:\\134 "
+            "rw,aname=drvfs;path=C:\\;metadata\n"
+        )
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                mountinfo,
+            )
+        )
+
+    def test_wsl_projected_mount_parser_is_narrow_and_defensive(self) -> None:
+        projected = (
+            "132 82 0:70 / /mnt/c rw,noatime - 9p C:\\134 "
+            "rw,aname=drvfs;path=C:\\\n"
+        )
+        self.assertTrue(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                projected,
+            )
+        )
+        non_windows = projected.replace("C:\\134", "server-share")
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                non_windows,
+            )
+        )
+        nested_posix = projected + (
+            "133 132 0:71 / /mnt/c/work rw - ext4 /dev/sda rw\n"
+        )
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                nested_posix,
+            )
+        )
+        escaped_space = projected.replace("/mnt/c", "/mnt/my\\040drive")
+        self.assertTrue(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/my drive/work/file"),
+                "microsoft-standard-WSL2",
+                escaped_space,
+            )
+        )
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                "malformed - 9p\n",
+            )
+        )
 
     def test_legacy_migration_is_atomic_write_delete_with_evidence(self) -> None:
         legacy = self.root / "workspace.yaml"

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -176,6 +176,18 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
                 malformed_before_projected,
             )
         )
+        no_separator = "malformed mount record\n"
+        for malformed_mountinfo in (
+            no_separator + projected,
+            projected + no_separator,
+        ):
+            self.assertFalse(
+                _mount_projects_windows_modes(
+                    PurePosixPath("/mnt/c/work/file"),
+                    "microsoft-standard-WSL2",
+                    malformed_mountinfo,
+                )
+            )
         stacked_metadata = projected + (
             "133 132 0:70 / /mnt/c rw - 9p C:\\134 "
             "rw,aname=drvfs;path=C:\\;metadata\n"

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -169,7 +169,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             )
         )
         malformed_before_projected = "malformed - 9p\n" + projected
-        self.assertTrue(
+        self.assertFalse(
             _mount_projects_windows_modes(
                 PurePosixPath("/mnt/c/work/file"),
                 "microsoft-standard-WSL2",
@@ -185,6 +185,14 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
                 PurePosixPath("/mnt/c/work/file"),
                 "microsoft-standard-WSL2",
                 stacked_metadata,
+            )
+        )
+        reverse_stacked_metadata = stacked_metadata.splitlines(keepends=True)
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                "".join(reversed(reverse_stacked_metadata)),
             )
         )
         escaped_space = projected.replace("/mnt/c", "/mnt/my\\040drive")

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -108,22 +108,51 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
     def test_wsl_windows_mount_accepts_projected_post_write_mode(self) -> None:
         target = self.root / "projected.txt"
         target.write_text("fixture\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+        anchor = self.root / "projected.anchor"
+        os.link(target, anchor)
         with mock.patch(
             "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
             return_value=True,
         ):
-            self.assertTrue(_post_write_mode_matches(target, 0o600))
+            self.assertTrue(_post_write_mode_matches(target, 0o644, anchor))
+            self.assertFalse(_post_write_mode_matches(target, 0o600, anchor))
 
     def test_posix_mode_mismatch_still_fails(self) -> None:
         target = self.root / "strict.txt"
         target.write_text("fixture\n", encoding="utf-8")
+        anchor = self.root / "strict.anchor"
+        os.link(target, anchor)
         actual_mode = target.stat().st_mode & 0o7777
         mismatched_mode = actual_mode ^ 0o100
         with mock.patch(
             "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
             return_value=False,
         ):
-            self.assertFalse(_post_write_mode_matches(target, mismatched_mode))
+            self.assertFalse(
+                _post_write_mode_matches(target, mismatched_mode, anchor)
+            )
+
+    def test_projected_mode_fallback_rejects_target_identity_swap(self) -> None:
+        target = self.root / "target.txt"
+        target.write_text("same bytes\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+        anchor = self.root / "target.anchor"
+        os.link(target, anchor)
+        unrelated = self.root / "unrelated.txt"
+        unrelated.write_text("same bytes\n", encoding="utf-8")
+        os.chmod(unrelated, 0o666)
+
+        def swap_target(_path: Path) -> bool:
+            target.unlink()
+            os.link(unrelated, target)
+            return True
+
+        with mock.patch(
+            "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
+            side_effect=swap_target,
+        ):
+            self.assertFalse(_post_write_mode_matches(target, 0o644, anchor))
 
     def test_agent_config_apply_rolls_back_when_mode_guard_rejects(self) -> None:
         path, proposal = self.propose()

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -118,6 +118,25 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             self.assertTrue(_post_write_mode_matches(target, 0o644, anchor))
             self.assertFalse(_post_write_mode_matches(target, 0o600, anchor))
 
+    def test_projected_mode_fallback_rejects_mixed_or_special_modes(self) -> None:
+        target = self.root / "projected.txt"
+        target.write_text("fixture\n", encoding="utf-8")
+        anchor = self.root / "projected.anchor"
+        os.link(target, anchor)
+        with mock.patch(
+            "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
+            return_value=True,
+        ):
+            for actual_mode in (0o755, 0o1755):
+                with self.subTest(mode=oct(actual_mode)), mock.patch.object(
+                    Path,
+                    "stat",
+                    return_value=mock.Mock(st_mode=stat.S_IFREG | actual_mode),
+                ):
+                    self.assertFalse(
+                        _post_write_mode_matches(target, 0o644, anchor)
+                    )
+
     def test_posix_mode_mismatch_still_fails(self) -> None:
         target = self.root / "strict.txt"
         target.write_text("fixture\n", encoding="utf-8")

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -127,7 +127,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
             "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
             return_value=True,
         ):
-            for actual_mode in (0o755, 0o1755):
+            for actual_mode in (0o755, 0o1755, 0o1777):
                 with self.subTest(mode=oct(actual_mode)), mock.patch.object(
                     Path,
                     "stat",
@@ -136,6 +136,38 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
                     self.assertFalse(
                         _post_write_mode_matches(target, 0o644, anchor)
                     )
+
+    def test_projected_mode_fallback_binds_observed_stat_to_anchor(self) -> None:
+        target = self.root / "target.txt"
+        target.write_text("same bytes\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+        anchor = self.root / "target.anchor"
+        os.link(target, anchor)
+        unrelated = self.root / "unrelated.txt"
+        unrelated.write_text("same bytes\n", encoding="utf-8")
+        os.chmod(unrelated, 0o666)
+        original_stat = Path.stat
+        captured = False
+
+        def capture_decoy_then_restore(candidate: Path, *args, **kwargs):
+            nonlocal captured
+            if candidate == target and not captured:
+                captured = True
+                target.unlink()
+                os.link(unrelated, target)
+                decoy_stat = original_stat(target, *args, **kwargs)
+                target.unlink()
+                os.link(anchor, target)
+                return decoy_stat
+            return original_stat(candidate, *args, **kwargs)
+
+        with mock.patch.object(
+            Path, "stat", autospec=True, side_effect=capture_decoy_then_restore
+        ), mock.patch(
+            "contextos.kernel._wsl_windows_mount_does_not_preserve_modes",
+            return_value=True,
+        ):
+            self.assertFalse(_post_write_mode_matches(target, 0o644, anchor))
 
     def test_posix_mode_mismatch_still_fails(self) -> None:
         target = self.root / "strict.txt"
@@ -162,7 +194,7 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
         unrelated.write_text("same bytes\n", encoding="utf-8")
         os.chmod(unrelated, 0o666)
 
-        def swap_target(_path: Path) -> bool:
+        def swap_target(_path: Path, _expected_st_dev: int) -> bool:
             target.unlink()
             os.link(unrelated, target)
             return True
@@ -211,6 +243,22 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
                 PurePosixPath("/mnt/c/work/file"),
                 "microsoft-standard-WSL2",
                 projected,
+            )
+        )
+        self.assertTrue(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                projected,
+                expected_device="0:70",
+            )
+        )
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                projected,
+                expected_device="0:71",
             )
         )
         non_windows = projected.replace("C:\\134", "server-share")

--- a/tests/test_agent_lifecycle_transactions.py
+++ b/tests/test_agent_lifecycle_transactions.py
@@ -168,6 +168,25 @@ class AgentLifecycleTransactionTest(unittest.TestCase):
                 nested_posix,
             )
         )
+        malformed_before_projected = "malformed - 9p\n" + projected
+        self.assertTrue(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                malformed_before_projected,
+            )
+        )
+        stacked_metadata = projected + (
+            "133 132 0:70 / /mnt/c rw - 9p C:\\134 "
+            "rw,aname=drvfs;path=C:\\;metadata\n"
+        )
+        self.assertFalse(
+            _mount_projects_windows_modes(
+                PurePosixPath("/mnt/c/work/file"),
+                "microsoft-standard-WSL2",
+                stacked_metadata,
+            )
+        )
         escaped_space = projected.replace("/mnt/c", "/mnt/my\\040drive")
         self.assertTrue(
             _mount_projects_windows_modes(


### PR DESCRIPTION
## Summary

- detect Windows-backed WSL drvfs/9p mounts without POSIX metadata
- limit compatibility to uniform projected permissions when the expected mode is `0644`
- bind fallback mode, inode, and mount-device evidence to the retained publication anchor
- preserve strict validation for private, special, or mixed modes; metadata mounts; malformed or ambiguous records; and target swaps

## Verification

- Native Windows focused module: 87 tests run, OK, 2 skipped
- WSL focused module: 87 tests run, OK, 7 Windows-only skipped
- Fresh documented setup at exact `c38d5cda103f628718535111e2c8706ebe3bf517` completed with receipt and unchanged Git HEAD
- Mutation control fails on old `4c12144` helper and passes on the final candidate
- Local Windows/WSL full validation's pre-existing skill-name portability failure is tracked separately in #193; hosted Linux validation passes
- Exact-SHA reviews: authenticated `claude-opus-5` and `opencode/muse-spark-1.3-contributor-free`; no verified remaining blocker
