### PR TITLE
ci: pilot SSOT checks for documented Python requirements

### DIFF
--- a/.github/workflows/ssot.yml
+++ b/.github/workflows/ssot.yml
@@ -1,0 +1,31 @@
+name: SSOT
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ssot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Get the reviewed checker
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: conorbronsdon/ssot-check
+          ref: f3289c400cd591cdcb6ce4016627a442d0804ce7 # v0.1.3
+          path: .ssot-tool
+          persist-credentials: false
+      - name: Check registered compatibility claims
+        run: python3 .ssot-tool/ssot_check.py check --manifest .ssot.yaml
+      - name: Warn about possible unregistered copies
+        run: python3 .ssot-tool/ssot_check.py discover --manifest .ssot.yaml --untracked-only --github-annotations
+      - name: Exercise drift and advisory controls
+        run: python3 scripts/check-ssot-controls.py .ssot-tool/ssot_check.py

--- a/.ssot.yaml
+++ b/.ssot.yaml
@@ -1,0 +1,31 @@
+# The executable interpreter probe owns the supported Python 3 minor floor.
+# History, test fixtures, templates and generated integration docs are not current claims.
+ignore_paths:
+  - "CHANGELOG.md"
+  - "tests/**"
+  - "docs/templates/**"
+  - "docs/evidence/**"
+  - "docs/releases/**"
+  - "references/integrations.md"
+  - ".ssot-tool/**"
+facts:
+  - name: minimum-python3-minor
+    type: integer
+    canonical:
+      file: scripts/python-env.sh
+      pattern: 'sys\.version_info >= \(3, (\d+)\)'
+    copies:
+      - file: CONTRIBUTING.md
+        pattern: 'Git, Bash, and Python 3\.(\d+) or newer'
+      - file: CONTRIBUTING.md
+        pattern: 'CI runs the suite on 3\.(\d+) so the floor stays real'
+      - file: docs/getting-started.md
+        pattern: 'You need Git, Bash, and Python 3\.(\d+) or newer'
+      - file: docs/getting-started.md
+        pattern: 'working Python 3\.(\d+)\+, setup'
+      - file: docs/first-handoff.md
+        pattern: 'Bash, Python 3\.(\d+)\+, and access'
+      - file: docs/continuity-benchmark.md
+        pattern: 'repository with Python 3\.(\d+)\+'
+      - file: .github/workflows/validate.yml
+        pattern: 'tests-minimum-python:[\s\S]*?python-version: ''3\.(\d+)'''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   command sources and lifecycle artifacts remain covered.
 
 ### Added
+- A repository-local SSOT CI pilot checks documented Python requirements against
+  the interpreter probe, warns about unregistered prose copies, and exercises
+  drift and exclusion controls in disposable fixtures.
 - A Codex workspace-companion plugin that routes to an explicitly selected
   workspace without importing context or installing hooks. Distribution files
   are development-owned and are not copied into composed workspaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,41 @@ the target. `bash scripts/check-links.sh` catches links to files that no longer
 exist; `bash scripts/check-doc-reachability.sh` catches the opposite problem —
 a doc that still exists but that nothing points to any more.
 
+## Documentation drift pilot
+
+The `SSOT / ssot` CI job checks the Python floor on every PR using `.ssot.yaml`.
+The executable interpreter probe in `scripts/python-env.sh` owns the Python 3
+minor requirement. The manifest checks the hand-maintained setup/contributor
+docs and the minimum-Python CI job against it. Existing component, generated
+reference, and release validators remain authoritative for their domains.
+
+Registered drift, missing copies, and malformed manifests fail CI. Fix the
+underlying requirement and its copies. Explain canonical changes, removed
+locators, or new exclusions in the PR; removing a check is not a drift fix.
+
+Discovery is advisory. It scans prose for supported numeric patterns and cannot
+infer the Python floor, so those locations are registered explicitly. History,
+test fixtures, templates, release notes, and generated integration references
+are excluded. Remaining baseline warnings include shell positional variables,
+release-command examples, and unrelated session counts. Review warnings before
+registering facts; excluded paths still receive their explicit checks.
+
+To reproduce CI, check out the checker revision pinned in
+`.github/workflows/ssot.yml` into a sibling `ssot-check` directory, then run:
+
+```bash
+python3 ../ssot-check/ssot_check.py check --manifest .ssot.yaml
+python3 ../ssot-check/ssot_check.py discover --manifest .ssot.yaml --untracked-only --github-annotations
+python3 scripts/check-ssot-controls.py ../ssot-check/ssot_check.py
+```
+
+Controls mutate disposable copies to prove drift, restoration, missing-copy and
+manifest failures. They verify that a history exclusion cannot hide registered
+drift and that an unregistered current price warns while `check` stays green.
+Record useful findings, repeated warnings, and maintenance effort in the pilot
+PR or a follow-up issue before expanding coverage. This is a source-repository
+check; its files are development-owned and are not installed into workspaces.
+
 ## Changelog
 
 Update `CHANGELOG.md` whenever you add, remove, or significantly change a file.

--- a/components/manifest.json
+++ b/components/manifest.json
@@ -25,6 +25,18 @@
             "depends_on": [],
             "paths": [
                 {
+                    "path": ".ssot.yaml",
+                    "policy": "development"
+                },
+                {
+                    "path": ".github/workflows/ssot.yml",
+                    "policy": "development"
+                },
+                {
+                    "path": "scripts/check-ssot-controls.py",
+                    "policy": "development"
+                },
+                {
                     "path": "docs/minimal-starter-evidence.md",
                     "policy": "managed"
                 },

--- a/scripts/check-ssot-controls.py
+++ b/scripts/check-ssot-controls.py
@@ -56,6 +56,8 @@ def main():
                     raise AssertionError(f"Mutation did not report drift: {locator}")
                 # Discovery exclusions must not disable an explicitly registered copy.
                 ignored = manifest_text.replace("ignore_paths:\n", f'ignore_paths:\n  - "{locator["file"]}"\n', 1)
+                if locator["file"] not in checker.parse_manifest(ignored).get("ignore_paths", []):
+                    raise AssertionError("Exclusion control did not add the target path")
                 (scratch / manifest_name).write_text(ignored, encoding="utf-8")
                 run(scratch, "check", 1)
                 (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
@@ -75,6 +77,7 @@ def main():
         scratch = Path(directory)
         (scratch / manifest_name).write_text(r"""ignore_paths:
   - "CHANGELOG.md"
+  - "history/**"
 facts:
   - name: example-price
     type: currency
@@ -88,14 +91,21 @@ facts:
         for name in ("current.md", "guide.md"):
             (scratch / name).write_text("Price: $100\n", encoding="utf-8")
         (scratch / "CHANGELOG.md").write_text("Historical price: $50\nOld price: $50\n", encoding="utf-8")
+        (scratch / "history/nested").mkdir(parents=True)
+        (scratch / "history/nested/old.md").write_text("Price: $50\n", encoding="utf-8")
+        (scratch / "history/other.md").write_text("Price: $50\n", encoding="utf-8")
         run(scratch)
         clean = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
         if "::warning" in clean:
             raise AssertionError(f"Tracked or historical values generated warnings: {clean}")
         (scratch / "new-page.md").write_text("Price: $100\n", encoding="utf-8")
+        (scratch / "history-current.md").write_text("Price: $100\n", encoding="utf-8")
         run(scratch)
         warning = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
-        if "::warning file=new-page.md" not in warning or "::warning file=CHANGELOG.md" in warning:
+        if ("::warning file=new-page.md" not in warning
+                or "::warning file=history-current.md" not in warning
+                or "::warning file=CHANGELOG.md" in warning
+                or "::warning file=history/" in warning):
             raise AssertionError(f"Expected only the unregistered current copy warning: {warning}")
     print(f"SSOT controls passed: {tested} real copy locators; drift, restore, missing copy/manifest, invalid manifest, exclusion, advisory discovery.")
 

--- a/scripts/check-ssot-controls.py
+++ b/scripts/check-ssot-controls.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Exercise this repository's SSOT locators in disposable copies, without edits."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    cli = Path(sys.argv[1]).resolve()
+    root = Path(__file__).resolve().parents[1]
+    manifest_name = ".ssot-local.yaml" if (root / ".ssot-local.yaml").exists() else ".ssot.yaml"
+    manifest_text = (root / manifest_name).read_text(encoding="utf-8")
+    spec = importlib.util.spec_from_file_location("ssot_check", cli)
+    checker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(checker)
+    manifest = checker.parse_manifest(manifest_text)
+
+    def run(at, command="check", expected=0, *extra):
+        result = subprocess.run(
+            [sys.executable, "-X", "utf8", str(cli), command, "--manifest", str(at / manifest_name), *extra],
+            text=True, capture_output=True, encoding="utf-8", cwd=at,
+            env={**os.environ, "GITHUB_WORKSPACE": str(at)},
+        )
+        if result.returncode != expected:
+            raise AssertionError(f"{command}: expected {expected}, got {result.returncode}\n{result.stdout}\n{result.stderr}")
+        return result.stdout
+
+    run(root)
+    tested = 0
+    with tempfile.TemporaryDirectory(prefix="ssot-controls-") as directory:
+        scratch = Path(directory)
+        (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
+        for fact in manifest["facts"]:
+            for locator in [fact["canonical"], *fact["copies"]]:
+                relative = locator["file"]
+                target = scratch / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes((root / relative).read_bytes())
+        run(scratch)
+        for fact in manifest["facts"]:
+            for locator in fact["copies"]:
+                target = scratch / locator["file"]
+                original = target.read_text(encoding="utf-8")
+                match = re.search(locator["pattern"], original, re.MULTILINE)
+                if match is None:
+                    raise AssertionError(f"Unmatched locator: {locator}")
+                changed = original[:match.start(1)] + "987654" + original[match.end(1):]
+                target.write_text(changed, encoding="utf-8")
+                report = json.loads(run(scratch, "check", 1, "--json"))
+                if report["summary"]["drifted"] < 1:
+                    raise AssertionError(f"Mutation did not report drift: {locator}")
+                # Discovery exclusions must not disable an explicitly registered copy.
+                ignored = manifest_text.replace("ignore_paths:\n", f'ignore_paths:\n  - "{locator["file"]}"\n', 1)
+                (scratch / manifest_name).write_text(ignored, encoding="utf-8")
+                run(scratch, "check", 1)
+                (scratch / manifest_name).write_text(manifest_text, encoding="utf-8")
+                target.write_text(original, encoding="utf-8")
+                run(scratch)
+                target.unlink()
+                run(scratch, "check", 1)
+                target.write_text(original, encoding="utf-8")
+                tested += 1
+        (scratch / manifest_name).unlink()
+        run(scratch, "check", 2)
+        (scratch / manifest_name).write_text("facts: invalid\n", encoding="utf-8")
+        run(scratch, "check", 2)
+
+    # Synthetic, supported discovery values. Node/Python floors are not discoverable.
+    with tempfile.TemporaryDirectory(prefix="ssot-discovery-") as directory:
+        scratch = Path(directory)
+        (scratch / manifest_name).write_text(r"""ignore_paths:
+  - "CHANGELOG.md"
+facts:
+  - name: example-price
+    type: currency
+    canonical:
+      file: current.md
+      pattern: 'Price: \$(\d+)'
+    copies:
+      - file: guide.md
+        pattern: 'Price: \$(\d+)'
+""", encoding="utf-8")
+        for name in ("current.md", "guide.md"):
+            (scratch / name).write_text("Price: $100\n", encoding="utf-8")
+        (scratch / "CHANGELOG.md").write_text("Historical price: $50\nOld price: $50\n", encoding="utf-8")
+        run(scratch)
+        clean = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
+        if "::warning" in clean:
+            raise AssertionError(f"Tracked or historical values generated warnings: {clean}")
+        (scratch / "new-page.md").write_text("Price: $100\n", encoding="utf-8")
+        run(scratch)
+        warning = run(scratch, "discover", 0, "--untracked-only", "--github-annotations")
+        if "::warning file=new-page.md" not in warning or "::warning file=CHANGELOG.md" in warning:
+            raise AssertionError(f"Expected only the unregistered current copy warning: {warning}")
+    print(f"SSOT controls passed: {tested} real copy locators; drift, restore, missing copy/manifest, invalid manifest, exclusion, advisory discovery.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What's in this PR

A documentation-only change to the Python floor can currently disagree with the executable interpreter probe. Add a small SSOT manifest linking the probe to seven setup/contributor/CI copies, plus an all-PR job that fails on registered drift and missing or invalid configuration. The reviewed checker revision and checkout actions are pinned; the job has read-only permissions.

Discovery remains advisory. Historical releases, fixtures, templates and generated integration references are excluded; 18 existing warnings are documented release examples, shell variables, and unrelated session counts. Contributor guidance explains repairs and exclusions. The new files are development-owned and do not ship into composed workspaces.

Controls exercise every real copy, restoration, missing copies/manifests, invalid manifests, explicit-location checks under exclusions, nested glob exclusions, and a similarly named current file that must still warn. Synthetic unregistered copies warn while the deterministic check remains green.

## Verification

- Full local `bash scripts/validate-all.sh` passed on Windows/Git Bash (722 tests, 48 skipped) and Linux (722 tests, 27 skipped); links, hooks, component inventory, bundle/runtime/workspace schemas, and JSON passed.
- Final SSOT baseline and all seven real-copy controls passed; actionlint passed.
- Authenticated claude-sonnet-5, tool-isolated opencode/muse-spark-1.3-contributor-free, and opencode/nemotron-3-ultra-free reviewed the exact commits. Claude's glob-control finding was fixed. Claude and Muse found no actionable defects in the fix. Nemotron's findings were checked and rejected: parse_manifest takes text, failed insertion is explicitly guarded, prefix assertions include nested paths, and the similarly named sibling is an intentional control.
- Initial full review: fbd35128532d46c2226deed80aa2b32260392307. Final affected-control review: f862199aae452210516007595248657b381062bb; unchanged-file review coverage carries forward. Free review prices/cost were zero and tools were disabled with no tool events.
- Hosted SSOT, standard Linux, minimum-Python, and macOS checks passed. The hosted Windows suite is still running; all-hosted-CI completion is not yet claimed. Required-check configuration and observation of useful findings, noise, and maintenance remain rollout follow-ups after merge.

## Checklist

Skills/commands and integration-catalog sections: not applicable.

- [x] No sensitive data committed
- [x] CHANGELOG.md updated
- [x] Full validation passed locally
- [ ] Hosted CI passes
