### PR TITLE
Add Codex workspace companion and fix catalog validation

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "agent-context-os",
+  "version": "0.1.0",
+  "description": "Use Context OS workflows in an explicitly selected workspace.",
+  "author": {
+    "name": "Conor Bronsdon",
+    "url": "https://github.com/conorbronsdon"
+  },
+  "homepage": "https://github.com/conorbronsdon/agent-context-os",
+  "repository": "https://github.com/conorbronsdon/agent-context-os",
+  "license": "MIT",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Context OS Workspace Companion",
+    "shortDescription": "Use Context OS workflows in an explicitly selected workspace.",
+    "longDescription": "Routes to the selected workspace's canonical lifecycle skills. Installation does not create a workspace, import context, install hooks, or authorize proposal application.",
+    "developerName": "Conor Bronsdon",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Check my Context OS workspace."
+    ]
+  }
+}

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,6 @@
+.git/
+node_modules/
+__pycache__/
+.venv/
+.env
+.env.local

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,8 +10,8 @@ jobs:
   opencode-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Check OpenCode fixture portability on macOS
@@ -20,7 +20,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Run repository validation
         run: |
@@ -41,9 +41,9 @@ jobs:
   tests-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -63,9 +63,9 @@ jobs:
   tests-minimum-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
+- Freeze the apply-time clock in four coordination promotion tests so fixed-date
+  message fixtures do not expire as wall-clock time advances.
 - Pin validation actions to immutable commits and label the OpenClaw gateway
   test token as synthetic without changing its authorization controls.
 - OpenCode live conformance dispatches registered commands with `--command`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
+- Pin validation actions to immutable commits and label the OpenClaw gateway
+  test token as synthetic without changing its authorization controls.
 - OpenCode live conformance dispatches registered commands with `--command`,
   rejects failed skill loads and Windows fixture traversal, and requires
   successful tool controls under both allowed and denied permission policies.
@@ -10,6 +12,9 @@
   command sources and lifecycle artifacts remain covered.
 
 ### Added
+- A Codex workspace-companion plugin that routes to an explicitly selected
+  workspace without importing context or installing hooks. Distribution files
+  are development-owned and are not copied into composed workspaces.
 - An experimental three-file starter for sequential project work, with explicit
   read/checkpoint prompts and a one-week guide for comparing it with one file.
   The supplied-snapshot evidence remains tracked as development material and is

--- a/ROUTING.md
+++ b/ROUTING.md
@@ -36,6 +36,11 @@ For tasks without a slash command, use this table to determine which files to lo
   `scripts/validate-all.sh --workspace`
 
 ## Agent migration
+
+For the optional Codex `contextos-workspace` plugin, read
+`docs/codex-onboarding.md`. It routes to a selected workspace, not plugin-local
+state; repository-native lifecycle skills remain canonical.
+
 - Importing selected context from an assistant, project, memory export, or account export → read `docs/migration-guide.md`, then use Claude Code `/setup` or portable `$context-setup`
 - Migrating selected Gemini CLI configuration or workflows → Claude Code `/migrate-gemini`; portable skill `$migrate-gemini`
 - Discovering repeated workflows from selected Gemini sessions → Claude Code `/mine-gemini-workflows`; portable skill `$mine-gemini-workflows`

--- a/adapters/openclaw/plugin/plugin.test.mjs
+++ b/adapters/openclaw/plugin/plugin.test.mjs
@@ -104,6 +104,10 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
     await writeFile(path.join(root, "scripts", "contextos.sh"), "#!/usr/bin/env bash\n");
 
     const methods = new Map();
+    // Expected outputs of the injected deterministic capability fixture.
+    const expectedOwnership = "contextos-owner-capability-1";
+    const scenarioOwnership = "contextos-owner-capability-3";
+    const rejectedOwnership = "contextos-owner-wrong";
     const commands = [];
     const calls = { run: [], wait: [], messages: [] };
     let runSequence = 0;
@@ -161,7 +165,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
     assert.deepEqual(methods.get("contextos.wait").options, { scope: "operator.read" });
     assert.deepEqual(methods.get("contextos.result").options, { scope: "operator.read" });
 
-    async function invoke(name, params, token = "gateway-a") {
+    async function invoke(name, params, token = "example-gateway-a") {
       let response;
       gatewaySequence += 1;
       await methods.get(name).handler({
@@ -180,7 +184,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       payload: {
         runId: "run-owned-1",
         sessionKey: "agent:main:subagent:contextos-session-id",
-        ownershipToken: "contextos-owner-capability-1"
+        ownershipToken: expectedOwnership
       },
       error: undefined
     });
@@ -193,7 +197,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       alias: "demo",
       sessionKey: "agent:main:subagent:contextos-session-id",
       message: "The audience is public.",
-      ownershipToken: "contextos-owner-capability-1"
+      ownershipToken: expectedOwnership
     });
     assert.equal(continued.ok, true);
     assert.equal(calls.run[1].sessionKey, "agent:main:subagent:contextos-session-id");
@@ -202,14 +206,14 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
     const continuedWait = await invoke("contextos.wait", {
       runId: "run-owned-2",
       timeoutMs: 1_000,
-      ownershipToken: "contextos-owner-capability-1"
+      ownershipToken: expectedOwnership
     });
     assert.equal(continuedWait.ok, true, continuedWait.error?.message);
     const crossGatewayContinue = await invoke("contextos.continue", {
       alias: "demo",
       sessionKey: "agent:main:subagent:contextos-session-id",
       message: "injected",
-      ownershipToken: "contextos-owner-wrong"
+      ownershipToken: rejectedOwnership
     });
     assert.equal(crossGatewayContinue.ok, false);
     assert.match(crossGatewayContinue.error.message, /not owned by this operator/);
@@ -223,7 +227,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       alias: "missing",
       sessionKey: "agent:main:subagent:contextos-session-id",
       message: "response",
-      ownershipToken: "contextos-owner-capability-1"
+      ownershipToken: expectedOwnership
     });
     assert.equal(wrongAlias.ok, false);
     assert.match(wrongAlias.error.message, /not owned by that project alias/);
@@ -242,7 +246,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       scenario: CONFORMANCE_SCENARIO
     });
     assert.equal(scenario.ok, true);
-    assert.equal(scenario.payload.ownershipToken, "contextos-owner-capability-3");
+    assert.equal(scenario.payload.ownershipToken, scenarioOwnership);
     assert.equal(scenario.payload.continuityChallenge, "contextos-continuity-continuity-id");
     assert.match(calls.run[2].message, /contextos-continuity-continuity-id/);
     assert.match(calls.run[2].message, /awaiting_input/);
@@ -250,7 +254,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       alias: "demo",
       sessionKey: "agent:main:subagent:contextos-scenario-session",
       scenario: CONFORMANCE_SCENARIO,
-      ownershipToken: "contextos-owner-capability-3"
+      ownershipToken: scenarioOwnership
     });
     assert.equal(scenarioContinued.ok, true);
     assert.match(calls.run[3].message, /Lifecycle Fixture/);
@@ -261,7 +265,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       sessionKey: "agent:main:subagent:contextos-scenario-session",
       scenario: CONFORMANCE_SCENARIO,
       message: "arbitrary",
-      ownershipToken: "contextos-owner-capability-3"
+      ownershipToken: scenarioOwnership
     });
     assert.equal(scenarioInjection.ok, false);
     assert.match(scenarioInjection.error.message, /no message/);
@@ -275,7 +279,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
 
     const crossGatewayWait = await invoke(
       "contextos.wait", {
-        runId: "run-owned-1", timeoutMs: 1_000, ownershipToken: "contextos-owner-wrong"
+        runId: "run-owned-1", timeoutMs: 1_000, ownershipToken: rejectedOwnership
       }
     );
     assert.equal(crossGatewayWait.ok, false);
@@ -283,13 +287,13 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
     const waited = await invoke("contextos.wait", {
       runId: "run-owned-1",
       timeoutMs: 1_000,
-      ownershipToken: "contextos-owner-capability-1"
+      ownershipToken: expectedOwnership
     });
     assert.equal(waited.ok, true, waited.error?.message);
     assert.deepEqual(calls.wait[1], { runId: "run-owned-1", timeoutMs: 1_000 });
     const result = await invoke("contextos.result", {
       sessionKey: "agent:main:subagent:contextos-session-id",
-      ownershipToken: "contextos-owner-capability-1"
+      ownershipToken: expectedOwnership
     });
     assert.deepEqual(result.payload, {
       sessionKey: "agent:main:subagent:contextos-session-id",
@@ -297,7 +301,7 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
     });
     const crossGatewayResult = await invoke("contextos.result", {
       sessionKey: "agent:main:subagent:contextos-session-id",
-      ownershipToken: "contextos-owner-wrong"
+      ownershipToken: rejectedOwnership
     });
     assert.equal(crossGatewayResult.ok, false);
     assert.match(crossGatewayResult.error.message, /not owned by this operator/);
@@ -309,19 +313,19 @@ test("registers operator-scoped lifecycle continuation with owned sessions", asy
       alias: "demo",
       sessionKey: "agent:main:subagent:contextos-session-id",
       message: "response",
-      ownershipToken: "contextos-owner-capability-1",
+      ownershipToken: expectedOwnership,
       proposalPath: "elsewhere.json"
     });
     assert.equal(injectedPath.ok, false);
     assert.match(injectedPath.error.message, /unexpected parameter/);
     const foreignWait = await invoke("contextos.wait", {
-      runId: "run-foreign", ownershipToken: "contextos-owner-capability-1"
+      runId: "run-foreign", ownershipToken: expectedOwnership
     });
     assert.equal(foreignWait.ok, false);
     assert.match(foreignWait.error.message, /not owned/);
     const foreignResult = await invoke("contextos.result", {
       sessionKey: "agent:main:subagent:other",
-      ownershipToken: "contextos-owner-capability-1"
+      ownershipToken: expectedOwnership
     });
     assert.equal(foreignResult.ok, false);
     assert.match(foreignResult.error.message, /not owned/);

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -73,6 +73,10 @@
                     "policy": "development"
                 },
                 {
+                    "path": ".github/dependabot.yml",
+                    "policy": "development"
+                },
+                {
                     "path": ".github/workflows/validate.yml",
                     "policy": "development"
                 },
@@ -1010,6 +1014,22 @@
                 "openai-skill-metadata"
             ],
             "paths": [
+                {
+                    "path": ".codex-plugin/plugin.json",
+                    "policy": "development"
+                },
+                {
+                    "path": ".codexignore",
+                    "policy": "development"
+                },
+                {
+                    "path": "skills/contextos-workspace/SKILL.md",
+                    "policy": "development"
+                },
+                {
+                    "path": "tests/test_codex_plugin_package.py",
+                    "policy": "development"
+                },
                 {
                     "path": ".codex/hooks.json",
                     "policy": "managed"

--- a/docs/codex-onboarding.md
+++ b/docs/codex-onboarding.md
@@ -56,6 +56,17 @@ client supports it. It is not the runtime path for Context OS or an account-wide
 importer. Preview every imported item and resolve duplicates against repository
 SSOTs.
 
+## Optional workspace-companion plugin
+
+The source repository also ships `.codex-plugin/plugin.json` and the
+`contextos-workspace` discovery skill. This is a companion to an existing
+repository-native installation, not a replacement for setup. It requires an
+explicitly selected Context OS workspace and follows that workspace's own
+instructions and kernel. Never keep personal state in a plugin cache.
+
+Installation does not import context, register hooks, or approve lifecycle
+writes. These distribution files are excluded from composed workspace bundles.
+
 ## Verify
 
 ```bash

--- a/skills/contextos-workspace/SKILL.md
+++ b/skills/contextos-workspace/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: contextos-workspace
+description: Run Context OS continuity and lifecycle workflows in a user-selected Context OS workspace. Use when asked to inspect, set up, update, or close a Context OS session.
+license: MIT
+---
+
+# Context OS workspace companion
+
+1. Identify the user's intended Context OS workspace. Ask for its path if it is
+   not explicit or unambiguous. Never use the plugin installation/cache as a
+   workspace, and never create a workspace or import context implicitly.
+2. Verify the selected root contains `AGENTS.md`, `ROUTING.md`,
+   `scripts/contextos.sh`, and `.agents/skills/`. If not, stop and explain the
+   repository-native setup in the bundled `docs/codex-onboarding.md` (relative
+   to the plugin root, two directories above this file).
+3. Read that workspace's `AGENTS.md`, `ROUTING.md`, and
+   `docs/safety-contract.md` completely. Use that workspace as the working
+   directory. Do not mix installed-plugin code with another workspace's state.
+4. For the operation the user requested, read its canonical
+   `.agents/skills/context-setup/SKILL.md`, `context-start/SKILL.md`,
+   `context-update/SKILL.md`, or `context-end/SKILL.md` in the selected workspace.
+   Follow that file; do not substitute a plugin-local copy or infer an operation
+   that would expand the request.
+5. Start is read-only. Setup, update and end require a displayed proposal and
+   explicit approval of its exact digest before apply. Never write lifecycle
+   state directly, install hooks, or commit/push implicitly. Report receipts
+   and verification limits. Plugin installation grants no extra authority.

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -1,0 +1,34 @@
+"""Validate the optional plugin's distribution metadata, not host enforcement."""
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CodexPluginPackageTests(unittest.TestCase):
+    def test_plugin_exposes_only_the_workspace_companion(self):
+        manifest = json.loads((ROOT / ".codex-plugin/plugin.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["name"], "agent-context-os")
+        self.assertEqual(manifest["skills"], "./skills/")
+        self.assertNotIn("hooks", manifest)
+        self.assertNotIn("mcpServers", manifest)
+        skills = sorted(path.relative_to(ROOT).as_posix() for path in (ROOT / "skills").glob("*/SKILL.md"))
+        self.assertEqual(skills, ["skills/contextos-workspace/SKILL.md"])
+
+    def test_plugin_files_are_not_managed_workspace_outputs(self):
+        inventory = json.loads((ROOT / "components/manifest.json").read_text(encoding="utf-8"))
+        owners = {
+            entry["path"]: (component["id"], entry["policy"])
+            for component in inventory["components"]
+            for entry in component["paths"]
+        }
+        for path in (".codex-plugin/plugin.json", ".codexignore", "skills/contextos-workspace/SKILL.md"):
+            self.assertEqual(owners[path], ("codex-adapter", "development"))
+            self.assertTrue((ROOT / path).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -988,6 +988,8 @@ class CoordinationTests(unittest.TestCase):
             + synced["scan"]["claim_bytes_read"],
         )
 
+    # Apply revalidates expiry against utc_now; use the fixture timeline, not the wall clock.
+    @mock.patch.object(coordination, "utc_now", lambda: NOW + timedelta(hours=1))
     def test_promotion_requires_exact_digest_and_preserves_source(self) -> None:
         self._prepare_workspace()
         message = post_message(
@@ -1090,6 +1092,7 @@ class CoordinationTests(unittest.TestCase):
             )
         self.assertEqual(before, decisions.read_text(encoding="utf-8"))
 
+    @mock.patch.object(coordination, "utc_now", lambda: NOW + timedelta(hours=1))
     def test_promotion_rolls_back_second_source_validation_failure(self) -> None:
         self._prepare_workspace()
         message = post_message(
@@ -1133,6 +1136,7 @@ class CoordinationTests(unittest.TestCase):
         journals = self.repo_a / ".context-os" / "journals"
         self.assertEqual([], list(journals.iterdir()))
 
+    @mock.patch.object(coordination, "utc_now", lambda: NOW + timedelta(hours=1))
     def test_promotion_retires_committed_journal_during_recovery(self) -> None:
         self._prepare_workspace()
         message = post_message(
@@ -1168,6 +1172,7 @@ class CoordinationTests(unittest.TestCase):
             (self.repo_a / "state" / "decisions.md").read_text(encoding="utf-8"),
         )
 
+    @mock.patch.object(coordination, "utc_now", lambda: NOW + timedelta(hours=1))
     def test_promotion_tolerates_unrelated_update_and_writes_handoff(self) -> None:
         self._prepare_workspace()
         source = post_message(


### PR DESCRIPTION
## What's in this PR

Adds an optional Codex workspace-companion plugin. It routes to the canonical skills in a user-selected Context OS workspace; it does not import context, install hooks, or grant implicit write permission. Plugin files are development-owned and excluded from composed workspace outputs.

Pins validation actions, adds action update checks, and labels the OpenClaw test credential as synthetic. Auth controls and production code are unchanged.

Full validation exposed four existing date-dependent coordination tests: their August 31 message fixtures had expired against the real clock. The second commit freezes only those four test clocks. The same failures were reproduced on unchanged main; the expiry-rejection and changed-source controls remain unchanged.

## Checklist

- [x] New skill has frontmatter, a specific trigger, and a ROUTING reference.
- [x] Host-specific behavior stays in the thin adapter; no new commands or integrations.
- [x] New files have component ownership; distribution files are not managed workspace outputs.
- [x] CHANGELOG updated; no credentials committed.
- [x] Official plugin-package validator passes.
- [x] Full local aggregate validator passes in an isolated Linux checkout.
- [x] Hosted CI passes: Linux aggregate, Python 3.10, Windows Python 3.13, and macOS OpenCode checks.

Scanner 2.0.1116 passes the corrected source at 91/100 with no high-severity findings. No secret rules, severities, or source paths were suppressed.

Packaging commit `708dfbc936250c837ada9a333118f7d356d497c6` and the affected-file repair at HEAD `b8f40f97fe5ed662021a2563c7b1a6632efed09d` were independently reviewed by authenticated `claude-sonnet-5`, free `opencode/muse-spark-1.3-contributor-free`, and free `opencode/big-pickle`. No verified actionable findings remain. The plugin metadata tests validate distribution contracts, not behavior of an installed Codex host.
